### PR TITLE
Add backup & restore (JSON for all engines, SQL dumps for relational)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ interactive **ER diagram**, and full **DDL**: create / drop / truncate tables
 with a column builder (primary key, auto-increment, unique, defaults) and
 create / drop databases.
 
+🧰 **Backup & restore** — one-click dumps of a whole database or a single
+table (portable **JSON** for any engine, or a **`.sql`** script for relational
+engines), and restore straight from a file.
+
 🎨 **Designed to live in** — shadcn/ui, light & dark themes, resizable panels,
 keyboard-friendly, and quiet.
 

--- a/apps/api/src/connections/connections.controller.ts
+++ b/apps/api/src/connections/connections.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import {
   type ConnectionConfig,
+  backupSchema,
   browseSchema,
   connectionInputSchema,
   createTableSchema,
@@ -19,6 +20,7 @@ import {
   insertRowSchema,
   querySchema,
   relationRefSchema,
+  restoreSchema,
   updateRowSchema,
   type ConnectionInputDTO,
 } from '@relay/core';
@@ -35,6 +37,8 @@ type DeleteDTO = z.infer<typeof deleteRowSchema>;
 type CreateTableDTO = z.infer<typeof createTableSchema>;
 type DatabaseNameDTO = z.infer<typeof databaseNameSchema>;
 type RelationRefDTO = z.infer<typeof relationRefSchema>;
+type BackupDTO = z.infer<typeof backupSchema>;
+type RestoreDTO = z.infer<typeof restoreSchema>;
 
 @Controller('connections')
 export class ConnectionsController {
@@ -227,5 +231,36 @@ export class ConnectionsController {
       a.truncateTable(dto.table, dto.schema),
     );
     return { success: true };
+  }
+
+  /* ----- backup & restore ----- */
+
+  @Post(':id/backup')
+  async backup(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(backupSchema)) dto: BackupDTO,
+    @Query('database') database?: string,
+  ): Promise<{ filename: string; format: string; content: string }> {
+    const content = await this.pool.withAdapter(id, database || undefined, (a) =>
+      a.backup(dto),
+    );
+    const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+    const base = (database || 'backup').replace(/[^\w.-]+/g, '_');
+    return {
+      filename: `${base}-${stamp}.${dto.format === 'sql' ? 'sql' : 'json'}`,
+      format: dto.format,
+      content,
+    };
+  }
+
+  @Post(':id/restore')
+  async restore(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(restoreSchema)) dto: RestoreDTO,
+    @Query('database') database?: string,
+  ) {
+    return this.pool.withAdapter(id, database || undefined, (a) =>
+      a.restore(dto.content, dto.format),
+    );
   }
 }

--- a/apps/web/src/components/schema/schema-tree.tsx
+++ b/apps/web/src/components/schema/schema-tree.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   AlertCircle,
+  Archive,
   Database,
+  DatabaseBackup,
+  Download,
   Eraser,
   Eye,
   KeyRound,
@@ -15,10 +18,12 @@ import {
   SquareTerminal,
   Table2,
   Trash2,
+  Upload,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import type { RelationKind, TableSchema } from '@relay/core';
+import type { BackupFormat, RelationKind, TableSchema } from '@relay/core';
 import { api, ApiError } from '@/lib/api';
+import { downloadText } from '@/lib/export';
 import {
   useConnections,
   useDatabases,
@@ -78,6 +83,8 @@ export function SchemaTree() {
   const canQuery = driver?.capabilities.queryLanguage === 'sql';
   const canDdl = !!driver?.capabilities.ddl;
   const canManageDb = !!driver?.capabilities.manageDatabases;
+  const backupFormats = driver?.capabilities.backupFormats ?? [];
+  const fileRef = useRef<HTMLInputElement>(null);
 
   const { data: databases } = useDatabases(
     driver?.capabilities.multipleDatabases ? activeConnectionId : null,
@@ -125,6 +132,55 @@ export function SchemaTree() {
       toast.success(`Dropped ${table}`);
     } catch (err) {
       toast.error('Drop failed', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleBackup(format: BackupFormat, table?: TableSchema) {
+    try {
+      const res = await api.backup(
+        activeConnectionId as string,
+        {
+          format,
+          tables: table ? [table.name] : undefined,
+          schema: table?.schema,
+        },
+        activeDatabase,
+      );
+      downloadText(res.filename, res.content);
+      toast.success('Backup downloaded', { description: res.filename });
+    } catch (err) {
+      toast.error('Backup failed', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleRestoreFile(file: File) {
+    const format: BackupFormat = file.name.endsWith('.sql') ? 'sql' : 'json';
+    if (
+      !window.confirm(
+        `Restore from "${file.name}"? This writes data into the current database.`,
+      )
+    )
+      return;
+    try {
+      const content = await file.text();
+      const res = await api.restore(
+        activeConnectionId as string,
+        { format, content },
+        activeDatabase,
+      );
+      await refreshSchema();
+      await qc.invalidateQueries({
+        queryKey: ['connections', activeConnectionId, 'browse'],
+      });
+      toast.success(
+        `Restored ${res.rows} row(s)${res.tables ? ` across ${res.tables} table(s)` : ''}`,
+      );
+    } catch (err) {
+      toast.error('Restore failed', {
         description: err instanceof ApiError ? err.message : String(err),
       });
     }
@@ -214,7 +270,46 @@ export function SchemaTree() {
             <Plus className="h-4 w-4" />
           </Button>
         )}
+        {backupFormats.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8 shrink-0"
+                title="Backup / restore"
+              >
+                <DatabaseBackup className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {backupFormats.map((fmt) => (
+                <DropdownMenuItem key={fmt} onClick={() => handleBackup(fmt)}>
+                  <Download className="mr-2 h-4 w-4" />
+                  Download backup ({fmt.toUpperCase()})
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => fileRef.current?.click()}>
+                <Upload className="mr-2 h-4 w-4" />
+                Restore from file…
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
+
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".json,.sql,application/json,text/plain"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = '';
+          if (file) void handleRestoreFile(file);
+        }}
+      />
 
       <ScrollArea className="min-h-0 flex-1 px-2">
         {isLoading && (
@@ -298,6 +393,14 @@ export function SchemaTree() {
                           >
                             <SquareTerminal className="mr-2 h-4 w-4" />
                             Open SELECT
+                          </DropdownMenuItem>
+                        )}
+                        {backupFormats.length > 0 && (
+                          <DropdownMenuItem
+                            onClick={() => handleBackup('json', table)}
+                          >
+                            <Archive className="mr-2 h-4 w-4" />
+                            Backup table
                           </DropdownMenuItem>
                         )}
                         {canDdl && (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -163,6 +163,25 @@ export const api = {
       `/connections/${id}/ddl/truncate-table${dbQuery(database)}`,
       { method: 'POST', ...jsonBody({ table, schema }) },
     ),
+
+  backup: (
+    id: string,
+    opts: { format: 'json' | 'sql'; tables?: string[]; schema?: string },
+    database?: string,
+  ) =>
+    request<{ filename: string; format: string; content: string }>(
+      `/connections/${id}/backup${dbQuery(database)}`,
+      { method: 'POST', ...jsonBody(opts) },
+    ),
+  restore: (
+    id: string,
+    body: { format: 'json' | 'sql'; content: string },
+    database?: string,
+  ) =>
+    request<{ tables: number; rows: number }>(
+      `/connections/${id}/restore${dbQuery(database)}`,
+      { method: 'POST', ...jsonBody(body) },
+    ),
 };
 
 function dbQuery(database?: string): string {

--- a/apps/web/src/lib/export.ts
+++ b/apps/web/src/lib/export.ts
@@ -26,6 +26,12 @@ function download(filename: string, content: string, mime: string): void {
   URL.revokeObjectURL(url);
 }
 
+/** Trigger a browser download of arbitrary text (used by backups). */
+export function downloadText(filename: string, content: string): void {
+  const mime = filename.endsWith('.json') ? 'application/json' : 'text/plain';
+  download(filename, content, mime);
+}
+
 export function exportRows(
   columns: string[],
   rows: Array<Record<string, unknown>>,

--- a/packages/core/src/adapters/nosql/mongodb-adapter.ts
+++ b/packages/core/src/adapters/nosql/mongodb-adapter.ts
@@ -6,6 +6,9 @@
 import { MongoClient, ObjectId, type Db } from 'mongodb';
 import type {
   AdapterCapabilities,
+  BackupDocument,
+  BackupFormat,
+  BackupOptions,
   BrowseParams,
   BrowseResult,
   ColumnSchema,
@@ -17,6 +20,7 @@ import type {
   FilterSpec,
   InsertRowParams,
   QueryResult,
+  RestoreResult,
   TableSchema,
   UpdateRowParams,
 } from '../types';
@@ -39,6 +43,7 @@ export const MONGODB_CAPABILITIES: AdapterCapabilities = {
   // implicitly by adding a collection, so we don't expose explicit DB creation.
   ddl: true,
   manageDatabases: false,
+  backupFormats: ['json'],
 };
 
 const SAMPLE_SIZE = 50;
@@ -284,6 +289,69 @@ export class MongodbAdapter implements DatabaseAdapter {
   async dropDatabase(name: string): Promise<void> {
     const client = await this.getClient();
     await client.db(name).dropDatabase();
+  }
+
+  /* ----- backup & restore ----- */
+
+  async backup(opts: BackupOptions): Promise<string> {
+    if (opts.format !== 'json') {
+      throw new UnsupportedError('MongoDB supports JSON backups only.');
+    }
+    const db = await this.getDb();
+    let names = (await db.listCollections().toArray()).map((c) => c.name);
+    if (opts.tables?.length) {
+      const wanted = new Set(opts.tables);
+      names = names.filter((n) => wanted.has(n));
+    }
+
+    const doc: BackupDocument = {
+      relay: 'backup',
+      version: 1,
+      engine: this.engine,
+      database: db.databaseName,
+      createdAt: new Date().toISOString(),
+      tables: [],
+    };
+    for (const name of names) {
+      const docs = await db.collection(name).find({}).toArray();
+      const rows = docs.map(normalizeDoc);
+      doc.tables.push({
+        name,
+        primaryKey: ['_id'],
+        columns: inferColumns(docs).map((c) => c.name),
+        rows,
+      });
+    }
+    return JSON.stringify(doc, null, 2);
+  }
+
+  async restore(content: string, format: BackupFormat): Promise<RestoreResult> {
+    if (format !== 'json') {
+      throw new UnsupportedError('MongoDB supports JSON restores only.');
+    }
+    let doc: BackupDocument;
+    try {
+      doc = JSON.parse(content) as BackupDocument;
+    } catch {
+      throw new BadRequestError('Backup file is not valid JSON');
+    }
+    if (doc.relay !== 'backup' || !Array.isArray(doc.tables)) {
+      throw new BadRequestError('Not a Relay backup file');
+    }
+    const db = await this.getDb();
+    let rows = 0;
+    for (const table of doc.tables) {
+      await db.createCollection(table.name).catch(() => undefined);
+      if (table.rows.length > 0) {
+        const docs = table.rows.map((r) => coerceId({ ...r }));
+        await db
+          .collection(table.name)
+          .insertMany(docs, { ordered: false })
+          .catch(() => undefined);
+        rows += table.rows.length;
+      }
+    }
+    return { tables: doc.tables.length, rows };
   }
 }
 

--- a/packages/core/src/adapters/nosql/redis-adapter.ts
+++ b/packages/core/src/adapters/nosql/redis-adapter.ts
@@ -6,6 +6,9 @@
 import Redis from 'ioredis';
 import type {
   AdapterCapabilities,
+  BackupDocument,
+  BackupFormat,
+  BackupOptions,
   BrowseParams,
   BrowseResult,
   ConnectionConfig,
@@ -14,9 +17,15 @@ import type {
   DeleteRowParams,
   InsertRowParams,
   QueryResult,
+  RestoreResult,
   UpdateRowParams,
 } from '../types';
-import { ConnectionError, QueryError, UnsupportedError } from '../../errors';
+import {
+  BadRequestError,
+  ConnectionError,
+  QueryError,
+  UnsupportedError,
+} from '../../errors';
 
 export const REDIS_CAPABILITIES: AdapterCapabilities = {
   query: true,
@@ -28,6 +37,7 @@ export const REDIS_CAPABILITIES: AdapterCapabilities = {
   transactions: false,
   ddl: false,
   manageDatabases: false,
+  backupFormats: ['json'],
 };
 
 const KEYSPACE = 'keys';
@@ -296,6 +306,105 @@ export class RedisAdapter implements DatabaseAdapter {
   }
   async dropDatabase(): Promise<void> {
     this.ddlUnsupported();
+  }
+
+  /* ----- backup & restore (every key in the current DB) ----- */
+
+  async backup(opts: BackupOptions): Promise<string> {
+    if (opts.format !== 'json') {
+      throw new UnsupportedError('Redis supports JSON backups only.');
+    }
+    const client = this.getClient();
+    if (client.status !== 'ready') await client.connect().catch(() => {});
+
+    const keys: string[] = [];
+    let cursor = '0';
+    do {
+      const [next, batch] = await client.scan(cursor, 'COUNT', 500);
+      keys.push(...batch);
+      cursor = next;
+    } while (cursor !== '0');
+
+    const rows = await Promise.all(keys.map((k) => this.readKey(client, k)));
+    const doc: BackupDocument = {
+      relay: 'backup',
+      version: 1,
+      engine: this.engine,
+      database: `db${this.config.options?.db ?? this.config.database ?? 0}`,
+      createdAt: new Date().toISOString(),
+      tables: [
+        {
+          name: KEYSPACE,
+          primaryKey: ['key'],
+          columns: ['key', 'type', 'ttl', 'value'],
+          rows,
+        },
+      ],
+    };
+    return JSON.stringify(doc, null, 2);
+  }
+
+  async restore(content: string, format: BackupFormat): Promise<RestoreResult> {
+    if (format !== 'json') {
+      throw new UnsupportedError('Redis supports JSON restores only.');
+    }
+    let doc: BackupDocument;
+    try {
+      doc = JSON.parse(content) as BackupDocument;
+    } catch {
+      throw new BadRequestError('Backup file is not valid JSON');
+    }
+    if (doc.relay !== 'backup' || !Array.isArray(doc.tables)) {
+      throw new BadRequestError('Not a Relay backup file');
+    }
+    const client = this.getClient();
+    if (client.status !== 'ready') await client.connect().catch(() => {});
+
+    let rows = 0;
+    for (const table of doc.tables) {
+      for (const row of table.rows) {
+        await this.writeKey(client, row);
+        rows++;
+      }
+    }
+    return { tables: doc.tables.length, rows };
+  }
+
+  private async writeKey(
+    client: Redis,
+    row: Record<string, unknown>,
+  ): Promise<void> {
+    const key = String(row.key ?? '');
+    if (!key) return;
+    const type = String(row.type ?? 'string');
+    const value = row.value;
+    await client.del(key);
+    switch (type) {
+      case 'list':
+        if (Array.isArray(value) && value.length)
+          await client.rpush(key, ...value.map(String));
+        break;
+      case 'set':
+        if (Array.isArray(value) && value.length)
+          await client.sadd(key, ...value.map(String));
+        break;
+      case 'zset':
+        if (Array.isArray(value)) {
+          // stored as [member, score, member, score, ...]
+          for (let i = 0; i + 1 < value.length; i += 2) {
+            await client.zadd(key, String(value[i + 1]), String(value[i]));
+          }
+        }
+        break;
+      case 'hash':
+        if (value && typeof value === 'object')
+          await client.hset(key, value as Record<string, string>);
+        break;
+      default:
+        await client.set(key, String(value ?? ''));
+    }
+    const ttl = Number(row.ttl);
+    if (Number.isFinite(ttl) && ttl > 0) await client.expire(key, ttl);
   }
 }
 

--- a/packages/core/src/adapters/sql/base-sql-adapter.ts
+++ b/packages/core/src/adapters/sql/base-sql-adapter.ts
@@ -9,6 +9,9 @@
  */
 import type {
   AdapterCapabilities,
+  BackupDocument,
+  BackupFormat,
+  BackupOptions,
   BrowseParams,
   BrowseResult,
   ColumnDefinition,
@@ -21,9 +24,13 @@ import type {
   FilterSpec,
   InsertRowParams,
   QueryResult,
+  RestoreResult,
+  TableSchema,
   UpdateRowParams,
 } from '../types';
 import { BadRequestError } from '../../errors';
+
+const RESTORE_BATCH = 500;
 
 /** Reject identifiers that aren't safe to embed in DDL (which can't be bound). */
 export function assertSafeIdentifier(name: string): string {
@@ -382,6 +389,190 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
     );
   }
 
+  /* ----- backup & restore ----- */
+
+  /** Boolean literal for SQL dumps (Postgres → TRUE/FALSE, others → 1/0). */
+  protected booleanLiteral(value: boolean): string {
+    return value ? '1' : '0';
+  }
+
+  private async targetTables(opts: BackupOptions): Promise<TableSchema[]> {
+    const schema = await this.getSchema();
+    let tables = schema.namespaces.flatMap((ns) => ns.tables);
+    tables = tables.filter((t) => t.kind === 'table');
+    if (opts.schema) tables = tables.filter((t) => (t.schema ?? '') === opts.schema);
+    if (opts.tables?.length) {
+      const wanted = new Set(opts.tables);
+      tables = tables.filter((t) => wanted.has(t.name));
+    }
+    return tables;
+  }
+
+  async backup(opts: BackupOptions): Promise<string> {
+    const { database } = await this.getSchema();
+    const tables = await this.targetTables(opts);
+
+    if (opts.format === 'json') {
+      const doc: BackupDocument = {
+        relay: 'backup',
+        version: 1,
+        engine: this.engine,
+        database,
+        createdAt: new Date().toISOString(),
+        tables: [],
+      };
+      for (const t of tables) {
+        const res = await this.runSql(
+          `SELECT * FROM ${this.qualify(t.name, t.schema)}`,
+          [],
+        );
+        doc.tables.push({
+          name: t.name,
+          schema: t.schema,
+          primaryKey: t.primaryKey,
+          columns: t.columns.map((c) => c.name),
+          rows: res.rows,
+        });
+      }
+      return JSON.stringify(doc, null, 2);
+    }
+
+    // SQL dump: DDL + INSERT statements.
+    const out: string[] = [
+      `-- Relay SQL backup`,
+      `-- engine: ${this.engine}`,
+      `-- database: ${database}`,
+      ``,
+    ];
+    for (const t of tables) {
+      out.push(this.createTableDump(t), ``);
+      const res = await this.runSql(
+        `SELECT * FROM ${this.qualify(t.name, t.schema)}`,
+        [],
+      );
+      if (res.rows.length === 0) continue;
+      const cols = t.columns.map((c) => c.name);
+      const colSql = cols.map((c) => this.quoteIdent(c)).join(', ');
+      const target = this.qualify(t.name, t.schema);
+      for (const row of res.rows) {
+        const values = cols.map((c) => this.sqlLiteral(row[c])).join(', ');
+        out.push(`INSERT INTO ${target} (${colSql}) VALUES (${values});`);
+      }
+      out.push(``);
+    }
+    return out.join('\n');
+  }
+
+  private createTableDump(t: TableSchema): string {
+    const defs = t.columns.map((c) => {
+      let s = `  ${this.quoteIdent(c.name)} ${c.dataType}`;
+      if (!c.nullable) s += ' NOT NULL';
+      // Skip sequence-backed defaults — they aren't portable in a logical dump.
+      if (c.defaultValue && !/nextval|auto_increment/i.test(c.defaultValue)) {
+        s += ` DEFAULT ${c.defaultValue}`;
+      }
+      return s;
+    });
+    if (t.primaryKey.length) {
+      defs.push(
+        `  PRIMARY KEY (${t.primaryKey.map((c) => this.quoteIdent(c)).join(', ')})`,
+      );
+    }
+    return `CREATE TABLE IF NOT EXISTS ${this.qualify(t.name, t.schema)} (\n${defs.join(',\n')}\n);`;
+  }
+
+  private sqlLiteral(value: unknown): string {
+    if (value === null || value === undefined) return 'NULL';
+    if (typeof value === 'number') return String(value);
+    if (typeof value === 'boolean') return this.booleanLiteral(value);
+    if (value instanceof Date) return `'${value.toISOString()}'`;
+    const text =
+      typeof value === 'object' ? JSON.stringify(value) : String(value);
+    return `'${text.replace(/'/g, "''")}'`;
+  }
+
+  async restore(content: string, format: BackupFormat): Promise<RestoreResult> {
+    if (format === 'sql') {
+      const statements = splitSqlStatements(content);
+      let count = 0;
+      for (const stmt of statements) {
+        await this.runSql(stmt, []);
+        count++;
+      }
+      return { tables: 0, rows: count };
+    }
+
+    let doc: BackupDocument;
+    try {
+      doc = JSON.parse(content) as BackupDocument;
+    } catch {
+      throw new BadRequestError('Backup file is not valid JSON');
+    }
+    if (doc.relay !== 'backup' || !Array.isArray(doc.tables)) {
+      throw new BadRequestError('Not a Relay backup file');
+    }
+
+    let rows = 0;
+    for (const table of doc.tables) {
+      // Best-effort recreate; ignore "already exists".
+      await this.createTable({
+        schema: table.schema,
+        table: table.name,
+        columns: table.columns.map((name) => ({
+          name,
+          type: this.defaultRestoreType(),
+          nullable: true,
+          primaryKey: false,
+          autoIncrement: false,
+        })),
+      }).catch(() => undefined);
+
+      rows += await this.bulkInsert(
+        table.name,
+        table.schema,
+        table.columns,
+        table.rows,
+      );
+    }
+    return { tables: doc.tables.length, rows };
+  }
+
+  /** Column type used when recreating a table from a column-name-only dump. */
+  protected defaultRestoreType(): string {
+    return 'TEXT';
+  }
+
+  private async bulkInsert(
+    table: string,
+    schema: string | undefined,
+    columns: string[],
+    rows: Array<Record<string, unknown>>,
+  ): Promise<number> {
+    if (rows.length === 0 || columns.length === 0) return 0;
+    const target = this.qualify(table, schema);
+    const colSql = columns.map((c) => this.quoteIdent(c)).join(', ');
+    let inserted = 0;
+
+    for (let i = 0; i < rows.length; i += RESTORE_BATCH) {
+      const batch = rows.slice(i, i + RESTORE_BATCH);
+      const params: unknown[] = [];
+      let ph = 1;
+      const tuples = batch.map((row) => {
+        const placeholders = columns.map((c) => {
+          params.push(normalizeForInsert(row[c]));
+          return this.placeholder(ph++);
+        });
+        return `(${placeholders.join(', ')})`;
+      });
+      await this.runSql(
+        `INSERT INTO ${target} (${colSql}) VALUES ${tuples.join(', ')}`,
+        params,
+      );
+      inserted += batch.length;
+    }
+    return inserted;
+  }
+
   /**
    * Primary-key columns for a relation, used to build safe row identities.
    * Default implementation derives them from the schema introspection; engines
@@ -399,4 +590,62 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
     }
     return [];
   }
+}
+
+/** Coerce a JSON-decoded value into something a driver can bind for INSERT. */
+function normalizeForInsert(value: unknown): unknown {
+  if (value !== null && typeof value === 'object' && !(value instanceof Date)) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+/**
+ * Split a `.sql` script into individual statements, respecting single-quoted
+ * strings (with `''` escapes) and `--` / block comments. Good enough for
+ * Relay-generated dumps and typical hand-written scripts.
+ */
+function splitSqlStatements(sql: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let inSingle = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i]!;
+    const next = sql[i + 1];
+    if (inSingle) {
+      cur += ch;
+      if (ch === "'") {
+        if (next === "'") {
+          cur += next;
+          i++;
+        } else {
+          inSingle = false;
+        }
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inSingle = true;
+      cur += ch;
+      continue;
+    }
+    if (ch === '-' && next === '-') {
+      while (i < sql.length && sql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < sql.length && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
+      i++;
+      continue;
+    }
+    if (ch === ';') {
+      if (cur.trim()) out.push(cur.trim());
+      cur = '';
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur.trim()) out.push(cur.trim());
+  return out;
 }

--- a/packages/core/src/adapters/sql/mysql-adapter.ts
+++ b/packages/core/src/adapters/sql/mysql-adapter.ts
@@ -22,6 +22,7 @@ export const MYSQL_CAPABILITIES: AdapterCapabilities = {
   transactions: true,
   ddl: true,
   manageDatabases: true,
+  backupFormats: ['json', 'sql'],
 };
 
 export class MysqlAdapter extends BaseSqlAdapter {

--- a/packages/core/src/adapters/sql/postgres-adapter.ts
+++ b/packages/core/src/adapters/sql/postgres-adapter.ts
@@ -24,6 +24,7 @@ export const POSTGRES_CAPABILITIES: AdapterCapabilities = {
   transactions: true,
   ddl: true,
   manageDatabases: true,
+  backupFormats: ['json', 'sql'],
 };
 
 export class PostgresAdapter extends BaseSqlAdapter {
@@ -91,6 +92,10 @@ export class PostgresAdapter extends BaseSqlAdapter {
 
   protected override serialType(): string {
     return 'SERIAL';
+  }
+
+  protected override booleanLiteral(value: boolean): string {
+    return value ? 'TRUE' : 'FALSE';
   }
 
   protected override async runSql(

--- a/packages/core/src/adapters/sql/sqlite-adapter.ts
+++ b/packages/core/src/adapters/sql/sqlite-adapter.ts
@@ -23,6 +23,7 @@ export const SQLITE_CAPABILITIES: AdapterCapabilities = {
   transactions: true,
   ddl: true,
   manageDatabases: false,
+  backupFormats: ['json', 'sql'],
 };
 
 export class SqliteAdapter extends BaseSqlAdapter {

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -46,6 +46,8 @@ export interface AdapterCapabilities {
   ddl: boolean;
   /** Supports creating / dropping databases on this connection. */
   manageDatabases: boolean;
+  /** Backup/restore formats this engine can produce/consume. */
+  backupFormats: BackupFormat[];
 }
 
 /* -------------------------------------------------------------------------- */
@@ -269,6 +271,45 @@ export interface CreateTableSpec {
 }
 
 /* -------------------------------------------------------------------------- */
+/* Backup & restore                                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `json` — portable, engine-agnostic dump (schema + data) that any engine can
+ * read back, with parameterized inserts on restore.
+ * `sql`  — a `.sql` script of DDL + INSERT statements (relational engines only).
+ */
+export type BackupFormat = 'json' | 'sql';
+
+export interface BackupOptions {
+  format: BackupFormat;
+  /** Restrict to these relations; defaults to every table in the database. */
+  tables?: string[];
+  schema?: string;
+}
+
+/** The portable JSON backup shape (also embedded inside `json` dumps). */
+export interface BackupDocument {
+  relay: 'backup';
+  version: 1;
+  engine: DatabaseEngine;
+  database: string;
+  createdAt: string;
+  tables: Array<{
+    name: string;
+    schema?: string;
+    primaryKey: string[];
+    columns: string[];
+    rows: Array<Record<string, unknown>>;
+  }>;
+}
+
+export interface RestoreResult {
+  tables: number;
+  rows: number;
+}
+
+/* -------------------------------------------------------------------------- */
 /* The adapter                                                                */
 /* -------------------------------------------------------------------------- */
 
@@ -303,4 +344,8 @@ export interface DatabaseAdapter {
   createTable(spec: CreateTableSpec): Promise<void>;
   dropTable(table: string, schema?: string): Promise<void>;
   truncateTable(table: string, schema?: string): Promise<void>;
+
+  /* backup & restore — guarded by `capabilities.backupFormats` */
+  backup(options: BackupOptions): Promise<string>;
+  restore(content: string, format: BackupFormat): Promise<RestoreResult>;
 }

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -117,3 +117,18 @@ export const relationRefSchema = z.object({
   schema: z.string().optional(),
   table: z.string().min(1),
 });
+
+/* ----- backup & restore ----- */
+
+export const backupFormatSchema = z.enum(['json', 'sql']);
+
+export const backupSchema = z.object({
+  format: backupFormatSchema.default('json'),
+  tables: z.array(z.string()).optional(),
+  schema: z.string().optional(),
+});
+
+export const restoreSchema = z.object({
+  format: backupFormatSchema.default('json'),
+  content: z.string().min(1),
+});


### PR DESCRIPTION
Backup a whole database or a single table; restore from a JSON/SQL file. Implemented across all adapters with safe escaping/parameterized inserts; new API routes and sidebar UI.