### PR TITLE
Add automation hooks: stream table/query rows to HTTP endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Prefer hot-reload while hacking?
 pnpm dev         # same setup, watch-mode on both sides
 ```
 
+**Running automation hooks** needs a Redis instance for the durable job queue
+(browsing, querying, and creating/previewing hooks do not):
+
+```bash
+docker compose up -d redis   # or set REDIS_URL to an existing Redis
+```
+
 ## Features
 
 🔌 **Many engines, one interface** — relational and NoSQL behind a single,
@@ -62,6 +69,14 @@ create / drop databases.
 table (portable **JSON** for any engine, or a **`.sql`** script for relational
 engines), and restore straight from a file.
 
+🪝 **Automations** — turn any table or query into a **webhook**. Create a hook
+that streams every row to an HTTP endpoint (one-by-one or batched), shape the
+body with a safe **token template** (`{{column}}`, `{{$row}}`, `{{$table}}`,
+`{{$now}}`, `{{$index}}`), and add headers + an encrypted auth secret. Runs are
+**durable** (BullMQ + Redis), **resumable** after a crash, **cancellable**, and
+rate-limited, with automatic retries/backoff and a per-delivery log. See the
+**Automations** tab in the sidebar, or right-click a table → _Create automation_.
+
 🎨 **Designed to live in** — shadcn/ui, light & dark themes, resizable panels,
 keyboard-friendly, and quiet.
 
@@ -78,6 +93,7 @@ relay/
 ├─ apps/
 │  ├─ api/             @relay/api — NestJS backend
 │  │  ├─ connections/    Prisma-backed store · connection pool · controllers
+│  │  ├─ hooks/          automation hooks · BullMQ run processor · delivery
 │  │  ├─ common/         crypto · Zod validation · exception filter
 │  │  └─ prisma/         metadata-store schema + migrations
 │  └─ web/             @relay/web — Next.js 15 frontend (shadcn/ui, TanStack)

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -29,3 +29,11 @@ RELAY_MAX_QUERY_ROWS=5000
 RELAY_POOL_IDLE_MS=300000
 # Where the encryption key + local state live (default: apps/api/.relay).
 # RELAY_DATA_DIR=.relay
+
+# ── Automation hooks (job queue) ─────────────────────────────
+# Redis backing the BullMQ queue that runs automation hooks. Start one with
+# `docker compose up -d redis` from the repo root. The studio, hook CRUD and
+# payload preview work without Redis — only *running* a hook needs it.
+REDIS_URL=redis://localhost:6379
+# How many hook runs may execute concurrently.
+RELAY_HOOK_CONCURRENCY=5

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,12 +15,15 @@
     "postinstall": "prisma generate"
   },
   "dependencies": {
+    "@nestjs/bullmq": "^10.2.3",
     "@nestjs/common": "^10.4.7",
     "@nestjs/core": "^10.4.7",
     "@nestjs/platform-express": "^10.4.7",
     "@relay/core": "workspace:*",
     "@prisma/client": "^5.22.0",
+    "bullmq": "^5.34.0",
     "dotenv": "^16.4.5",
+    "ioredis": "^5.4.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^3.23.8"

--- a/apps/api/prisma/migrations/20260603121025_hooks/migration.sql
+++ b/apps/api/prisma/migrations/20260603121025_hooks/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE "hooks" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "connection_id" TEXT NOT NULL,
+    "source_json" TEXT NOT NULL,
+    "destination_json" TEXT NOT NULL,
+    "auth_enc" TEXT,
+    "transform_json" TEXT NOT NULL,
+    "delivery_json" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "hook_runs" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "hook_id" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "cursor_offset" INTEGER NOT NULL DEFAULT 0,
+    "sent_count" INTEGER NOT NULL DEFAULT 0,
+    "failed_count" INTEGER NOT NULL DEFAULT 0,
+    "total_count" INTEGER,
+    "config_snapshot_json" TEXT NOT NULL,
+    "error" TEXT,
+    "started_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finished_at" DATETIME,
+    CONSTRAINT "hook_runs_hook_id_fkey" FOREIGN KEY ("hook_id") REFERENCES "hooks" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "hook_deliveries" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "run_id" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL,
+    "row_index" INTEGER NOT NULL,
+    "row_count" INTEGER NOT NULL,
+    "status" TEXT NOT NULL,
+    "http_status" INTEGER,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "error" TEXT,
+    "response_snippet" TEXT,
+    "duration_ms" INTEGER,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "hook_deliveries_run_id_fkey" FOREIGN KEY ("run_id") REFERENCES "hook_runs" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "hooks_connection_id_idx" ON "hooks"("connection_id");
+
+-- CreateIndex
+CREATE INDEX "hook_runs_hook_id_idx" ON "hook_runs"("hook_id");
+
+-- CreateIndex
+CREATE INDEX "hook_runs_status_idx" ON "hook_runs"("status");
+
+-- CreateIndex
+CREATE INDEX "hook_deliveries_run_id_idx" ON "hook_deliveries"("run_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "hook_deliveries_run_id_sequence_key" ON "hook_deliveries"("run_id", "sequence");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,3 +31,81 @@ model Connection {
 
   @@map("connections")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Automation hooks
+//
+//  A Hook reads rows from a connected database (table or query) and POSTs each
+//  one to an HTTP endpoint with a templated payload. Nested config objects are
+//  stored as JSON strings (SQLite has no JSON columns), mirroring `optionsJson`.
+//  The destination's auth secret is the only sensitive field and is encrypted at
+//  rest in `authEnc`, exactly like a connection password.
+// ─────────────────────────────────────────────────────────────────────────────
+
+model Hook {
+  id              String   @id
+  name            String
+  connectionId    String   @map("connection_id")
+  sourceJson      String   @map("source_json")
+  destinationJson String   @map("destination_json") // auth secret stripped
+  authEnc         String?  @map("auth_enc")          // encrypted secret material only
+  transformJson   String   @map("transform_json")
+  deliveryJson    String   @map("delivery_json")
+  enabled         Boolean  @default(true)
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
+
+  runs HookRun[]
+
+  @@index([connectionId])
+  @@map("hooks")
+}
+
+model HookRun {
+  id     String @id
+  hookId String @map("hook_id")
+  // 'queued' | 'running' | 'completed' | 'failed' | 'canceling' | 'canceled' | 'interrupted'
+  status String
+
+  // Resumable progress.
+  cursorOffset Int  @default(0) @map("cursor_offset") // next source offset on resume
+  sentCount    Int  @default(0) @map("sent_count")
+  failedCount  Int  @default(0) @map("failed_count")
+  totalCount   Int? @map("total_count") // best-effort; may be null
+
+  // Resolved config captured at start (auth still encrypted) so editing/deleting
+  // the Hook mid-run cannot corrupt or leak the in-flight run.
+  configSnapshotJson String  @map("config_snapshot_json")
+  error              String?
+
+  startedAt  DateTime  @default(now()) @map("started_at")
+  finishedAt DateTime? @map("finished_at")
+
+  hook       Hook           @relation(fields: [hookId], references: [id], onDelete: Cascade)
+  deliveries HookDelivery[]
+
+  @@index([hookId])
+  @@index([status])
+  @@map("hook_runs")
+}
+
+model HookDelivery {
+  id              String   @id
+  runId           String   @map("run_id")
+  sequence        Int // monotonic per run — also the idempotency key
+  rowIndex        Int      @map("row_index") // first row index in this delivery
+  rowCount        Int      @map("row_count") // 1, or batchSize
+  status          String // 'success' | 'failed'
+  httpStatus      Int?     @map("http_status")
+  attempts        Int      @default(0)
+  error           String?
+  responseSnippet String?  @map("response_snippet") // truncated to ~2KB
+  durationMs      Int?     @map("duration_ms")
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  run HookRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  @@unique([runId, sequence]) // idempotency guard for resume / stalled-job recovery
+  @@index([runId])
+  @@map("hook_deliveries")
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,8 +1,18 @@
+import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
+import { CommonModule } from './common/common.module';
+import { redisConnectionOptions } from './common/runtime-config';
 import { ConnectionsModule } from './connections/connections.module';
 import { DriversModule } from './drivers/drivers.module';
+import { HooksModule } from './hooks/hooks.module';
 
 @Module({
-  imports: [ConnectionsModule, DriversModule],
+  imports: [
+    CommonModule,
+    BullModule.forRoot({ connection: redisConnectionOptions() }),
+    ConnectionsModule,
+    DriversModule,
+    HooksModule,
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -1,0 +1,15 @@
+import { Global, Module } from '@nestjs/common';
+import { CryptoService } from './crypto.service';
+import { PrismaService } from './prisma.service';
+
+/**
+ * Shared singletons (Prisma client + credential crypto). Marked `@Global` so any
+ * feature module can inject them without re-listing them as providers — which
+ * would otherwise create a second `CryptoService` that reloads the master key.
+ */
+@Global()
+@Module({
+  providers: [PrismaService, CryptoService],
+  exports: [PrismaService, CryptoService],
+})
+export class CommonModule {}

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -21,4 +21,34 @@ export const runtimeConfig = {
   poolIdleMs: Number(process.env.RELAY_POOL_IDLE_MS ?? 300_000),
   port: Number(process.env.PORT ?? 4000),
   webOrigin: process.env.WEB_ORIGIN ?? true,
+  /** Redis URL backing the BullMQ hook-run queue. */
+  redisUrl: process.env.REDIS_URL ?? 'redis://localhost:6379',
+  /** Worker concurrency: how many hook runs may execute in parallel. */
+  hookConcurrency: Number(process.env.RELAY_HOOK_CONCURRENCY ?? 5),
 } as const;
+
+/**
+ * Parse {@link runtimeConfig.redisUrl} into ioredis connection options for
+ * BullMQ. `maxRetriesPerRequest: null` is required by BullMQ's blocking
+ * connections; ioredis still reconnects in the background, so a missing Redis
+ * never crashes bootstrap — only enqueuing a run fails (with a clear message).
+ */
+export function redisConnectionOptions(): {
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  db: number;
+  maxRetriesPerRequest: null;
+} {
+  const u = new URL(runtimeConfig.redisUrl);
+  const db = u.pathname && u.pathname.length > 1 ? Number(u.pathname.slice(1)) : 0;
+  return {
+    host: u.hostname || 'localhost',
+    port: u.port ? Number(u.port) : 6379,
+    username: u.username || undefined,
+    password: u.password || undefined,
+    db: Number.isFinite(db) ? db : 0,
+    maxRetriesPerRequest: null,
+  };
+}

--- a/apps/api/src/connections/connections.module.ts
+++ b/apps/api/src/connections/connections.module.ts
@@ -1,18 +1,12 @@
 import { Module } from '@nestjs/common';
-import { CryptoService } from '../common/crypto.service';
-import { PrismaService } from '../common/prisma.service';
 import { AdapterPoolService } from './adapter-pool.service';
 import { ConnectionStoreService } from './connection-store.service';
 import { ConnectionsController } from './connections.controller';
 
+// PrismaService + CryptoService come from the global CommonModule.
 @Module({
   controllers: [ConnectionsController],
-  providers: [
-    PrismaService,
-    CryptoService,
-    ConnectionStoreService,
-    AdapterPoolService,
-  ],
+  providers: [ConnectionStoreService, AdapterPoolService],
   exports: [ConnectionStoreService, AdapterPoolService],
 })
 export class ConnectionsModule {}

--- a/apps/api/src/hooks/delivery.service.ts
+++ b/apps/api/src/hooks/delivery.service.ts
@@ -1,0 +1,178 @@
+/**
+ * Single-request HTTP delivery with retries, exponential backoff and a hard
+ * per-request timeout. Pure transport: it knows nothing about runs, rows, or
+ * persistence — the caller supplies the body and records the outcome.
+ *
+ * Auth secrets are applied to headers at send time and never logged; only a
+ * truncated response snippet is retained.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import type { HookDeliveryConfig, HookDestination } from '@relay/core';
+import type { DeliveryOutcome } from './hooks.types';
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const SNIPPET_LIMIT = 2048;
+
+@Injectable()
+export class DeliveryService {
+  private readonly logger = new Logger('HookDelivery');
+
+  /** Build request headers, merging static headers with the auth scheme. */
+  buildHeaders(
+    dest: HookDestination,
+    idempotencyKey?: string,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      ...(dest.headers ?? {}),
+    };
+    if (dest.auth.type === 'bearer' && dest.auth.token) {
+      headers['authorization'] = `Bearer ${dest.auth.token}`;
+    } else if (dest.auth.type === 'header' && dest.auth.value) {
+      headers[dest.auth.name] = dest.auth.value;
+    }
+    if (idempotencyKey && dest.idempotency) {
+      headers['idempotency-key'] = idempotencyKey;
+    }
+    return headers;
+  }
+
+  /** Headers with the auth secret redacted — safe for preview/UI. */
+  redactedHeaders(dest: HookDestination): Record<string, string> {
+    const headers = this.buildHeaders(dest);
+    if (dest.auth.type === 'bearer' && headers['authorization']) {
+      headers['authorization'] = 'Bearer ********';
+    } else if (dest.auth.type === 'header' && dest.auth.name in headers) {
+      headers[dest.auth.name] = '********';
+    }
+    return headers;
+  }
+
+  /**
+   * Send one request, retrying transient failures up to `maxAttempts`. Resolves
+   * with an outcome describing success or terminal failure — it does not throw
+   * for HTTP errors (the run decides whether to continue). It re-throws only if
+   * the run's abort signal fires, so the caller can finalize as canceled.
+   */
+  async send(
+    body: unknown,
+    dest: HookDestination,
+    delivery: HookDeliveryConfig,
+    runSignal: AbortSignal,
+    idempotencyKey?: string,
+  ): Promise<DeliveryOutcome> {
+    const headers = this.buildHeaders(dest, idempotencyKey);
+    const payload = JSON.stringify(body ?? null);
+    const started = performance.now();
+    let lastError: string | null = null;
+    let lastStatus: number | null = null;
+    let lastSnippet: string | null = null;
+
+    for (let attempt = 1; attempt <= delivery.maxAttempts; attempt++) {
+      if (runSignal.aborted) throw new DOMException('Run canceled', 'AbortError');
+
+      const timeout = AbortSignal.timeout(delivery.timeoutMs);
+      const signal = AbortSignal.any([runSignal, timeout]);
+      try {
+        const res = await fetch(dest.url, {
+          method: dest.method,
+          headers,
+          body: payload,
+          signal,
+        });
+        lastStatus = res.status;
+        lastSnippet = (await res.text().catch(() => '')).slice(0, SNIPPET_LIMIT);
+
+        if (res.ok) {
+          return {
+            status: 'success',
+            httpStatus: res.status,
+            attempts: attempt,
+            error: null,
+            responseSnippet: lastSnippet || null,
+            durationMs: Math.round(performance.now() - started),
+          };
+        }
+
+        lastError = `HTTP ${res.status} ${res.statusText}`.trim();
+        if (RETRYABLE_STATUS.has(res.status) && attempt < delivery.maxAttempts) {
+          await this.backoff(attempt, delivery, res.headers.get('retry-after'));
+          continue;
+        }
+        break; // non-retryable HTTP error
+      } catch (err) {
+        // A run-level abort must propagate; a timeout/network error is retryable.
+        if (runSignal.aborted) throw err;
+        lastError = describeFetchError(err);
+        lastStatus = null;
+        if (attempt < delivery.maxAttempts) {
+          await this.backoff(attempt, delivery, null);
+          continue;
+        }
+      }
+    }
+
+    return {
+      status: 'failed',
+      httpStatus: lastStatus,
+      attempts: delivery.maxAttempts,
+      error: lastError ?? 'Delivery failed',
+      responseSnippet: lastSnippet,
+      durationMs: Math.round(performance.now() - started),
+    };
+  }
+
+  /** Exponential backoff with jitter, honoring a numeric `Retry-After`. */
+  private async backoff(
+    attempt: number,
+    delivery: HookDeliveryConfig,
+    retryAfter: string | null,
+  ): Promise<void> {
+    let delay = Math.min(
+      delivery.backoffMaxMs,
+      delivery.backoffMs * 2 ** (attempt - 1),
+    );
+    const retryAfterMs = retryAfter ? Number(retryAfter) * 1000 : NaN;
+    if (Number.isFinite(retryAfterMs)) {
+      delay = Math.max(delay, Math.min(retryAfterMs, delivery.backoffMaxMs));
+    }
+    const jitter = delay * 0.2 * Math.random();
+    await sleep(delay + jitter);
+  }
+}
+
+/**
+ * Turn an opaque `fetch failed` into something actionable. Node's `fetch`
+ * (undici) wraps the real reason in `error.cause` — surface its `code`,
+ * `address`/`port` and message so a delivery log says e.g.
+ * "fetch failed (ECONNREFUSED 127.0.0.1:8000)" instead of just "fetch failed".
+ */
+export function describeFetchError(err: unknown): string {
+  if (err instanceof DOMException && err.name === 'TimeoutError') {
+    return 'Request timed out';
+  }
+  if (!(err instanceof Error)) return String(err);
+  const cause = (err as { cause?: unknown }).cause as
+    | { code?: string; address?: string; port?: number; message?: string }
+    | undefined;
+  if (!cause) return err.message;
+  const where = cause.address
+    ? ` ${cause.address}${cause.port ? `:${cause.port}` : ''}`
+    : '';
+  const detail = cause.code ? `${cause.code}${where}` : (cause.message ?? '');
+  return detail ? `${err.message} (${detail.trim()})` : err.message;
+}
+
+/** Sleep that resolves early if the signal aborts — keeps cancel responsive. */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(done, ms);
+    function done() {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', done);
+      resolve();
+    }
+    signal?.addEventListener('abort', done, { once: true });
+  });
+}

--- a/apps/api/src/hooks/hook-run.processor.ts
+++ b/apps/api/src/hooks/hook-run.processor.ts
@@ -1,0 +1,261 @@
+/**
+ * BullMQ worker that executes a hook run. One job == one run (`jobId = runId`),
+ * so the run's lifecycle is the job's lifecycle — no cross-job bookkeeping.
+ *
+ * Streaming: rows are read a page at a time (table) or once (query) and grouped
+ * into batches of `batchSize`. Each batch is one HTTP delivery. Only a single
+ * page is ever held in memory, and deliveries are awaited sequentially, which
+ * gives natural backpressure and lets `minDelayMs` pace the send rate.
+ *
+ * Resumability: the run checkpoints `cursorOffset` at every batch boundary
+ * (always batch-aligned), so a stalled-job recovery or explicit resume restarts
+ * mid-stream. The `(runId, sequence)` unique row + a skip-set of already-succeeded
+ * sequences make re-delivery idempotent. `sequence = floor(rowIndex / batchSize)`
+ * is deterministic, so the numbering lines up across attempts.
+ */
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { BadRequestError, renderBatch, renderRow, type SortSpec } from '@relay/core';
+import type { Job } from 'bullmq';
+import { AdapterPoolService } from '../connections/adapter-pool.service';
+import { runtimeConfig } from '../common/runtime-config';
+import { sleep } from './delivery.service';
+import { DeliveryService } from './delivery.service';
+import { HookRunService } from './hook-run.service';
+import { HookStoreService } from './hook-store.service';
+import { RunRegistryService } from './run-registry.service';
+import { HOOK_RUNS_QUEUE, type HookRunJob, type ResolvedHook } from './hooks.types';
+
+interface StreamItem {
+  row: Record<string, unknown>;
+  index: number;
+}
+
+@Processor(HOOK_RUNS_QUEUE, { concurrency: runtimeConfig.hookConcurrency })
+export class HookRunProcessor extends WorkerHost {
+  private readonly logger = new Logger('HookRunProcessor');
+
+  constructor(
+    private readonly runs: HookRunService,
+    private readonly store: HookStoreService,
+    private readonly pool: AdapterPoolService,
+    private readonly delivery: DeliveryService,
+    private readonly registry: RunRegistryService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<HookRunJob>): Promise<void> {
+    const { runId } = job.data;
+    const row = await this.runs.getRunRow(runId);
+
+    // Already settled by a previous attempt, or canceled before we started.
+    if (['completed', 'failed', 'canceled', 'interrupted'].includes(row.status)) return;
+    if (row.status === 'canceling') {
+      await this.runs.finalize(runId, 'canceled');
+      return;
+    }
+
+    const controller = this.registry.register(runId);
+    try {
+      await this.execute(runId, row.cursorOffset, row.configSnapshotJson, controller.signal);
+    } finally {
+      this.registry.release(runId);
+    }
+  }
+
+  private async execute(
+    runId: string,
+    startOffset: number,
+    snapshotJson: string,
+    signal: AbortSignal,
+  ): Promise<void> {
+    await this.runs.markRunning(runId);
+    const hook = this.store.resolveSnapshot(snapshotJson);
+    const { delivery } = hook;
+    const batchSize = delivery.batchSize;
+    const table = hook.source.kind === 'table' ? hook.source.table : '(query)';
+    const done = await this.runs.succeededSequences(runId);
+
+    // Cancellation works across processes: any worker may own the job, so the
+    // local abort signal alone isn't authoritative. Poll the run status too,
+    // throttled to keep DB load negligible on high-throughput runs.
+    let lastStatusCheck = 0;
+    const stopRequested = async (): Promise<boolean> => {
+      if (signal.aborted) return true;
+      const now = Date.now();
+      if (now - lastStatusCheck < 750) return false;
+      lastStatusCheck = now;
+      return this.runs.cancelRequested(runId);
+    };
+
+    let buffer: Record<string, unknown>[] = [];
+    let bufferStart = startOffset;
+
+    try {
+      for await (const item of this.streamRows(hook, runId, startOffset)) {
+        if (await stopRequested()) {
+          await this.runs.finalize(runId, 'canceled');
+          return;
+        }
+        buffer.push(item.row);
+        if (buffer.length === batchSize) {
+          const stop = await this.flush(runId, table, buffer, bufferStart, done, hook, signal);
+          buffer = [];
+          bufferStart = item.index + 1;
+          await this.runs.setCursor(runId, bufferStart);
+          if (stop) {
+            await this.runs.finalize(runId, 'failed', 'Stopped after a failed delivery (onError=abort).');
+            return;
+          }
+          await sleep(delivery.minDelayMs, signal);
+        }
+      }
+
+      if (buffer.length > 0) {
+        if (await stopRequested()) {
+          await this.runs.finalize(runId, 'canceled');
+          return;
+        }
+        const stop = await this.flush(runId, table, buffer, bufferStart, done, hook, signal);
+        if (stop) {
+          await this.runs.finalize(runId, 'failed', 'Stopped after a failed delivery (onError=abort).');
+          return;
+        }
+      }
+
+      await this.runs.finalize(runId, (await stopRequested()) ? 'canceled' : 'completed');
+    } catch (err) {
+      if (signal.aborted || (await this.runs.cancelRequested(runId))) {
+        await this.runs.finalize(runId, 'canceled');
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Run ${runId} failed: ${message}`);
+      await this.runs.finalize(runId, 'failed', message);
+    }
+  }
+
+  /** Render + deliver one batch; returns true if the run should abort. */
+  private async flush(
+    runId: string,
+    table: string,
+    rows: Record<string, unknown>[],
+    startIndex: number,
+    done: Set<number>,
+    hook: ResolvedHook,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    const batchSize = hook.delivery.batchSize;
+    const sequence = Math.floor(startIndex / batchSize);
+    if (done.has(sequence)) return false; // already delivered on a prior attempt
+
+    const now = new Date().toISOString();
+    const { body } =
+      rows.length === 1
+        ? renderRow(rows[0]!, hook.transform, { table, now, index: startIndex })
+        : renderBatch(rows, hook.transform, startIndex, { table, now });
+
+    const outcome = await this.delivery.send(
+      body,
+      hook.destination,
+      hook.delivery,
+      signal,
+      `${runId}:${sequence}`,
+    );
+    await this.runs.recordDelivery(
+      runId,
+      { sequence, rowIndex: startIndex, rowCount: rows.length },
+      outcome,
+    );
+    return outcome.status === 'failed' && hook.delivery.onError === 'abort';
+  }
+
+  /* ----- row streaming ----- */
+
+  private streamRows(
+    hook: ResolvedHook,
+    runId: string,
+    startOffset: number,
+  ): AsyncGenerator<StreamItem> {
+    return hook.source.kind === 'table'
+      ? this.streamTable(hook, runId, startOffset)
+      : this.streamQuery(hook, runId, startOffset);
+  }
+
+  private async *streamTable(
+    hook: ResolvedHook,
+    runId: string,
+    startOffset: number,
+  ): AsyncGenerator<StreamItem> {
+    if (hook.source.kind !== 'table') return;
+    const src = hook.source;
+    const { sort, total } = await this.resolveTableOrder(hook);
+    await this.runs.setTotal(runId, total);
+
+    let offset = startOffset;
+    for (;;) {
+      const page = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
+        a.browse({
+          schema: src.schema,
+          table: src.table,
+          filters: src.filters,
+          sort,
+          limit: hook.delivery.pageSize,
+          offset,
+        }),
+      );
+      for (let i = 0; i < page.rows.length; i++) {
+        yield { row: page.rows[i]!, index: offset + i };
+      }
+      if (!page.hasMore || page.rows.length === 0) return;
+      offset += page.rows.length;
+    }
+  }
+
+  /**
+   * A stable order is mandatory: `LIMIT/OFFSET` without `ORDER BY` can skip or
+   * repeat rows across pages. Use the caller's sort, else the primary key.
+   */
+  private async resolveTableOrder(
+    hook: ResolvedHook,
+  ): Promise<{ sort: SortSpec[]; total: number | null }> {
+    if (hook.source.kind !== 'table') return { sort: [], total: null };
+    const src = hook.source;
+    const probe = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
+      a.browse({ schema: src.schema, table: src.table, filters: src.filters, limit: 1, offset: 0 }),
+    );
+    if (src.sort && src.sort.length > 0) return { sort: src.sort, total: probe.total };
+    if (probe.primaryKey.length > 0) {
+      return {
+        sort: probe.primaryKey.map((column) => ({ column, direction: 'asc' as const })),
+        total: probe.total,
+      };
+    }
+    throw new BadRequestError(
+      `Table "${src.table}" has no primary key, so rows cannot be paged in a stable order. Add a sort to the hook to replay it safely.`,
+    );
+  }
+
+  private async *streamQuery(
+    hook: ResolvedHook,
+    runId: string,
+    startOffset: number,
+  ): AsyncGenerator<StreamItem> {
+    if (hook.source.kind !== 'query') return;
+    const src = hook.source;
+    const result = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
+      a.query(src.statement),
+    );
+    if (result.truncated) {
+      throw new BadRequestError(
+        `Query result was capped at ${result.rowCount} rows (limit ${runtimeConfig.maxQueryRows}). ` +
+          `Narrow the query, or use a table source to replay every row.`,
+      );
+    }
+    await this.runs.setTotal(runId, result.rows.length);
+    for (let i = startOffset; i < result.rows.length; i++) {
+      yield { row: result.rows[i]!, index: i };
+    }
+  }
+}

--- a/apps/api/src/hooks/hook-run.service.ts
+++ b/apps/api/src/hooks/hook-run.service.ts
@@ -1,0 +1,308 @@
+/**
+ * Hook-run lifecycle + queue glue. Owns every Prisma write to `hook_runs` /
+ * `hook_deliveries` and the BullMQ enqueue/cancel paths, so the processor only
+ * has to stream and deliver.
+ *
+ * Durability model: one BullMQ job per run (`jobId = runId`). A crashed run is
+ * recovered by BullMQ's stalled-job detection and resumed from `cursorOffset`;
+ * on boot we also re-enqueue any non-terminal run so nothing is orphaned.
+ */
+import { randomUUID } from 'node:crypto';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+import {
+  AppError,
+  ConflictError,
+  type HookDelivery,
+  type HookRun,
+  type HookRunStatus,
+  NotFoundError,
+} from '@relay/core';
+import { Queue } from 'bullmq';
+import type { HookDelivery as DeliveryRow, HookRun as RunRow } from '@prisma/client';
+import { PrismaService } from '../common/prisma.service';
+import { HookStoreService } from './hook-store.service';
+import { RunRegistryService } from './run-registry.service';
+import { HOOK_RUNS_QUEUE, type DeliveryOutcome, type HookRunJob } from './hooks.types';
+
+const ACTIVE: HookRunStatus[] = ['queued', 'running', 'canceling'];
+const TERMINAL: HookRunStatus[] = ['completed', 'failed', 'canceled', 'interrupted'];
+
+@Injectable()
+export class HookRunService implements OnModuleInit {
+  private readonly logger = new Logger('HookRun');
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly store: HookStoreService,
+    private readonly registry: RunRegistryService,
+    @InjectQueue(HOOK_RUNS_QUEUE) private readonly queue: Queue<HookRunJob>,
+  ) {}
+
+  /* ----- start / resume ----- */
+
+  async start(hookId: string, resumeRunId?: string): Promise<HookRun> {
+    await this.store.get(hookId); // 404 if the hook is gone
+
+    if (resumeRunId) return this.resume(hookId, resumeRunId);
+
+    const active = await this.prisma.hookRun.findFirst({
+      where: { hookId, status: { in: ACTIVE } },
+    });
+    if (active) {
+      throw new ConflictError(
+        'A run is already in progress for this hook. Cancel it before starting another.',
+      );
+    }
+
+    await this.ensureQueueReady();
+    const id = randomUUID();
+    const snapshot = await this.store.snapshotJson(hookId);
+    const row = await this.prisma.hookRun.create({
+      data: { id, hookId, status: 'queued', configSnapshotJson: snapshot },
+    });
+    await this.enqueue(id, hookId);
+    return this.toRun(row);
+  }
+
+  private async resume(hookId: string, runId: string): Promise<HookRun> {
+    const row = await this.getRunRow(runId);
+    if (row.hookId !== hookId) throw new NotFoundError(`Run "${runId}" not found`);
+    if (!TERMINAL.includes(row.status as HookRunStatus) || row.status === 'completed') {
+      throw new ConflictError(`Run "${runId}" cannot be resumed (status: ${row.status}).`);
+    }
+    await this.ensureQueueReady();
+    const reset = await this.prisma.hookRun.update({
+      where: { id: runId },
+      data: { status: 'queued', error: null, finishedAt: null },
+    });
+    await this.enqueue(runId, hookId);
+    return this.toRun(reset);
+  }
+
+  private async enqueue(runId: string, hookId: string): Promise<void> {
+    await this.queue.add(
+      'run',
+      { runId, hookId },
+      { jobId: runId, removeOnComplete: true, removeOnFail: 500, attempts: 1 },
+    );
+  }
+
+  /** Fail fast with a friendly message when Redis is unreachable. */
+  private async ensureQueueReady(): Promise<void> {
+    try {
+      await Promise.race([
+        this.queue.waitUntilReady(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), 2000),
+        ),
+      ]);
+      return;
+    } catch {
+      throw new AppError(
+        'CONNECTION_FAILED',
+        'The job queue (Redis) is unavailable. Start it with `docker compose up -d redis` or set REDIS_URL.',
+        503,
+      );
+    }
+  }
+
+  /* ----- cancel ----- */
+
+  async cancel(hookId: string, runId: string): Promise<HookRun> {
+    const row = await this.getRunRow(runId);
+    if (row.hookId !== hookId) throw new NotFoundError(`Run "${runId}" not found`);
+    if (TERMINAL.includes(row.status as HookRunStatus)) return this.toRun(row);
+
+    const updated = await this.prisma.hookRun.update({
+      where: { id: runId },
+      data: { status: 'canceling' },
+    });
+    this.registry.abort(runId); // stop the in-flight fetch immediately
+    await this.queue.remove(runId).catch(() => {}); // best-effort; worker also self-stops
+    return this.toRun(updated);
+  }
+
+  /* ----- queries ----- */
+
+  async listRuns(hookId: string, limit = 50): Promise<HookRun[]> {
+    const rows = await this.prisma.hookRun.findMany({
+      where: { hookId },
+      orderBy: { startedAt: 'desc' },
+      take: limit,
+    });
+    return rows.map((r) => this.toRun(r));
+  }
+
+  async getRun(hookId: string, runId: string): Promise<HookRun> {
+    const row = await this.getRunRow(runId);
+    if (row.hookId !== hookId) throw new NotFoundError(`Run "${runId}" not found`);
+    return this.toRun(row);
+  }
+
+  async listDeliveries(
+    runId: string,
+    opts: { status?: 'success' | 'failed'; offset?: number; limit?: number } = {},
+  ): Promise<HookDelivery[]> {
+    const rows = await this.prisma.hookDelivery.findMany({
+      where: { runId, ...(opts.status ? { status: opts.status } : {}) },
+      orderBy: { sequence: 'asc' },
+      skip: opts.offset ?? 0,
+      take: Math.min(opts.limit ?? 100, 500),
+    });
+    return rows.map((r) => this.toDelivery(r));
+  }
+
+  /* ----- processor-facing mutations ----- */
+
+  async getRunRow(runId: string): Promise<RunRow> {
+    const row = await this.prisma.hookRun.findUnique({ where: { id: runId } });
+    if (!row) throw new NotFoundError(`Run "${runId}" not found`);
+    return row;
+  }
+
+  /**
+   * Whether a stop was requested for this run — works across processes (any
+   * BullMQ worker can own the job, so checking the DB status is authoritative,
+   * not just the local abort signal).
+   */
+  async cancelRequested(runId: string): Promise<boolean> {
+    const r = await this.prisma.hookRun.findUnique({
+      where: { id: runId },
+      select: { status: true },
+    });
+    return !r || r.status === 'canceling' || r.status === 'canceled';
+  }
+
+  async markRunning(runId: string): Promise<void> {
+    await this.prisma.hookRun.update({
+      where: { id: runId },
+      data: { status: 'running' },
+    });
+  }
+
+  async setTotal(runId: string, totalCount: number | null): Promise<void> {
+    await this.prisma.hookRun.update({ where: { id: runId }, data: { totalCount } });
+  }
+
+  async setCursor(runId: string, cursorOffset: number): Promise<void> {
+    await this.prisma.hookRun.update({ where: { id: runId }, data: { cursorOffset } });
+  }
+
+  /** Sequences already delivered successfully — skipped on resume. */
+  async succeededSequences(runId: string): Promise<Set<number>> {
+    const rows = await this.prisma.hookDelivery.findMany({
+      where: { runId, status: 'success' },
+      select: { sequence: true },
+    });
+    return new Set(rows.map((r) => r.sequence));
+  }
+
+  /** Persist one delivery and advance the run's counters atomically. */
+  async recordDelivery(
+    runId: string,
+    meta: { sequence: number; rowIndex: number; rowCount: number },
+    outcome: DeliveryOutcome,
+  ): Promise<void> {
+    await this.prisma.$transaction([
+      this.prisma.hookDelivery.upsert({
+        where: { runId_sequence: { runId, sequence: meta.sequence } },
+        create: {
+          id: randomUUID(),
+          runId,
+          sequence: meta.sequence,
+          rowIndex: meta.rowIndex,
+          rowCount: meta.rowCount,
+          status: outcome.status,
+          httpStatus: outcome.httpStatus,
+          attempts: outcome.attempts,
+          error: outcome.error,
+          responseSnippet: outcome.responseSnippet,
+          durationMs: outcome.durationMs,
+        },
+        update: {
+          status: outcome.status,
+          httpStatus: outcome.httpStatus,
+          attempts: outcome.attempts,
+          error: outcome.error,
+          responseSnippet: outcome.responseSnippet,
+          durationMs: outcome.durationMs,
+        },
+      }),
+      this.prisma.hookRun.update({
+        where: { id: runId },
+        data:
+          outcome.status === 'success'
+            ? { sentCount: { increment: meta.rowCount } }
+            : { failedCount: { increment: meta.rowCount } },
+      }),
+    ]);
+  }
+
+  async finalize(
+    runId: string,
+    status: HookRunStatus,
+    error?: string | null,
+  ): Promise<void> {
+    await this.prisma.hookRun.update({
+      where: { id: runId },
+      data: { status, error: error ?? null, finishedAt: new Date() },
+    });
+  }
+
+  /* ----- boot reconcile ----- */
+
+  async onModuleInit(): Promise<void> {
+    let rows: { id: string; hookId: string }[];
+    try {
+      rows = await this.prisma.hookRun.findMany({
+        where: { status: { in: ACTIVE } },
+        select: { id: true, hookId: true },
+      });
+    } catch (err) {
+      this.logger.warn(`Skipped run recovery: ${(err as Error).message}`);
+      return;
+    }
+    for (const r of rows) {
+      // Deterministic jobId means this is a no-op if the job already exists.
+      await this.enqueue(r.id, r.hookId).catch((err) =>
+        this.logger.warn(`Could not re-enqueue run ${r.id}: ${(err as Error).message}`),
+      );
+    }
+    if (rows.length) this.logger.log(`Recovered ${rows.length} interrupted hook run(s)`);
+  }
+
+  /* ----- mappers ----- */
+
+  private toRun(row: RunRow): HookRun {
+    return {
+      id: row.id,
+      hookId: row.hookId,
+      status: row.status as HookRunStatus,
+      cursorOffset: row.cursorOffset,
+      sentCount: row.sentCount,
+      failedCount: row.failedCount,
+      totalCount: row.totalCount,
+      error: row.error,
+      startedAt: row.startedAt.toISOString(),
+      finishedAt: row.finishedAt ? row.finishedAt.toISOString() : null,
+    };
+  }
+
+  private toDelivery(row: DeliveryRow): HookDelivery {
+    return {
+      id: row.id,
+      runId: row.runId,
+      sequence: row.sequence,
+      rowIndex: row.rowIndex,
+      rowCount: row.rowCount,
+      status: row.status as 'success' | 'failed',
+      httpStatus: row.httpStatus,
+      attempts: row.attempts,
+      error: row.error,
+      responseSnippet: row.responseSnippet,
+      durationMs: row.durationMs,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+}

--- a/apps/api/src/hooks/hook-store.service.ts
+++ b/apps/api/src/hooks/hook-store.service.ts
@@ -1,0 +1,207 @@
+/**
+ * Persistent store for automation hooks (Prisma / SQLite). Nested config is kept
+ * as JSON strings; the destination's auth secret is the only sensitive field and
+ * is encrypted at rest in `auth_enc`, mirroring how `ConnectionStoreService`
+ * handles passwords. Callers get a redacted view unless they explicitly resolve.
+ */
+import { randomUUID } from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import type { Hook as HookRow } from '@prisma/client';
+import {
+  type Hook,
+  type HookAuth,
+  type HookDestination,
+  type HookInputDTO,
+  NotFoundError,
+} from '@relay/core';
+import { CryptoService } from '../common/crypto.service';
+import { PrismaService } from '../common/prisma.service';
+import type { ResolvedHook } from './hooks.types';
+
+const REDACTED = '********';
+
+/** The resolved-config snapshot persisted on a run (auth stays encrypted). */
+interface RunSnapshot {
+  name: string;
+  source: HookInputDTO['source'];
+  destination: HookDestination; // secret blanked
+  authEnc: string | null;
+  transform: HookInputDTO['transform'];
+  delivery: HookInputDTO['delivery'];
+}
+
+@Injectable()
+export class HookStoreService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
+
+  /* ----- secret split / merge ----- */
+
+  /** Separate the encryptable secret from the rest of the destination. */
+  private splitSecret(dest: HookDestination): {
+    sanitized: HookDestination;
+    secret: string | null;
+  } {
+    const auth = dest.auth;
+    if (auth.type === 'bearer') {
+      return {
+        sanitized: { ...dest, auth: { type: 'bearer', token: '' } },
+        secret: auth.token,
+      };
+    }
+    if (auth.type === 'header') {
+      return {
+        sanitized: { ...dest, auth: { type: 'header', name: auth.name, value: '' } },
+        secret: auth.value,
+      };
+    }
+    return { sanitized: dest, secret: null };
+  }
+
+  /** Re-attach the auth secret to a sanitized destination. */
+  private withSecret(
+    dest: HookDestination,
+    secret: string | null,
+  ): HookDestination {
+    const auth = dest.auth;
+    if (auth.type === 'bearer') {
+      return { ...dest, auth: { ...auth, token: secret ?? '' } };
+    }
+    if (auth.type === 'header') {
+      return { ...dest, auth: { ...auth, value: secret ?? '' } };
+    }
+    return dest;
+  }
+
+  private decryptSecret(authEnc: string | null): string | null {
+    return authEnc ? this.crypto.decrypt(authEnc) : null;
+  }
+
+  /* ----- row → DTO ----- */
+
+  private toHook(row: HookRow, includeSecrets: boolean): Hook {
+    const sanitized = JSON.parse(row.destinationJson) as HookDestination;
+    const secret = includeSecrets
+      ? this.decryptSecret(row.authEnc)
+      : row.authEnc
+        ? REDACTED
+        : null;
+    return {
+      id: row.id,
+      name: row.name,
+      source: JSON.parse(row.sourceJson),
+      destination: this.withSecret(sanitized, secret),
+      transform: JSON.parse(row.transformJson),
+      delivery: JSON.parse(row.deliveryJson),
+      enabled: row.enabled,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+
+  private async getRow(id: string): Promise<HookRow> {
+    const row = await this.prisma.hook.findUnique({ where: { id } });
+    if (!row) throw new NotFoundError(`Hook "${id}" not found`);
+    return row;
+  }
+
+  /* ----- CRUD ----- */
+
+  async list(): Promise<Hook[]> {
+    const rows = await this.prisma.hook.findMany({ orderBy: { name: 'asc' } });
+    return rows.map((r) => this.toHook(r, false));
+  }
+
+  async get(id: string): Promise<Hook> {
+    return this.toHook(await this.getRow(id), false);
+  }
+
+  /** Full config including the decrypted auth secret — server-internal only. */
+  async resolve(id: string): Promise<ResolvedHook> {
+    const hook = this.toHook(await this.getRow(id), true);
+    return hook;
+  }
+
+  async create(input: HookInputDTO): Promise<Hook> {
+    const { sanitized, secret } = this.splitSecret(input.destination);
+    const row = await this.prisma.hook.create({
+      data: {
+        id: randomUUID(),
+        name: input.name,
+        connectionId: input.source.connectionId,
+        sourceJson: JSON.stringify(input.source),
+        destinationJson: JSON.stringify(sanitized),
+        authEnc: secret ? this.crypto.encrypt(secret) : null,
+        transformJson: JSON.stringify(input.transform),
+        deliveryJson: JSON.stringify(input.delivery),
+        enabled: input.enabled,
+      },
+    });
+    return this.toHook(row, false);
+  }
+
+  async update(id: string, input: HookInputDTO): Promise<Hook> {
+    const existing = await this.getRow(id);
+    const { sanitized, secret } = this.splitSecret(input.destination);
+
+    // Preserve the stored secret when the client echoes the redaction sentinel.
+    const authEnc =
+      secret === REDACTED
+        ? existing.authEnc
+        : secret
+          ? this.crypto.encrypt(secret)
+          : null;
+
+    const row = await this.prisma.hook.update({
+      where: { id },
+      data: {
+        name: input.name,
+        connectionId: input.source.connectionId,
+        sourceJson: JSON.stringify(input.source),
+        destinationJson: JSON.stringify(sanitized),
+        authEnc,
+        transformJson: JSON.stringify(input.transform),
+        deliveryJson: JSON.stringify(input.delivery),
+        enabled: input.enabled,
+      },
+    });
+    return this.toHook(row, false);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.getRow(id);
+    await this.prisma.hook.delete({ where: { id } });
+  }
+
+  /* ----- run snapshot (auth kept encrypted) ----- */
+
+  /** Build the config snapshot persisted on a run. */
+  async snapshotJson(id: string): Promise<string> {
+    const row = await this.getRow(id);
+    const snapshot: RunSnapshot = {
+      name: row.name,
+      source: JSON.parse(row.sourceJson),
+      destination: JSON.parse(row.destinationJson), // secret blanked
+      authEnc: row.authEnc,
+      transform: JSON.parse(row.transformJson),
+      delivery: JSON.parse(row.deliveryJson),
+    };
+    return JSON.stringify(snapshot);
+  }
+
+  /** Decrypt a run snapshot into a runnable, fully-resolved hook config. */
+  resolveSnapshot(json: string): ResolvedHook {
+    const s = JSON.parse(json) as RunSnapshot;
+    return {
+      id: '',
+      name: s.name,
+      source: s.source,
+      destination: this.withSecret(s.destination, this.decryptSecret(s.authEnc)),
+      transform: s.transform,
+      delivery: s.delivery,
+      enabled: true,
+    };
+  }
+}

--- a/apps/api/src/hooks/hooks.controller.ts
+++ b/apps/api/src/hooks/hooks.controller.ts
@@ -1,0 +1,183 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import {
+  type Hook,
+  type HookDelivery,
+  type HookInputDTO,
+  type HookPreview,
+  type HookPreviewDTO,
+  type HookRun,
+  type StartRunDTO,
+  hookInputSchema,
+  hookPreviewSchema,
+  renderRow,
+  startRunSchema,
+} from '@relay/core';
+import { AdapterPoolService } from '../connections/adapter-pool.service';
+import { ZodValidationPipe } from '../common/zod-validation.pipe';
+import { DeliveryService } from './delivery.service';
+import { HookRunService } from './hook-run.service';
+import { HookStoreService } from './hook-store.service';
+
+@Controller('hooks')
+export class HooksController {
+  constructor(
+    private readonly store: HookStoreService,
+    private readonly runs: HookRunService,
+    private readonly pool: AdapterPoolService,
+    private readonly delivery: DeliveryService,
+  ) {}
+
+  /* ----- CRUD ----- */
+
+  @Get()
+  list(): Promise<Hook[]> {
+    return this.store.list();
+  }
+
+  @Post()
+  create(
+    @Body(new ZodValidationPipe(hookInputSchema)) dto: HookInputDTO,
+  ): Promise<Hook> {
+    return this.store.create(dto);
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string): Promise<Hook> {
+    return this.store.get(id);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(hookInputSchema)) dto: HookInputDTO,
+  ): Promise<Hook> {
+    return this.store.update(id, dto);
+  }
+
+  @Delete(':id')
+  async remove(@Param('id') id: string): Promise<{ id: string }> {
+    await this.store.remove(id);
+    return { id };
+  }
+
+  /* ----- payload preview (no delivery) ----- */
+
+  @Post(':id/preview')
+  async preview(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(hookPreviewSchema)) dto: HookPreviewDTO,
+  ): Promise<HookPreview> {
+    const hook = await this.store.resolve(id);
+    const table = hook.source.kind === 'table' ? hook.source.table : '(query)';
+    const now = new Date().toISOString();
+
+    let rows: Record<string, unknown>[];
+    let fromSource: boolean;
+    if (dto.sampleRow) {
+      rows = [dto.sampleRow];
+      fromSource = false;
+    } else {
+      rows = await this.fetchSample(hook.source, dto.limit);
+      fromSource = true;
+    }
+
+    const warnings = new Set<string>();
+    const bodies = rows.map((row, index) => {
+      const result = renderRow(row, hook.transform, { table, now, index });
+      result.warnings.forEach((w) => warnings.add(w));
+      return result.body;
+    });
+
+    return {
+      method: hook.destination.method,
+      url: hook.destination.url,
+      headers: this.delivery.redactedHeaders(hook.destination),
+      bodies,
+      warnings: [...warnings],
+      fromSource,
+    };
+  }
+
+  private async fetchSample(
+    source: Hook['source'],
+    limit: number,
+  ): Promise<Record<string, unknown>[]> {
+    if (source.kind === 'table') {
+      const page = await this.pool.withAdapter(
+        source.connectionId,
+        source.database,
+        (a) =>
+          a.browse({
+            schema: source.schema,
+            table: source.table,
+            filters: source.filters,
+            sort: source.sort,
+            limit,
+            offset: 0,
+          }),
+      );
+      return page.rows;
+    }
+    const result = await this.pool.withAdapter(
+      source.connectionId,
+      source.database,
+      (a) => a.query(source.statement),
+    );
+    return result.rows.slice(0, limit);
+  }
+
+  /* ----- runs ----- */
+
+  @Post(':id/runs')
+  startRun(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(startRunSchema)) dto: StartRunDTO,
+  ): Promise<HookRun> {
+    return this.runs.start(id, dto.resumeRunId);
+  }
+
+  @Get(':id/runs')
+  listRuns(@Param('id') id: string): Promise<HookRun[]> {
+    return this.runs.listRuns(id);
+  }
+
+  @Get(':id/runs/:runId')
+  getRun(
+    @Param('id') id: string,
+    @Param('runId') runId: string,
+  ): Promise<HookRun> {
+    return this.runs.getRun(id, runId);
+  }
+
+  @Post(':id/runs/:runId/cancel')
+  cancelRun(
+    @Param('id') id: string,
+    @Param('runId') runId: string,
+  ): Promise<HookRun> {
+    return this.runs.cancel(id, runId);
+  }
+
+  @Get(':id/runs/:runId/deliveries')
+  listDeliveries(
+    @Param('id') _id: string,
+    @Param('runId') runId: string,
+    @Query('status') status?: 'success' | 'failed',
+    @Query('offset') offset?: string,
+    @Query('limit') limit?: string,
+  ): Promise<HookDelivery[]> {
+    return this.runs.listDeliveries(runId, {
+      status: status === 'success' || status === 'failed' ? status : undefined,
+      offset: offset ? Number(offset) : undefined,
+      limit: limit ? Number(limit) : undefined,
+    });
+  }
+}

--- a/apps/api/src/hooks/hooks.module.ts
+++ b/apps/api/src/hooks/hooks.module.ts
@@ -1,0 +1,26 @@
+import { BullModule } from '@nestjs/bullmq';
+import { Module } from '@nestjs/common';
+import { ConnectionsModule } from '../connections/connections.module';
+import { DeliveryService } from './delivery.service';
+import { HookRunProcessor } from './hook-run.processor';
+import { HookRunService } from './hook-run.service';
+import { HookStoreService } from './hook-store.service';
+import { HooksController } from './hooks.controller';
+import { RunRegistryService } from './run-registry.service';
+import { HOOK_RUNS_QUEUE } from './hooks.types';
+
+@Module({
+  imports: [
+    ConnectionsModule, // AdapterPoolService
+    BullModule.registerQueue({ name: HOOK_RUNS_QUEUE }),
+  ],
+  controllers: [HooksController],
+  providers: [
+    HookStoreService,
+    HookRunService,
+    DeliveryService,
+    RunRegistryService,
+    HookRunProcessor,
+  ],
+})
+export class HooksModule {}

--- a/apps/api/src/hooks/hooks.types.ts
+++ b/apps/api/src/hooks/hooks.types.ts
@@ -1,0 +1,40 @@
+/**
+ * Server-internal hook types. The fully *resolved* config carries the decrypted
+ * auth secret and is used only inside the runner — it is never serialized back
+ * to a client (the API surface returns the redacted {@link Hook} from core).
+ */
+import type {
+  HookDeliveryConfig,
+  HookDestination,
+  HookSource,
+  HookTransformConfig,
+} from '@relay/core';
+
+/** A hook with its auth secret decrypted — server-internal use only. */
+export interface ResolvedHook {
+  id: string;
+  name: string;
+  source: HookSource;
+  destination: HookDestination; // auth carries the real secret here
+  transform: HookTransformConfig;
+  delivery: HookDeliveryConfig;
+  enabled: boolean;
+}
+
+/** Outcome of a single HTTP delivery attempt sequence. */
+export interface DeliveryOutcome {
+  status: 'success' | 'failed';
+  httpStatus: number | null;
+  attempts: number;
+  error: string | null;
+  responseSnippet: string | null;
+  durationMs: number;
+}
+
+/** The BullMQ job payload for the `hook-runs` queue. */
+export interface HookRunJob {
+  runId: string;
+  hookId: string;
+}
+
+export const HOOK_RUNS_QUEUE = 'hook-runs';

--- a/apps/api/src/hooks/run-registry.service.ts
+++ b/apps/api/src/hooks/run-registry.service.ts
@@ -1,0 +1,34 @@
+/**
+ * In-process registry of `AbortController`s for currently-executing runs. The
+ * BullMQ worker runs in this process, so aborting the controller here cancels
+ * the in-flight `fetch` immediately (no Redis round-trip). State is intentionally
+ * ephemeral — durability lives in Redis/Prisma, this is only for live abort.
+ */
+import { Injectable, type OnModuleDestroy } from '@nestjs/common';
+
+@Injectable()
+export class RunRegistryService implements OnModuleDestroy {
+  private readonly controllers = new Map<string, AbortController>();
+
+  register(runId: string): AbortController {
+    const controller = new AbortController();
+    this.controllers.set(runId, controller);
+    return controller;
+  }
+
+  release(runId: string): void {
+    this.controllers.delete(runId);
+  }
+
+  abort(runId: string): boolean {
+    const controller = this.controllers.get(runId);
+    if (!controller) return false;
+    controller.abort();
+    return true;
+  }
+
+  onModuleDestroy(): void {
+    for (const controller of this.controllers.values()) controller.abort();
+    this.controllers.clear();
+  }
+}

--- a/apps/web/src/components/automations/automations-view.tsx
+++ b/apps/web/src/components/automations/automations-view.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Pencil, Play, Trash2, Webhook, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { ApiError } from '@/lib/api';
+import {
+  useDeleteHook,
+  useHookRuns,
+  useHooks,
+  useStartHookRun,
+} from '@/lib/queries';
+import { useStudio } from '@/lib/store';
+import { cn } from '@/lib/utils';
+import { useConfirm } from '@/components/confirm';
+import { Button } from '@/components/ui/button';
+import { RunDetail, RunStatusBadge } from './run-detail';
+
+export function AutomationsView() {
+  const { selectedHookId, selectHook, openHookEditor } = useStudio();
+  const { data: hooks } = useHooks();
+  const hook = hooks?.find((h) => h.id === selectedHookId) ?? null;
+
+  if (!hook) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+        <Webhook className="h-10 w-10 opacity-40" />
+        <div>
+          <p className="text-sm">No automation selected</p>
+          <p className="text-xs">
+            Pick a hook on the left, or{' '}
+            <button
+              className="text-primary hover:underline"
+              onClick={() => openHookEditor()}
+            >
+              create one
+            </button>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return <HookPanel key={hook.id} hookId={hook.id} hookName={hook.name} sourceLabel={
+    hook.source.kind === 'table' ? hook.source.table : 'custom query'
+  } destLabel={`${hook.destination.method} ${hook.destination.url}`} onDeleted={() => selectHook(null)} />;
+}
+
+function HookPanel({
+  hookId,
+  hookName,
+  sourceLabel,
+  destLabel,
+  onDeleted,
+}: {
+  hookId: string;
+  hookName: string;
+  sourceLabel: string;
+  destLabel: string;
+  onDeleted: () => void;
+}) {
+  const confirm = useConfirm();
+  const { openHookEditor } = useStudio();
+  const start = useStartHookRun(hookId);
+  const del = useDeleteHook();
+  const { data: runs } = useHookRuns(hookId);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+
+  // Default to (and follow) the most recent run.
+  useEffect(() => {
+    if (!runs || runs.length === 0) {
+      setSelectedRunId(null);
+      return;
+    }
+    setSelectedRunId((cur) =>
+      cur && runs.some((r) => r.id === cur) ? cur : runs[0]!.id,
+    );
+  }, [runs]);
+
+  const selectedRun = runs?.find((r) => r.id === selectedRunId) ?? null;
+
+  async function handleRun() {
+    try {
+      const run = await start.mutateAsync(undefined);
+      setSelectedRunId(run.id);
+      toast.success('Run started');
+    } catch (err) {
+      toast.error('Could not start run', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleDelete() {
+    const ok = await confirm({
+      title: `Delete "${hookName}"?`,
+      description: 'This removes the hook and its run history. This cannot be undone.',
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await del.mutateAsync(hookId);
+      onDeleted();
+      toast.success('Hook deleted');
+    } catch (err) {
+      toast.error('Could not delete', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-start gap-3 border-b px-4 py-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold">{hookName}</h2>
+          <p className="truncate font-mono text-xs text-muted-foreground">
+            {sourceLabel} → {destLabel}
+          </p>
+        </div>
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <Button size="sm" onClick={handleRun} disabled={start.isPending}>
+            {start.isPending ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Play className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            Run
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => openHookEditor({ editingId: hookId })}
+          >
+            <Pencil className="mr-1.5 h-3.5 w-3.5" />
+            Edit
+          </Button>
+          <Button size="sm" variant="ghost" onClick={handleDelete}>
+            <Trash2 className="h-3.5 w-3.5 text-destructive" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Runs strip */}
+      <div className="flex items-center gap-2 overflow-x-auto border-b px-4 py-2">
+        {(!runs || runs.length === 0) && (
+          <p className="text-xs text-muted-foreground">
+            No runs yet — press Run to stream rows to the endpoint.
+          </p>
+        )}
+        {runs?.map((run) => (
+          <button
+            key={run.id}
+            onClick={() => setSelectedRunId(run.id)}
+            className={cn(
+              'flex shrink-0 items-center gap-2 rounded-md border px-2.5 py-1 text-xs transition-colors',
+              selectedRunId === run.id
+                ? 'border-primary bg-accent'
+                : 'border-transparent hover:bg-accent/50',
+            )}
+          >
+            <RunStatusBadge status={run.status} />
+            <span className="text-muted-foreground">
+              {new Date(run.startedAt).toLocaleString()}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Selected run */}
+      <div className="min-h-0 flex-1">
+        {selectedRun ? (
+          <RunDetail hookId={hookId} run={selectedRun} />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Select a run to see its delivery log.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/automations/delivery-log.tsx
+++ b/apps/web/src/components/automations/delivery-log.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { CheckCircle2, XCircle } from 'lucide-react';
+import { useHookDeliveries } from '@/lib/queries';
+import { cn } from '@/lib/utils';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+export function DeliveryLog({
+  hookId,
+  runId,
+  live,
+}: {
+  hookId: string;
+  runId: string;
+  live: boolean;
+}) {
+  const { data: deliveries, isLoading } = useHookDeliveries(hookId, runId, live);
+
+  if (isLoading) {
+    return <p className="p-4 text-sm text-muted-foreground">Loading deliveries…</p>;
+  }
+  if (!deliveries || deliveries.length === 0) {
+    return (
+      <p className="p-4 text-sm text-muted-foreground">
+        No deliveries recorded yet.
+      </p>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <Table>
+        <TableHeader className="sticky top-0 bg-background">
+          <TableRow>
+            <TableHead className="w-16">#</TableHead>
+            <TableHead className="w-20">Status</TableHead>
+            <TableHead className="w-20">Code</TableHead>
+            <TableHead className="w-16">Rows</TableHead>
+            <TableHead className="w-20">Tries</TableHead>
+            <TableHead className="w-20">Time</TableHead>
+            <TableHead>Detail</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {deliveries.map((d) => (
+            <TableRow key={d.id}>
+              <TableCell className="font-mono text-xs text-muted-foreground">
+                {d.sequence}
+              </TableCell>
+              <TableCell>
+                <span
+                  className={cn(
+                    'inline-flex items-center gap-1 text-xs font-medium',
+                    d.status === 'success' ? 'text-emerald-600' : 'text-destructive',
+                  )}
+                >
+                  {d.status === 'success' ? (
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                  ) : (
+                    <XCircle className="h-3.5 w-3.5" />
+                  )}
+                  {d.status}
+                </span>
+              </TableCell>
+              <TableCell className="font-mono text-xs">
+                {d.httpStatus ?? '—'}
+              </TableCell>
+              <TableCell className="font-mono text-xs">{d.rowCount}</TableCell>
+              <TableCell className="font-mono text-xs">{d.attempts}</TableCell>
+              <TableCell className="font-mono text-xs text-muted-foreground">
+                {d.durationMs != null ? `${d.durationMs}ms` : '—'}
+              </TableCell>
+              <TableCell className="max-w-[1px] truncate font-mono text-xs text-muted-foreground">
+                {d.error ?? d.responseSnippet ?? ''}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollArea>
+  );
+}

--- a/apps/web/src/components/automations/hook-editor.tsx
+++ b/apps/web/src/components/automations/hook-editor.tsx
@@ -1,0 +1,904 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, Plus, X, Eye } from 'lucide-react';
+import { toast } from 'sonner';
+import { renderRow, type HookInputDTO, type TableSchema } from '@relay/core';
+import { api, ApiError } from '@/lib/api';
+import {
+  useConnections,
+  useCreateHook,
+  useDatabases,
+  useSchema,
+  useUpdateHook,
+} from '@/lib/queries';
+import { useStudio } from '@/lib/store';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+const DEFAULT_TEMPLATE = '{{$row}}';
+
+interface HeaderPair {
+  key: string;
+  value: string;
+}
+
+interface FormState {
+  name: string;
+  sourceKind: 'table' | 'query';
+  connectionId: string;
+  database: string;
+  schema: string;
+  table: string;
+  sortColumn: string;
+  sortDir: 'asc' | 'desc';
+  statement: string;
+  url: string;
+  method: 'POST' | 'PUT' | 'PATCH';
+  headers: HeaderPair[];
+  authType: 'none' | 'bearer' | 'header';
+  authToken: string;
+  authHeaderName: string;
+  authHeaderValue: string;
+  idempotency: boolean;
+  template: string;
+  wrapKey: string;
+  fields: string;
+  batchSize: number;
+  maxAttempts: number;
+  minDelayMs: number;
+  timeoutMs: number;
+  pageSize: number;
+  backoffMs: number;
+  backoffMaxMs: number;
+  onError: 'continue' | 'abort';
+  enabled: boolean;
+}
+
+function blankForm(): FormState {
+  return {
+    name: '',
+    sourceKind: 'table',
+    connectionId: '',
+    database: '',
+    schema: '',
+    table: '',
+    sortColumn: '',
+    sortDir: 'asc',
+    statement: '',
+    url: '',
+    method: 'POST',
+    headers: [],
+    authType: 'none',
+    authToken: '',
+    authHeaderName: '',
+    authHeaderValue: '',
+    idempotency: false,
+    template: DEFAULT_TEMPLATE,
+    wrapKey: '',
+    fields: '',
+    batchSize: 1,
+    maxAttempts: 3,
+    minDelayMs: 0,
+    timeoutMs: 15000,
+    pageSize: 200,
+    backoffMs: 500,
+    backoffMaxMs: 30000,
+    onError: 'continue',
+    enabled: true,
+  };
+}
+
+export function HookEditor() {
+  const { hookEditor, closeHookEditor, selectHook } = useStudio();
+  const create = useCreateHook();
+  const update = useUpdateHook();
+  const [form, setForm] = useState<FormState>(blankForm);
+  const editing = hookEditor.editingId;
+
+  const { data: connections } = useConnections();
+  const { data: databases } = useDatabases(form.connectionId || null);
+  const { data: schema } = useSchema(
+    form.connectionId || null,
+    form.database || undefined,
+  );
+
+  /* Populate form on open. */
+  useEffect(() => {
+    if (!hookEditor.open) return;
+    if (editing) {
+      void api.getHook(editing).then((h) => setForm(fromHook(h)));
+      return;
+    }
+    const base = blankForm();
+    if (hookEditor.seed) {
+      base.sourceKind = 'table';
+      base.connectionId = hookEditor.seed.connectionId;
+      base.database = hookEditor.seed.database ?? '';
+      base.schema = hookEditor.seed.schema ?? '';
+      base.table = hookEditor.seed.table;
+      base.name = `${hookEditor.seed.table} → webhook`;
+    }
+    setForm(base);
+  }, [hookEditor.open, editing, hookEditor.seed]);
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((f) => ({ ...f, [key]: value }));
+
+  /* All tables across namespaces, for the table picker. */
+  const tables = useMemo<TableSchema[]>(
+    () => schema?.namespaces.flatMap((ns) => ns.tables) ?? [],
+    [schema],
+  );
+  const selectedTable = tables.find((t) => t.name === form.table);
+  const columns = selectedTable?.columns.map((c) => c.name) ?? [];
+
+  function buildInput(): HookInputDTO {
+    const source: HookInputDTO['source'] =
+      form.sourceKind === 'table'
+        ? {
+            kind: 'table',
+            connectionId: form.connectionId,
+            database: form.database || undefined,
+            schema: form.schema || undefined,
+            table: form.table,
+            sort: form.sortColumn
+              ? [{ column: form.sortColumn, direction: form.sortDir }]
+              : undefined,
+          }
+        : {
+            kind: 'query',
+            connectionId: form.connectionId,
+            database: form.database || undefined,
+            statement: form.statement,
+          };
+
+    const auth: HookInputDTO['destination']['auth'] =
+      form.authType === 'bearer'
+        ? { type: 'bearer', token: form.authToken }
+        : form.authType === 'header'
+          ? {
+              type: 'header',
+              name: form.authHeaderName,
+              value: form.authHeaderValue,
+            }
+          : { type: 'none' };
+
+    const headerEntries = form.headers
+      .filter((h) => h.key.trim())
+      .map((h) => [h.key.trim(), h.value] as const);
+
+    return {
+      name: form.name.trim() || 'Untitled hook',
+      source,
+      destination: {
+        url: form.url.trim(),
+        method: form.method,
+        headers: headerEntries.length
+          ? Object.fromEntries(headerEntries)
+          : undefined,
+        auth,
+        idempotency: form.idempotency,
+      },
+      transform: {
+        template: form.template || DEFAULT_TEMPLATE,
+        wrapKey: form.wrapKey || undefined,
+        fields: form.fields.trim()
+          ? form.fields
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined,
+      },
+      delivery: {
+        batchSize: form.batchSize,
+        maxAttempts: form.maxAttempts,
+        minDelayMs: form.minDelayMs,
+        timeoutMs: form.timeoutMs,
+        pageSize: form.pageSize,
+        backoffMs: form.backoffMs,
+        backoffMaxMs: form.backoffMaxMs,
+        onError: form.onError,
+      },
+      enabled: form.enabled,
+    };
+  }
+
+  async function handleSave() {
+    try {
+      const input = buildInput();
+      if (editing) {
+        await update.mutateAsync({ id: editing, input });
+        toast.success('Hook updated');
+      } else {
+        const hook = await create.mutateAsync(input);
+        selectHook(hook.id);
+        toast.success('Hook created');
+      }
+      closeHookEditor();
+    } catch (err) {
+      toast.error('Could not save hook', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  const saving = create.isPending || update.isPending;
+
+  return (
+    <Dialog
+      open={hookEditor.open}
+      onOpenChange={(o) => !o && closeHookEditor()}
+    >
+      <DialogContent className="max-h-[88vh] gap-0 overflow-hidden p-0 sm:max-w-[680px]">
+        <DialogHeader className="border-b px-5 py-3.5">
+          <DialogTitle>{editing ? 'Edit hook' : 'New hook'}</DialogTitle>
+          <DialogDescription>
+            Stream rows from a database to an HTTP endpoint with a templated
+            payload.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-2 px-5 py-3">
+          <Label htmlFor="hook-name">Name</Label>
+          <Input
+            id="hook-name"
+            value={form.name}
+            placeholder="Sync users to CRM"
+            onChange={(e) => set('name', e.target.value)}
+          />
+        </div>
+
+        <Tabs defaultValue="source" className="flex min-h-0 flex-col">
+          <TabsList className="mx-5 grid w-auto grid-cols-4">
+            <TabsTrigger value="source">Source</TabsTrigger>
+            <TabsTrigger value="destination">Destination</TabsTrigger>
+            <TabsTrigger value="payload">Payload</TabsTrigger>
+            <TabsTrigger value="delivery">Delivery</TabsTrigger>
+          </TabsList>
+
+          <div className="max-h-[46vh] overflow-y-auto px-5 py-4">
+            {/* ---- Source ---- */}
+            <TabsContent value="source" className="mt-0 grid gap-4">
+              <div className="grid gap-2">
+                <Label>Connection</Label>
+                <Select
+                  value={form.connectionId}
+                  onValueChange={(v) => set('connectionId', v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a connection" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {connections?.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {(databases?.length ?? 0) > 0 && (
+                <div className="grid gap-2">
+                  <Label>Database</Label>
+                  <Select
+                    value={form.database || '__default'}
+                    onValueChange={(v) =>
+                      set('database', v === '__default' ? '' : v)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__default">
+                        (connection default)
+                      </SelectItem>
+                      {databases?.map((d) => (
+                        <SelectItem key={d} value={d}>
+                          {d}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              <div className="grid gap-2">
+                <Label>Source type</Label>
+                <Select
+                  value={form.sourceKind}
+                  onValueChange={(v) =>
+                    set('sourceKind', v as 'table' | 'query')
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="table">
+                      Table — replay every row
+                    </SelectItem>
+                    <SelectItem value="query">
+                      Query — replay a result set
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {form.sourceKind === 'table' ? (
+                <>
+                  <div className="grid gap-2">
+                    <Label>Table</Label>
+                    <Select
+                      value={form.table}
+                      onValueChange={(v) => set('table', v)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a table" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {tables.map((t) => (
+                          <SelectItem
+                            key={`${t.schema ?? ''}.${t.name}`}
+                            value={t.name}
+                          >
+                            {t.schema ? `${t.schema}.${t.name}` : t.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="grid gap-2">
+                      <Label>Order by</Label>
+                      <Select
+                        value={form.sortColumn || '__pk'}
+                        onValueChange={(v) =>
+                          set('sortColumn', v === '__pk' ? '' : v)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__pk">
+                            Primary key (default)
+                          </SelectItem>
+                          {columns.map((c) => (
+                            <SelectItem key={c} value={c}>
+                              {c}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="grid gap-2">
+                      <Label>Direction</Label>
+                      <Select
+                        value={form.sortDir}
+                        onValueChange={(v) =>
+                          set('sortDir', v as 'asc' | 'desc')
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="asc">Ascending</SelectItem>
+                          <SelectItem value="desc">Descending</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <p className="text-muted-foreground text-xs">
+                    Rows are paged in a stable order so each is delivered
+                    exactly once. Tables without a primary key need an explicit
+                    order.
+                  </p>
+                </>
+              ) : (
+                <div className="grid gap-2">
+                  <Label>Query</Label>
+                  <Textarea
+                    value={form.statement}
+                    placeholder="SELECT * FROM users WHERE active = true"
+                    className="font-mono text-xs"
+                    rows={5}
+                    onChange={(e) => set('statement', e.target.value)}
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    The full result is streamed once (bounded by the server row
+                    cap).
+                  </p>
+                </div>
+              )}
+            </TabsContent>
+
+            {/* ---- Destination ---- */}
+            <TabsContent value="destination" className="mt-0 grid gap-4">
+              <div className="grid grid-cols-[110px_1fr] gap-3">
+                <div className="grid gap-2">
+                  <Label>Method</Label>
+                  <Select
+                    value={form.method}
+                    onValueChange={(v) =>
+                      set('method', v as FormState['method'])
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="POST">POST</SelectItem>
+                      <SelectItem value="PUT">PUT</SelectItem>
+                      <SelectItem value="PATCH">PATCH</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-2">
+                  <Label>Endpoint URL</Label>
+                  <Input
+                    value={form.url}
+                    placeholder="https://api.example.com/webhooks/relay"
+                    onChange={(e) => set('url', e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <Label>Authentication</Label>
+                <Select
+                  value={form.authType}
+                  onValueChange={(v) =>
+                    set('authType', v as FormState['authType'])
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    <SelectItem value="bearer">Bearer token</SelectItem>
+                    <SelectItem value="header">Custom header</SelectItem>
+                  </SelectContent>
+                </Select>
+                {form.authType === 'bearer' && (
+                  <Input
+                    type="password"
+                    value={form.authToken}
+                    placeholder="Token"
+                    onChange={(e) => set('authToken', e.target.value)}
+                  />
+                )}
+                {form.authType === 'header' && (
+                  <div className="grid grid-cols-2 gap-2">
+                    <Input
+                      value={form.authHeaderName}
+                      placeholder="X-API-Key"
+                      onChange={(e) => set('authHeaderName', e.target.value)}
+                    />
+                    <Input
+                      type="password"
+                      value={form.authHeaderValue}
+                      placeholder="Value"
+                      onChange={(e) => set('authHeaderValue', e.target.value)}
+                    />
+                  </div>
+                )}
+                <p className="text-muted-foreground text-xs">
+                  Secrets are encrypted at rest, never returned to the browser.
+                </p>
+              </div>
+
+              <div className="grid gap-2">
+                <Label>Custom headers</Label>
+                {form.headers.map((h, i) => (
+                  <div key={i} className="grid grid-cols-[1fr_1fr_auto] gap-2">
+                    <Input
+                      value={h.key}
+                      placeholder="Header"
+                      onChange={(e) =>
+                        set(
+                          'headers',
+                          form.headers.map((x, j) =>
+                            j === i ? { ...x, key: e.target.value } : x,
+                          ),
+                        )
+                      }
+                    />
+                    <Input
+                      value={h.value}
+                      placeholder="Value"
+                      onChange={(e) =>
+                        set(
+                          'headers',
+                          form.headers.map((x, j) =>
+                            j === i ? { ...x, value: e.target.value } : x,
+                          ),
+                        )
+                      }
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() =>
+                        set(
+                          'headers',
+                          form.headers.filter((_, j) => j !== i),
+                        )
+                      }
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="justify-self-start"
+                  onClick={() =>
+                    set('headers', [...form.headers, { key: '', value: '' }])
+                  }
+                >
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  Add header
+                </Button>
+              </div>
+
+              <label className="flex items-center justify-between rounded-md border p-3">
+                <span className="text-sm">
+                  Send <code className="text-xs">Idempotency-Key</code> header
+                  <span className="text-muted-foreground block text-xs">
+                    Lets the receiver dedupe redeliveries on resume.
+                  </span>
+                </span>
+                <Switch
+                  checked={form.idempotency}
+                  onCheckedChange={(v) => set('idempotency', v)}
+                />
+              </label>
+            </TabsContent>
+
+            {/* ---- Payload ---- */}
+            <TabsContent value="payload" className="mt-0 grid gap-4">
+              <PayloadEditor form={form} set={set} />
+            </TabsContent>
+
+            {/* ---- Delivery ---- */}
+            <TabsContent
+              value="delivery"
+              className="mt-0 grid grid-cols-2 gap-4"
+            >
+              <NumberField
+                label="Batch size"
+                hint="Rows per request (1 = one-by-one)"
+                value={form.batchSize}
+                onChange={(v) => set('batchSize', v)}
+                min={1}
+              />
+              <NumberField
+                label="Max attempts"
+                hint="Retries per request"
+                value={form.maxAttempts}
+                onChange={(v) => set('maxAttempts', v)}
+                min={1}
+              />
+              <NumberField
+                label="Delay between sends (ms)"
+                hint="Rate limit"
+                value={form.minDelayMs}
+                onChange={(v) => set('minDelayMs', v)}
+                min={0}
+              />
+              <NumberField
+                label="Request timeout (ms)"
+                value={form.timeoutMs}
+                onChange={(v) => set('timeoutMs', v)}
+                min={100}
+              />
+              <NumberField
+                label="Page size"
+                hint="Rows fetched per page"
+                value={form.pageSize}
+                onChange={(v) => set('pageSize', v)}
+                min={1}
+              />
+              <NumberField
+                label="Backoff base (ms)"
+                value={form.backoffMs}
+                onChange={(v) => set('backoffMs', v)}
+                min={0}
+              />
+              <div className="grid gap-2">
+                <Label>On delivery failure</Label>
+                <Select
+                  value={form.onError}
+                  onValueChange={(v) =>
+                    set('onError', v as 'continue' | 'abort')
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="continue">Log & continue</SelectItem>
+                    <SelectItem value="abort">Stop the run</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <label className="flex items-end justify-between gap-2 pb-1">
+                <span className="text-sm">Enabled</span>
+                <Switch
+                  checked={form.enabled}
+                  onCheckedChange={(v) => set('enabled', v)}
+                />
+              </label>
+            </TabsContent>
+          </div>
+        </Tabs>
+
+        <DialogFooter className="border-t px-5 py-3">
+          <Button variant="ghost" onClick={closeHookEditor}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {editing ? 'Save' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+function PayloadEditor({
+  form,
+  set,
+}: {
+  form: FormState;
+  set: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}) {
+  const [preview, setPreview] = useState<{
+    bodies: unknown[];
+    warnings: string[];
+    error?: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function runPreview() {
+    setLoading(true);
+    setPreview(null);
+    try {
+      let rows: Record<string, unknown>[];
+      if (form.sourceKind === 'table') {
+        const page = await api.browse(
+          form.connectionId,
+          {
+            schema: form.schema || undefined,
+            table: form.table,
+            limit: 3,
+            offset: 0,
+            sort: form.sortColumn
+              ? [{ column: form.sortColumn, direction: form.sortDir }]
+              : undefined,
+          },
+          form.database || undefined,
+        );
+        rows = page.rows;
+      } else {
+        const result = await api.runQuery(
+          form.connectionId,
+          form.statement,
+          [],
+          form.database || undefined,
+        );
+        rows = result.rows.slice(0, 3);
+      }
+
+      const transform = {
+        template: form.template || DEFAULT_TEMPLATE,
+        wrapKey: form.wrapKey || undefined,
+        fields: form.fields.trim()
+          ? form.fields
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined,
+      };
+      const table = form.sourceKind === 'table' ? form.table : '(query)';
+      const now = new Date().toISOString();
+      const warnings = new Set<string>();
+      const bodies = rows.map((row, index) => {
+        const r = renderRow(row, transform, { table, now, index });
+        r.warnings.forEach((w) => warnings.add(w));
+        return r.body;
+      });
+      setPreview({ bodies, warnings: [...warnings] });
+    } catch (err) {
+      setPreview({
+        bodies: [],
+        warnings: [],
+        error: err instanceof ApiError ? err.message : String(err),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="grid gap-2">
+        <Label>Payload template (JSON)</Label>
+        <Textarea
+          value={form.template}
+          className="font-mono text-xs"
+          rows={6}
+          onChange={(e) => set('template', e.target.value)}
+        />
+        <p className="text-muted-foreground text-xs">
+          Tokens: <code>{'{{column}}'}</code>, <code>{'{{$row}}'}</code> (whole
+          row), <code>{'{{$table}}'}</code>, <code>{'{{$now}}'}</code>,{' '}
+          <code>{'{{$index}}'}</code>.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="grid gap-2">
+          <Label>Wrap under key (optional)</Label>
+          <Input
+            value={form.wrapKey}
+            placeholder="data"
+            onChange={(e) => set('wrapKey', e.target.value)}
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label>Fields for {'{{$row}}'} (optional)</Label>
+          <Input
+            value={form.fields}
+            placeholder="id, email, name"
+            onChange={(e) => set('fields', e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={runPreview}
+          disabled={loading || !form.connectionId}
+        >
+          {loading ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Eye className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Preview with live data
+        </Button>
+      </div>
+
+      {preview?.error && (
+        <p className="bg-destructive/10 text-destructive rounded-md px-3 py-2 text-xs">
+          {preview.error}
+        </p>
+      )}
+      {preview && !preview.error && (
+        <div className="grid gap-2">
+          {preview.warnings.length > 0 && (
+            <p className="text-xs text-amber-600">
+              Unresolved tokens: {preview.warnings.join(', ')}
+            </p>
+          )}
+          <pre className="bg-muted max-h-48 overflow-auto rounded-md p-3 font-mono text-xs">
+            {preview.bodies.length === 0
+              ? 'No sample rows returned.'
+              : preview.bodies
+                  .map((b) => JSON.stringify(b, null, 2))
+                  .join('\n\n──────────\n\n')}
+          </pre>
+        </div>
+      )}
+    </>
+  );
+}
+
+function NumberField({
+  label,
+  hint,
+  value,
+  onChange,
+  min,
+}: {
+  label: string;
+  hint?: string;
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label>{label}</Label>
+      <Input
+        type="number"
+        min={min}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+      {hint && <p className="text-muted-foreground text-xs">{hint}</p>}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+function fromHook(h: import('@relay/core').Hook): FormState {
+  const f = blankForm();
+  f.name = h.name;
+  f.sourceKind = h.source.kind;
+  f.connectionId = h.source.connectionId;
+  f.database = h.source.database ?? '';
+  if (h.source.kind === 'table') {
+    f.schema = h.source.schema ?? '';
+    f.table = h.source.table;
+    const sort = h.source.sort?.[0];
+    if (sort) {
+      f.sortColumn = sort.column;
+      f.sortDir = sort.direction;
+    }
+  } else {
+    f.statement = h.source.statement;
+  }
+  f.url = h.destination.url;
+  f.method = h.destination.method;
+  f.headers = Object.entries(h.destination.headers ?? {}).map(
+    ([key, value]) => ({
+      key,
+      value,
+    }),
+  );
+  f.idempotency = h.destination.idempotency;
+  if (h.destination.auth.type === 'bearer') {
+    f.authType = 'bearer';
+    f.authToken = h.destination.auth.token;
+  } else if (h.destination.auth.type === 'header') {
+    f.authType = 'header';
+    f.authHeaderName = h.destination.auth.name;
+    f.authHeaderValue = h.destination.auth.value;
+  }
+  f.template = h.transform.template;
+  f.wrapKey = h.transform.wrapKey ?? '';
+  f.fields = (h.transform.fields ?? []).join(', ');
+  f.batchSize = h.delivery.batchSize;
+  f.maxAttempts = h.delivery.maxAttempts;
+  f.minDelayMs = h.delivery.minDelayMs;
+  f.timeoutMs = h.delivery.timeoutMs;
+  f.pageSize = h.delivery.pageSize;
+  f.backoffMs = h.delivery.backoffMs;
+  f.backoffMaxMs = h.delivery.backoffMaxMs;
+  f.onError = h.delivery.onError;
+  f.enabled = h.enabled;
+  return f;
+}

--- a/apps/web/src/components/automations/hook-list.tsx
+++ b/apps/web/src/components/automations/hook-list.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Plus, Webhook } from 'lucide-react';
+import type { Hook } from '@relay/core';
+import { useHooks } from '@/lib/queries';
+import { useStudio } from '@/lib/store';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+function sourceLabel(hook: Hook): string {
+  return hook.source.kind === 'table'
+    ? hook.source.table
+    : 'custom query';
+}
+
+export function HookList() {
+  const { selectedHookId, selectHook, openHookEditor } = useStudio();
+  const { data: hooks, isLoading } = useHooks();
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center justify-between px-3 py-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Automations
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 gap-1 px-2 text-xs"
+          onClick={() => openHookEditor()}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New
+        </Button>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1 px-2 pb-2">
+        {isLoading && (
+          <p className="px-2 py-3 text-sm text-muted-foreground">Loading…</p>
+        )}
+        {!isLoading && (hooks?.length ?? 0) === 0 && (
+          <div className="px-2 py-6 text-center text-sm text-muted-foreground">
+            <Webhook className="mx-auto mb-2 h-6 w-6 opacity-50" />
+            No hooks yet.
+            <button
+              className="mt-1 block w-full text-primary hover:underline"
+              onClick={() => openHookEditor()}
+            >
+              Create your first hook
+            </button>
+          </div>
+        )}
+        <div className="flex flex-col gap-0.5">
+          {hooks?.map((hook) => (
+            <button
+              key={hook.id}
+              onClick={() => selectHook(hook.id)}
+              className={cn(
+                'flex flex-col gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors',
+                selectedHookId === hook.id
+                  ? 'bg-accent'
+                  : 'hover:bg-accent/50',
+              )}
+            >
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={cn(
+                    'h-1.5 w-1.5 shrink-0 rounded-full',
+                    hook.enabled ? 'bg-emerald-500' : 'bg-muted-foreground/40',
+                  )}
+                />
+                <span className="truncate text-sm font-medium">{hook.name}</span>
+              </div>
+              <span className="truncate pl-3 font-mono text-xs text-muted-foreground">
+                {sourceLabel(hook)} → {hook.destination.method}
+              </span>
+            </button>
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/web/src/components/automations/run-detail.tsx
+++ b/apps/web/src/components/automations/run-detail.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { Loader2, Ban, RotateCcw } from 'lucide-react';
+import { toast } from 'sonner';
+import type { HookRun, HookRunStatus } from '@relay/core';
+import { ApiError } from '@/lib/api';
+import { useCancelHookRun, useStartHookRun } from '@/lib/queries';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { DeliveryLog } from './delivery-log';
+
+const STATUS_STYLES: Record<HookRunStatus, string> = {
+  queued: 'bg-muted text-muted-foreground',
+  running: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
+  completed: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  failed: 'bg-destructive/15 text-destructive',
+  canceling: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  canceled: 'bg-muted text-muted-foreground',
+  interrupted: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+};
+
+export function RunStatusBadge({ status }: { status: HookRunStatus }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+        STATUS_STYLES[status],
+      )}
+    >
+      {(status === 'running' || status === 'queued' || status === 'canceling') && (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      )}
+      {status}
+    </span>
+  );
+}
+
+const ACTIVE: HookRunStatus[] = ['queued', 'running', 'canceling'];
+const RESUMABLE: HookRunStatus[] = ['failed', 'canceled', 'interrupted'];
+
+export function RunDetail({ hookId, run }: { hookId: string; run: HookRun }) {
+  const cancel = useCancelHookRun(hookId);
+  const resume = useStartHookRun(hookId);
+
+  const isActive = ACTIVE.includes(run.status);
+  const total = run.totalCount;
+  const done = run.sentCount + run.failedCount;
+  const pct = total && total > 0 ? Math.min(100, Math.round((done / total) * 100)) : null;
+
+  async function handleCancel() {
+    try {
+      await cancel.mutateAsync(run.id);
+    } catch (err) {
+      toast.error('Could not cancel', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleResume() {
+    try {
+      await resume.mutateAsync(run.id);
+      toast.success('Run resumed');
+    } catch (err) {
+      toast.error('Could not resume', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-wrap items-center gap-3 border-b px-4 py-3">
+        <RunStatusBadge status={run.status} />
+        <div className="flex items-center gap-4 text-sm">
+          <span>
+            <span className="font-medium text-emerald-600">{run.sentCount}</span>{' '}
+            <span className="text-muted-foreground">sent</span>
+          </span>
+          <span>
+            <span className="font-medium text-destructive">{run.failedCount}</span>{' '}
+            <span className="text-muted-foreground">failed</span>
+          </span>
+          <span className="text-muted-foreground">
+            {total != null ? `of ${total}` : 'of ?'}
+          </span>
+          {pct != null && (
+            <span className="text-muted-foreground">· {pct}%</span>
+          )}
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          {isActive && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={cancel.isPending}
+            >
+              <Ban className="mr-1.5 h-3.5 w-3.5" />
+              Cancel
+            </Button>
+          )}
+          {RESUMABLE.includes(run.status) && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleResume}
+              disabled={resume.isPending}
+            >
+              <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+              Resume
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {pct != null && (
+        <div className="h-1 w-full bg-muted">
+          <div
+            className="h-full bg-primary transition-all"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+
+      {run.error && (
+        <p className="border-b bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          {run.error}
+        </p>
+      )}
+
+      <div className="min-h-0 flex-1">
+        <DeliveryLog hookId={hookId} runId={run.id} live={isActive} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/schema/schema-tree.tsx
+++ b/apps/web/src/components/schema/schema-tree.tsx
@@ -20,6 +20,7 @@ import {
   Table2,
   Trash2,
   Upload,
+  Webhook,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import type { BackupFormat, RelationKind, TableSchema } from '@relay/core';
@@ -72,6 +73,7 @@ export function SchemaTree() {
     selected,
     selectRelation,
     openInQuery,
+    openHookEditor,
   } = useStudio();
   const [filter, setFilter] = useState('');
   const [createTableOpen, setCreateTableOpen] = useState(false);
@@ -453,6 +455,23 @@ export function SchemaTree() {
                           >
                             <SquareTerminal className="mr-2 h-4 w-4" />
                             Open SELECT
+                          </DropdownMenuItem>
+                        )}
+                        {activeConnectionId && (
+                          <DropdownMenuItem
+                            onClick={() =>
+                              openHookEditor({
+                                seed: {
+                                  connectionId: activeConnectionId,
+                                  database: activeDatabase,
+                                  schema: table.schema,
+                                  table: table.name,
+                                },
+                              })
+                            }
+                          >
+                            <Webhook className="mr-2 h-4 w-4" />
+                            Create automation
                           </DropdownMenuItem>
                         )}
                         {backupFormats.length > 0 && (

--- a/apps/web/src/components/studio.tsx
+++ b/apps/web/src/components/studio.tsx
@@ -6,9 +6,10 @@ import {
   Network,
   Table2,
   TerminalSquare,
+  Webhook,
 } from 'lucide-react';
 import { useConnections } from '@/lib/queries';
-import { useStudio, type StudioTab } from '@/lib/store';
+import { useStudio, type AppMode, type StudioTab } from '@/lib/store';
 import { cn } from '@/lib/utils';
 import {
   ResizableHandle,
@@ -24,6 +25,9 @@ import { DataGrid } from '@/components/data/data-grid';
 import { QueryEditor } from '@/components/query/query-editor';
 import { StructureView } from '@/components/structure/structure-view';
 import { ERDiagram } from '@/components/diagram/er-diagram';
+import { AutomationsView } from '@/components/automations/automations-view';
+import { HookList } from '@/components/automations/hook-list';
+import { HookEditor } from '@/components/automations/hook-editor';
 
 const TABS: { id: StudioTab; label: string; icon: typeof Table2 }[] = [
   { id: 'data', label: 'Data', icon: LayoutGrid },
@@ -32,8 +36,13 @@ const TABS: { id: StudioTab; label: string; icon: typeof Table2 }[] = [
   { id: 'diagram', label: 'Diagram', icon: Network },
 ];
 
+const MODES: { id: AppMode; label: string; icon: typeof Database }[] = [
+  { id: 'browse', label: 'Browse', icon: Database },
+  { id: 'automations', label: 'Automations', icon: Webhook },
+];
+
 export function Studio() {
-  const { activeConnectionId, activeDatabase, selected, tab, setTab } =
+  const { appMode, setAppMode, activeConnectionId, activeDatabase, selected, tab, setTab } =
     useStudio();
   const { data: connections } = useConnections();
   const conn = connections?.find((c) => c.id === activeConnectionId);
@@ -46,15 +55,41 @@ export function Studio() {
           <div className="flex h-full flex-col border-r">
             <div className="flex items-center justify-between px-3 py-2.5">
               <div className="flex items-center gap-2">
-                <Database className="h-5 w-5 text-primary" />
+                <Webhook className="h-5 w-5 text-primary" />
                 <span className="font-semibold tracking-tight">Relay</span>
               </div>
               <ThemeToggle />
             </div>
+
+            {/* Mode switch */}
+            <div className="grid grid-cols-2 gap-1 px-2 pb-2">
+              {MODES.map((m) => (
+                <button
+                  key={m.id}
+                  onClick={() => setAppMode(m.id)}
+                  className={cn(
+                    'flex items-center justify-center gap-1.5 rounded-md py-1.5 text-xs font-medium transition-colors',
+                    appMode === m.id
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:bg-accent',
+                  )}
+                >
+                  <m.icon className="h-3.5 w-3.5" />
+                  {m.label}
+                </button>
+              ))}
+            </div>
             <Separator />
-            <ConnectionList />
-            <Separator className="my-1" />
-            <SchemaTree />
+
+            {appMode === 'browse' ? (
+              <>
+                <ConnectionList />
+                <Separator className="my-1" />
+                <SchemaTree />
+              </>
+            ) : (
+              <HookList />
+            )}
           </div>
         </ResizablePanel>
 
@@ -62,66 +97,69 @@ export function Studio() {
 
         {/* Main */}
         <ResizablePanel defaultSize={80}>
-          <div className="flex h-full flex-col">
-            {/* Breadcrumb + tabs */}
-            <div className="flex items-center gap-1 border-b px-3">
-              <div className="flex h-11 items-center gap-1.5 pr-3 text-sm text-muted-foreground">
-                {conn ? (
-                  <>
-                    <span className="font-medium text-foreground">
-                      {conn.name}
-                    </span>
-                    {activeDatabase && (
-                      <>
-                        <span>/</span>
-                        <span>{activeDatabase}</span>
-                      </>
-                    )}
-                    {selected && (
-                      <>
-                        <span>/</span>
-                        <span className="font-mono text-foreground">
-                          {selected.table}
-                        </span>
-                      </>
-                    )}
-                  </>
-                ) : (
-                  <span>No connection selected</span>
-                )}
+          {appMode === 'automations' ? (
+            <AutomationsView />
+          ) : (
+            <div className="flex h-full flex-col">
+              {/* Breadcrumb + tabs */}
+              <div className="flex items-center gap-1 border-b px-3">
+                <div className="flex h-11 items-center gap-1.5 pr-3 text-sm text-muted-foreground">
+                  {conn ? (
+                    <>
+                      <span className="font-medium text-foreground">{conn.name}</span>
+                      {activeDatabase && (
+                        <>
+                          <span>/</span>
+                          <span>{activeDatabase}</span>
+                        </>
+                      )}
+                      {selected && (
+                        <>
+                          <span>/</span>
+                          <span className="font-mono text-foreground">
+                            {selected.table}
+                          </span>
+                        </>
+                      )}
+                    </>
+                  ) : (
+                    <span>No connection selected</span>
+                  )}
+                </div>
+
+                <div className="ml-auto flex items-center">
+                  {TABS.map((t) => (
+                    <button
+                      key={t.id}
+                      onClick={() => setTab(t.id)}
+                      className={cn(
+                        'flex h-11 items-center gap-1.5 border-b-2 px-3 text-sm transition-colors',
+                        tab === t.id
+                          ? 'border-primary text-foreground'
+                          : 'border-transparent text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      <t.icon className="h-4 w-4" />
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
               </div>
 
-              <div className="ml-auto flex items-center">
-                {TABS.map((t) => (
-                  <button
-                    key={t.id}
-                    onClick={() => setTab(t.id)}
-                    className={cn(
-                      'flex h-11 items-center gap-1.5 border-b-2 px-3 text-sm transition-colors',
-                      tab === t.id
-                        ? 'border-primary text-foreground'
-                        : 'border-transparent text-muted-foreground hover:text-foreground',
-                    )}
-                  >
-                    <t.icon className="h-4 w-4" />
-                    {t.label}
-                  </button>
-                ))}
+              {/* Tab content */}
+              <div className="min-h-0 flex-1">
+                {tab === 'data' && <DataGrid />}
+                {tab === 'structure' && <StructureView />}
+                {tab === 'query' && <QueryEditor />}
+                {tab === 'diagram' && <ERDiagram />}
               </div>
             </div>
-
-            {/* Tab content */}
-            <div className="min-h-0 flex-1">
-              {tab === 'data' && <DataGrid />}
-              {tab === 'structure' && <StructureView />}
-              {tab === 'query' && <QueryEditor />}
-              {tab === 'diagram' && <ERDiagram />}
-            </div>
-          </div>
+          )}
         </ResizablePanel>
       </ResizablePanelGroup>
 
       <ConnectionDialog />
+      <HookEditor />
     </>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -11,6 +11,12 @@ import type {
   DatabaseSchema,
   DeleteRowParams,
   DriverInfo,
+  Hook,
+  HookDelivery,
+  HookInputDTO,
+  HookPreview,
+  HookPreviewDTO,
+  HookRun,
   InsertRowParams,
   QueryResult,
   UpdateRowParams,
@@ -182,6 +188,46 @@ export const api = {
       `/connections/${id}/restore${dbQuery(database)}`,
       { method: 'POST', ...jsonBody(body) },
     ),
+
+  /* ----- automation hooks ----- */
+
+  listHooks: () => request<Hook[]>('/hooks'),
+  getHook: (id: string) => request<Hook>(`/hooks/${id}`),
+  createHook: (input: HookInputDTO) =>
+    request<Hook>('/hooks', { method: 'POST', ...jsonBody(input) }),
+  updateHook: (id: string, input: HookInputDTO) =>
+    request<Hook>(`/hooks/${id}`, { method: 'PUT', ...jsonBody(input) }),
+  deleteHook: (id: string) =>
+    request<{ id: string }>(`/hooks/${id}`, { method: 'DELETE' }),
+  previewHook: (id: string, body: HookPreviewDTO) =>
+    request<HookPreview>(`/hooks/${id}/preview`, {
+      method: 'POST',
+      ...jsonBody(body),
+    }),
+  startHookRun: (id: string, resumeRunId?: string) =>
+    request<HookRun>(`/hooks/${id}/runs`, {
+      method: 'POST',
+      ...jsonBody({ resumeRunId }),
+    }),
+  listHookRuns: (id: string) => request<HookRun[]>(`/hooks/${id}/runs`),
+  getHookRun: (id: string, runId: string) =>
+    request<HookRun>(`/hooks/${id}/runs/${runId}`),
+  cancelHookRun: (id: string, runId: string) =>
+    request<HookRun>(`/hooks/${id}/runs/${runId}/cancel`, { method: 'POST' }),
+  listHookDeliveries: (
+    id: string,
+    runId: string,
+    opts: { status?: 'success' | 'failed'; offset?: number; limit?: number } = {},
+  ) => {
+    const q = new URLSearchParams();
+    if (opts.status) q.set('status', opts.status);
+    if (opts.offset != null) q.set('offset', String(opts.offset));
+    if (opts.limit != null) q.set('limit', String(opts.limit));
+    const qs = q.toString();
+    return request<HookDelivery[]>(
+      `/hooks/${id}/runs/${runId}/deliveries${qs ? `?${qs}` : ''}`,
+    );
+  },
 };
 
 function dbQuery(database?: string): string {

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -8,6 +8,8 @@ import {
 import type {
   BrowseParams,
   ConnectionInputDTO,
+  HookInputDTO,
+  HookRun,
 } from '@relay/core';
 import { api } from './api';
 
@@ -20,6 +22,12 @@ export const queryKeys = {
     ['connections', id, 'schema', database ?? 'default'] as const,
   browse: (id: string, database: string | undefined, params: BrowseParams) =>
     ['connections', id, 'browse', database ?? 'default', params] as const,
+  hooks: ['hooks'] as const,
+  hook: (id: string) => ['hooks', id] as const,
+  hookRuns: (id: string) => ['hooks', id, 'runs'] as const,
+  hookRun: (id: string, runId: string) => ['hooks', id, 'runs', runId] as const,
+  hookDeliveries: (id: string, runId: string) =>
+    ['hooks', id, 'runs', runId, 'deliveries'] as const,
 };
 
 export function useDrivers() {
@@ -91,5 +99,89 @@ export function useBrowse(
     queryFn: () => api.browse(id as string, params as BrowseParams, database),
     enabled: !!id && !!params,
     placeholderData: (prev) => prev,
+  });
+}
+
+/* ----- automation hooks ----- */
+
+export function useHooks() {
+  return useQuery({
+    queryKey: queryKeys.hooks,
+    queryFn: () => api.listHooks(),
+  });
+}
+
+export function useCreateHook() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: HookInputDTO) => api.createHook(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hooks }),
+  });
+}
+
+export function useUpdateHook() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: HookInputDTO }) =>
+      api.updateHook(id, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hooks }),
+  });
+}
+
+export function useDeleteHook() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.deleteHook(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hooks }),
+  });
+}
+
+export function useStartHookRun(hookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (resumeRunId?: string) => api.startHookRun(hookId, resumeRunId),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+  });
+}
+
+export function useCancelHookRun(hookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (runId: string) => api.cancelHookRun(hookId, runId),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+  });
+}
+
+/** Live-polls while any run is still active. */
+export function useHookRuns(hookId: string | null) {
+  return useQuery({
+    queryKey: hookId ? queryKeys.hookRuns(hookId) : ['hookRuns', 'none'],
+    queryFn: () => api.listHookRuns(hookId as string),
+    enabled: !!hookId,
+    refetchInterval: (query) => {
+      const runs = query.state.data as HookRun[] | undefined;
+      const active = runs?.some((r) =>
+        ['queued', 'running', 'canceling'].includes(r.status),
+      );
+      return active ? 1500 : false;
+    },
+  });
+}
+
+export function useHookDeliveries(
+  hookId: string | null,
+  runId: string | null,
+  live: boolean,
+) {
+  return useQuery({
+    queryKey:
+      hookId && runId
+        ? queryKeys.hookDeliveries(hookId, runId)
+        : ['hookDeliveries', 'none'],
+    queryFn: () => api.listHookDeliveries(hookId as string, runId as string, { limit: 500 }),
+    enabled: !!hookId && !!runId,
+    refetchInterval: live ? 1500 : false,
   });
 }

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -5,10 +5,21 @@ import type { RelationKind } from '@relay/core';
 
 export type StudioTab = 'data' | 'query' | 'structure' | 'diagram';
 
+/** Top-level app surface: the database browser vs. the automation tool. */
+export type AppMode = 'browse' | 'automations';
+
 export interface SelectedRelation {
   schema?: string;
   table: string;
   kind: RelationKind;
+}
+
+/** Prefill payload when opening the hook editor (e.g. from the schema tree). */
+export interface HookEditorSeed {
+  connectionId: string;
+  database?: string;
+  schema?: string;
+  table: string;
 }
 
 export interface QueryTab {
@@ -26,6 +37,7 @@ function freshTabs(): { tabs: QueryTab[]; activeId: string } {
 }
 
 interface StudioState {
+  appMode: AppMode;
   activeConnectionId: string | null;
   activeDatabase?: string;
   selected: SelectedRelation | null;
@@ -34,14 +46,24 @@ interface StudioState {
   /** Connection editor dialog state. */
   dialog: { open: boolean; editingId: string | null };
 
+  /** Automations surface: the currently selected hook. */
+  selectedHookId: string | null;
+  /** Hook editor dialog: open + which hook (null = new) + optional prefill. */
+  hookEditor: { open: boolean; editingId: string | null; seed: HookEditorSeed | null };
+
   /** Query editor tabs, lifted here so they survive view switches. */
   queryTabs: QueryTab[];
   activeQueryTabId: string;
 
+  setAppMode: (mode: AppMode) => void;
   setActiveConnection: (id: string | null) => void;
   setActiveDatabase: (db?: string) => void;
   selectRelation: (rel: SelectedRelation) => void;
   setTab: (tab: StudioTab) => void;
+
+  selectHook: (id: string | null) => void;
+  openHookEditor: (opts?: { editingId?: string | null; seed?: HookEditorSeed }) => void;
+  closeHookEditor: () => void;
 
   addQueryTab: (opts?: { sql?: string; name?: string }) => void;
   closeQueryTab: (id: string) => void;
@@ -57,13 +79,31 @@ interface StudioState {
 const initial = freshTabs();
 
 export const useStudio = create<StudioState>((set) => ({
+  appMode: 'browse',
   activeConnectionId: null,
   activeDatabase: undefined,
   selected: null,
   tab: 'data',
   dialog: { open: false, editingId: null },
+  selectedHookId: null,
+  hookEditor: { open: false, editingId: null, seed: null },
   queryTabs: initial.tabs,
   activeQueryTabId: initial.activeId,
+
+  setAppMode: (mode) => set({ appMode: mode }),
+
+  selectHook: (id) => set({ selectedHookId: id }),
+  openHookEditor: (opts) =>
+    set({
+      appMode: 'automations',
+      hookEditor: {
+        open: true,
+        editingId: opts?.editingId ?? null,
+        seed: opts?.seed ?? null,
+      },
+    }),
+  closeHookEditor: () =>
+    set({ hookEditor: { open: false, editingId: null, seed: null } }),
 
   setActiveConnection: (id) => {
     const f = freshTabs();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+# Local infrastructure for Relay's automation hooks.
+#
+#   docker compose up -d redis
+#
+# Redis backs the BullMQ queue that executes hook runs durably (jobs survive an
+# API restart and auto-resume). The database studio, hook CRUD and payload
+# preview do not need Redis — only *running* a hook does.
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: relay-redis
+    restart: unless-stopped
+    ports:
+      - '6379:6379'
+    command: ['redis-server', '--save', '60', '1', '--appendonly', 'yes']
+    volumes:
+      - relay-redis-data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  relay-redis-data:

--- a/packages/core/src/adapters/sql/base-sql-adapter.ts
+++ b/packages/core/src/adapters/sql/base-sql-adapter.ts
@@ -400,7 +400,8 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
     const schema = await this.getSchema();
     let tables = schema.namespaces.flatMap((ns) => ns.tables);
     tables = tables.filter((t) => t.kind === 'table');
-    if (opts.schema) tables = tables.filter((t) => (t.schema ?? '') === opts.schema);
+    if (opts.schema)
+      tables = tables.filter((t) => (t.schema ?? '') === opts.schema);
     if (opts.tables?.length) {
       const wanted = new Set(opts.tables);
       tables = tables.filter((t) => wanted.has(t.name));

--- a/packages/core/src/hooks/hook-config.ts
+++ b/packages/core/src/hooks/hook-config.ts
@@ -1,0 +1,191 @@
+/**
+ * Shared Zod schemas + types for automation hooks. Used by the API (validation,
+ * persistence) and the web client (forms, preview) — so the contract lives in
+ * exactly one place, mirroring `validation.ts`.
+ */
+import { z } from 'zod';
+import { filterSchema, sortSchema } from '../validation';
+
+/* -------------------------------------------------------------------------- */
+/* Source — where rows are read from                                          */
+/* -------------------------------------------------------------------------- */
+
+const tableSourceSchema = z.object({
+  kind: z.literal('table'),
+  connectionId: z.string().min(1),
+  database: z.string().optional(),
+  schema: z.string().optional(),
+  table: z.string().min(1),
+  filters: z.array(filterSchema).optional(),
+  sort: z.array(sortSchema).optional(),
+});
+
+const querySourceSchema = z.object({
+  kind: z.literal('query'),
+  connectionId: z.string().min(1),
+  database: z.string().optional(),
+  statement: z.string().min(1),
+});
+
+export const hookSourceSchema = z.discriminatedUnion('kind', [
+  tableSourceSchema,
+  querySourceSchema,
+]);
+
+/* -------------------------------------------------------------------------- */
+/* Destination — where rows are sent                                          */
+/* -------------------------------------------------------------------------- */
+
+export const hookAuthSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('none') }),
+  z.object({ type: z.literal('bearer'), token: z.string() }),
+  z.object({ type: z.literal('header'), name: z.string().min(1), value: z.string() }),
+]);
+
+export const hookDestinationSchema = z.object({
+  url: z.string().url('Enter a valid http(s) URL'),
+  method: z.enum(['POST', 'PUT', 'PATCH']).default('POST'),
+  headers: z.record(z.string(), z.string()).optional(),
+  auth: hookAuthSchema.default({ type: 'none' }),
+  /**
+   * Add an `Idempotency-Key` header derived from `(runId, sequence)` so the
+   * receiver can dedupe at-least-once redeliveries (see runner docs).
+   */
+  idempotency: z.boolean().default(false),
+});
+
+/* -------------------------------------------------------------------------- */
+/* Transform — how each row becomes a body                                    */
+/* -------------------------------------------------------------------------- */
+
+export const hookTransformSchema = z.object({
+  template: z.string().min(1).default('{{$row}}'),
+  fields: z.array(z.string()).optional(),
+  rename: z.record(z.string(), z.string()).optional(),
+  wrapKey: z.string().optional(),
+});
+
+/* -------------------------------------------------------------------------- */
+/* Delivery — pacing, retries, batching                                       */
+/* -------------------------------------------------------------------------- */
+
+export const hookDeliverySchema = z.object({
+  /** Rows per HTTP request. 1 = strictly one-by-one. */
+  batchSize: z.coerce.number().int().min(1).max(1000).default(1),
+  /** Total attempts per request (1 = no retry). */
+  maxAttempts: z.coerce.number().int().min(1).max(10).default(3),
+  /** Base backoff in ms; doubles each retry up to `backoffMaxMs`. */
+  backoffMs: z.coerce.number().int().min(0).max(60_000).default(500),
+  backoffMaxMs: z.coerce.number().int().min(0).max(300_000).default(30_000),
+  /** Minimum delay between requests (rate limit). */
+  minDelayMs: z.coerce.number().int().min(0).max(600_000).default(0),
+  /** Per-request timeout. */
+  timeoutMs: z.coerce.number().int().min(100).max(120_000).default(15_000),
+  /** Rows fetched per page from a table source. */
+  pageSize: z.coerce.number().int().min(1).max(1000).default(200),
+  /** Whether a failed delivery aborts the run or is logged and skipped. */
+  onError: z.enum(['continue', 'abort']).default('continue'),
+});
+
+/* -------------------------------------------------------------------------- */
+/* Hook                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export const hookInputSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(120),
+  source: hookSourceSchema,
+  destination: hookDestinationSchema,
+  transform: hookTransformSchema,
+  delivery: hookDeliverySchema.default({}),
+  enabled: z.boolean().default(true),
+});
+
+export const hookPreviewSchema = z.object({
+  /** Render against this row instead of fetching from the source. */
+  sampleRow: z.record(z.string(), z.unknown()).optional(),
+  /** When no sampleRow is given, fetch this many rows from the source. */
+  limit: z.coerce.number().int().min(1).max(10).default(3),
+});
+
+export const startRunSchema = z.object({
+  /** Resume a previously interrupted run instead of starting fresh. */
+  resumeRunId: z.string().optional(),
+});
+
+/* -------------------------------------------------------------------------- */
+/* Inferred types + DTOs surfaced to the web client                           */
+/* -------------------------------------------------------------------------- */
+
+export type HookSource = z.infer<typeof hookSourceSchema>;
+export type HookAuth = z.infer<typeof hookAuthSchema>;
+export type HookDestination = z.infer<typeof hookDestinationSchema>;
+export type HookTransformConfig = z.infer<typeof hookTransformSchema>;
+export type HookDeliveryConfig = z.infer<typeof hookDeliverySchema>;
+export type HookInputDTO = z.infer<typeof hookInputSchema>;
+export type HookPreviewDTO = z.infer<typeof hookPreviewSchema>;
+export type StartRunDTO = z.infer<typeof startRunSchema>;
+
+export type HookRunStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'canceling'
+  | 'canceled'
+  | 'interrupted';
+
+export type DeliveryStatus = 'success' | 'failed';
+
+/** The hook as returned by the API (secret redacted). */
+export interface Hook {
+  id: string;
+  name: string;
+  source: HookSource;
+  destination: HookDestination;
+  transform: HookTransformConfig;
+  delivery: HookDeliveryConfig;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface HookRun {
+  id: string;
+  hookId: string;
+  status: HookRunStatus;
+  cursorOffset: number;
+  sentCount: number;
+  failedCount: number;
+  totalCount: number | null;
+  error: string | null;
+  startedAt: string;
+  finishedAt: string | null;
+}
+
+export interface HookDelivery {
+  id: string;
+  runId: string;
+  sequence: number;
+  rowIndex: number;
+  rowCount: number;
+  status: DeliveryStatus;
+  httpStatus: number | null;
+  attempts: number;
+  error: string | null;
+  responseSnippet: string | null;
+  durationMs: number | null;
+  createdAt: string;
+}
+
+/** Result of the preview endpoint: rendered bodies + resolved request shape. */
+export interface HookPreview {
+  method: string;
+  url: string;
+  /** Headers with any auth secret redacted. */
+  headers: Record<string, string>;
+  /** One rendered body per sample row (or per batch when batched). */
+  bodies: unknown[];
+  warnings: string[];
+  /** True when the rows came from the live source rather than a sample. */
+  fromSource: boolean;
+}

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './transform';
+export * from './hook-config';

--- a/packages/core/src/hooks/transform.test.ts
+++ b/packages/core/src/hooks/transform.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { renderBatch, renderRow, type TransformContext } from './transform';
+
+const ctx: TransformContext = {
+  table: 'users',
+  now: '2026-06-03T00:00:00.000Z',
+  index: 7,
+};
+
+describe('renderRow', () => {
+  it('passes through the projected row via {{$row}}', () => {
+    const { body, warnings } = renderRow(
+      { id: 1, email: 'a@b.com' },
+      { template: '{{$row}}' },
+      ctx,
+    );
+    expect(body).toEqual({ id: 1, email: 'a@b.com' });
+    expect(warnings).toEqual([]);
+  });
+
+  it('preserves value types for whole-token string nodes', () => {
+    const { body } = renderRow(
+      { id: 42, active: true, meta: { a: 1 }, nada: null },
+      {
+        template:
+          '{"id":"{{id}}","active":"{{active}}","meta":"{{meta}}","nada":"{{nada}}"}',
+      },
+      ctx,
+    );
+    // Whole-token strings adopt the real JS type, not a string.
+    expect(body).toEqual({ id: 42, active: true, meta: { a: 1 }, nada: null });
+  });
+
+  it('interpolates tokens inside larger strings (stringified)', () => {
+    const { body } = renderRow(
+      { id: 5 },
+      { template: '{"ref":"order-{{id}}-{{$index}}"}' },
+      ctx,
+    );
+    expect(body).toEqual({ ref: 'order-5-7' });
+  });
+
+  it('resolves $table, $now and $index helpers', () => {
+    const { body } = renderRow(
+      { id: 1 },
+      { template: '{"t":"{{$table}}","at":"{{$now}}","i":"{{$index}}"}' },
+      ctx,
+    );
+    expect(body).toEqual({ t: 'users', at: ctx.now, i: 7 });
+  });
+
+  it('is injection-safe: values with quotes/newlines cannot break JSON', () => {
+    const { body } = renderRow(
+      { note: 'he said "hi"\n} malicious", "admin":true' },
+      { template: '{"note":"{{note}}"}' },
+      ctx,
+    );
+    expect(body).toEqual({ note: 'he said "hi"\n} malicious", "admin":true' });
+    expect((body as { admin?: unknown }).admin).toBeUndefined();
+  });
+
+  it('applies fields whitelist and rename to {{$row}}', () => {
+    const { body } = renderRow(
+      { id: 1, email: 'a@b.com', password: 'secret' },
+      {
+        template: '{{$row}}',
+        fields: ['id', 'email'],
+        rename: { email: 'contact' },
+      },
+      ctx,
+    );
+    expect(body).toEqual({ id: 1, contact: 'a@b.com' });
+  });
+
+  it('wraps the body under wrapKey', () => {
+    const { body } = renderRow(
+      { id: 1 },
+      { template: '{{$row}}', wrapKey: 'data' },
+      ctx,
+    );
+    expect(body).toEqual({ data: { id: 1 } });
+  });
+
+  it('collects warnings for unknown tokens without throwing', () => {
+    const { body, warnings } = renderRow(
+      { id: 1 },
+      { template: '{"x":"{{missing}}"}' },
+      ctx,
+    );
+    expect(body).toEqual({ x: null });
+    expect(warnings).toEqual(['missing']);
+  });
+
+  it('throws a clear error on malformed template JSON', () => {
+    expect(() => renderRow({ id: 1 }, { template: '{not json' }, ctx)).toThrow(
+      /not valid JSON/i,
+    );
+  });
+});
+
+describe('renderBatch', () => {
+  it('renders an array with per-row $index', () => {
+    const { body } = renderBatch(
+      [{ id: 1 }, { id: 2 }],
+      { template: '{"id":"{{id}}","i":"{{$index}}"}' },
+      10,
+      { table: 'users', now: ctx.now },
+    );
+    expect(body).toEqual([
+      { id: 1, i: 10 },
+      { id: 2, i: 11 },
+    ]);
+  });
+
+  it('wraps the whole array under wrapKey', () => {
+    const { body } = renderBatch(
+      [{ id: 1 }, { id: 2 }],
+      { template: '{{$row}}', wrapKey: 'records' },
+      0,
+      { table: 'users', now: ctx.now },
+    );
+    expect(body).toEqual({ records: [{ id: 1 }, { id: 2 }] });
+  });
+});

--- a/packages/core/src/hooks/transform.ts
+++ b/packages/core/src/hooks/transform.ts
@@ -1,0 +1,177 @@
+/**
+ * Payload templating for automation hooks. Pure and framework-agnostic so it
+ * runs identically in the API runner and in the web preview — and is trivially
+ * unit-testable.
+ *
+ * A template is a **JSON document** with `{{token}}` placeholders. We parse it
+ * to a JSON tree exactly once and substitute tokens at the node level:
+ *
+ *   - A string node that is *entirely* one token (`"{{email}}"`) is replaced by
+ *     the token's real value, preserving its type (number, object, null, …).
+ *   - A string node containing tokens among other text (`"id-{{id}}"`) has each
+ *     token stringified and interpolated, staying a string.
+ *
+ * Because substitution happens on the parsed tree (never by splicing raw values
+ * into template text and re-parsing), a value containing quotes or newlines can
+ * never break out of its position or produce invalid JSON. This is the key
+ * difference from naive string interpolation, which is an injection bug.
+ *
+ * Tokens:
+ *   {{column}}  — a column value from the source row (original, pre-rename)
+ *   {{$row}}    — the projected row object (after `fields` filter + `rename`)
+ *   {{$table}}  — the source table/relation name
+ *   {{$now}}    — ISO timestamp captured once per delivery
+ *   {{$index}}  — 0-based row index across the whole run
+ */
+import { BadRequestError } from '../errors';
+
+export interface TransformContext {
+  /** Resolves `{{$table}}`. */
+  table: string;
+  /** Resolves `{{$now}}` — captured once per delivery. */
+  now: string;
+  /** Resolves `{{$index}}` — 0-based row index across the run. */
+  index: number;
+}
+
+export interface TransformConfig {
+  /** JSON template with `{{token}}` placeholders. */
+  template: string;
+  /** Whitelist of source columns kept in `{{$row}}` (default: all). */
+  fields?: string[];
+  /** Map of source column → output key, applied to `{{$row}}`. */
+  rename?: Record<string, string>;
+  /** When set, the final body is wrapped as `{ [wrapKey]: body }`. */
+  wrapKey?: string;
+}
+
+export interface RenderResult {
+  /** The request body value (the caller is responsible for JSON.stringify). */
+  body: unknown;
+  /** Tokens that did not resolve — surfaced for preview, never fatal. */
+  warnings: string[];
+}
+
+type Row = Record<string, unknown>;
+
+const WHOLE_TOKEN = /^\{\{\s*([\w$]+)\s*\}\}$/;
+const ANY_TOKEN = /\{\{\s*([\w$]+)\s*\}\}/g;
+
+/** Apply the `fields` whitelist and `rename` map to produce `{{$row}}`. */
+function projectRow(row: Row, cfg: TransformConfig): Row {
+  let entries = Object.entries(row);
+  if (cfg.fields && cfg.fields.length > 0) {
+    const keep = new Set(cfg.fields);
+    entries = entries.filter(([k]) => keep.has(k));
+  }
+  if (cfg.rename) {
+    entries = entries.map(([k, v]) => [cfg.rename![k] ?? k, v]);
+  }
+  return Object.fromEntries(entries);
+}
+
+function buildScope(row: Row, cfg: TransformConfig, ctx: TransformContext): Row {
+  return {
+    ...row,
+    $row: projectRow(row, cfg),
+    $table: ctx.table,
+    $now: ctx.now,
+    $index: ctx.index,
+  };
+}
+
+/** Coerce a resolved value to its string form for in-string interpolation. */
+function stringify(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/** Recursively substitute tokens in a parsed JSON node. */
+function substitute(node: unknown, scope: Row, warnings: Set<string>): unknown {
+  if (typeof node === 'string') {
+    const whole = node.match(WHOLE_TOKEN);
+    if (whole) {
+      const name = whole[1]!;
+      if (name in scope) return scope[name];
+      warnings.add(name);
+      return null;
+    }
+    return node.replace(ANY_TOKEN, (_m, name: string) => {
+      if (name in scope) return stringify(scope[name]);
+      warnings.add(name);
+      return '';
+    });
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => substitute(item, scope, warnings));
+  }
+  if (node && typeof node === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node)) {
+      // Keys are interpolated (string-only); values are fully substituted.
+      const renderedKey = key.replace(ANY_TOKEN, (_m, name: string) => {
+        if (name in scope) return stringify(scope[name]);
+        warnings.add(name);
+        return '';
+      });
+      out[renderedKey] = substitute(value, scope, warnings);
+    }
+    return out;
+  }
+  return node;
+}
+
+/**
+ * Parse a template once, surfacing a clear error on malformed JSON. A template
+ * that is a single bare token (e.g. the default `{{$row}}`) is returned as that
+ * token string so `substitute` resolves it to a typed value — it need not be
+ * quoted JSON.
+ */
+function parseTemplate(template: string): unknown {
+  const trimmed = template.trim();
+  if (WHOLE_TOKEN.test(trimmed)) return trimmed;
+  try {
+    return JSON.parse(template);
+  } catch (err) {
+    throw new BadRequestError(
+      `Payload template is not valid JSON: ${(err as Error).message}`,
+    );
+  }
+}
+
+/** Render a single row to a request body. */
+export function renderRow(
+  row: Row,
+  cfg: TransformConfig,
+  ctx: TransformContext,
+): RenderResult {
+  const warnings = new Set<string>();
+  const tree = parseTemplate(cfg.template);
+  const rendered = substitute(tree, buildScope(row, cfg, ctx), warnings);
+  return { body: wrap(rendered, cfg), warnings: [...warnings] };
+}
+
+/**
+ * Render N rows into a single array body (used when `batchSize > 1`). Each row
+ * is rendered with its own `{{$index}}`; the optional `wrapKey` wraps the array.
+ */
+export function renderBatch(
+  rows: Row[],
+  cfg: TransformConfig,
+  startIndex: number,
+  ctx: Omit<TransformContext, 'index'>,
+): RenderResult {
+  const warnings = new Set<string>();
+  const tree = parseTemplate(cfg.template);
+  const items = rows.map((row, i) => {
+    const scope = buildScope(row, cfg, { ...ctx, index: startIndex + i });
+    return substitute(tree, scope, warnings);
+  });
+  return { body: wrap(items, cfg), warnings: [...warnings] };
+}
+
+function wrap(body: unknown, cfg: TransformConfig): unknown {
+  return cfg.wrapKey ? { [cfg.wrapKey]: body } : body;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
 export * from './adapters/types';
 export * from './errors';
 export * from './validation';
+export * from './hooks';
 
 // Type-only re-exports of the driver metadata (no driver implementations are
 // pulled in, so this stays safe for the browser bundle).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@nestjs/bullmq':
+        specifier: ^10.2.3
+        version: 10.2.3(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(bullmq@5.78.0)
       '@nestjs/common':
         specifier: ^10.4.7
         version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -38,9 +41,15 @@ importers:
       '@relay/core':
         specifier: workspace:*
         version: link:../../packages/core
+      bullmq:
+        specifier: ^5.34.0
+        version: 5.78.0
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      ioredis:
+        specifier: ^5.4.1
+        version: 5.11.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -652,6 +661,9 @@ packages:
   '@ioredis/commands@1.10.0':
     resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -693,11 +705,54 @@ packages:
   '@mongodb-js/saslprep@1.4.11':
     resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nestjs/bull-shared@10.2.3':
+    resolution: {integrity: sha512-XcgAjNOgq6b5DVCytxhR5BKiwWo7hsusVeyE7sfFnlXRHeEtIuC2hYWBr/ZAtvL/RH0/O0tqtq0rVl972nbhJw==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
+      '@nestjs/core': ^8.0.0 || ^9.0.0 || ^10.0.0
+
+  '@nestjs/bullmq@10.2.3':
+    resolution: {integrity: sha512-Lo4W5kWD61/246Y6H70RNgV73ybfRbZyKKS4CBRDaMELpxgt89O+EgYZUB4pdoNrWH16rKcaT0AoVsB/iDztKg==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
+      '@nestjs/core': ^8.0.0 || ^9.0.0 || ^10.0.0
+      bullmq: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@nestjs/cli@10.4.9':
     resolution: {integrity: sha512-s8qYd97bggqeK7Op3iD49X2MpFtW4LVNLAwXFkfbRxKME6IYT7X0muNTJ2+QfI8hpbNx9isWkrLWIp+g5FOhiA==}
@@ -2059,6 +2114,15 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bullmq@5.78.0:
+    resolution: {integrity: sha512-tT9jJmbobk9ueEfFc22egLmgwCcMGgOjZ5Y1cvgczBPv1JUmC7iHQVbQtqku2YBE5dE9uzdVpxIrBvL/YAjGwA==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      redis: '>=5.0.0'
+    peerDependenciesMeta:
+      redis:
+        optional: true
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -2238,6 +2302,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2910,6 +2978,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ioredis@5.11.0:
     resolution: {integrity: sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==}
     engines: {node: '>=12.22.0'}
@@ -3141,6 +3213,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -3172,6 +3250,10 @@ packages:
     resolution: {integrity: sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3301,6 +3383,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@2.0.2:
+    resolution: {integrity: sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==}
+
   multer@2.0.2:
     resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
     engines: {node: '>= 10.16.0'}
@@ -3401,6 +3490,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
@@ -3953,6 +4046,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.1:
@@ -4968,6 +5066,8 @@ snapshots:
 
   '@ioredis/commands@1.10.0': {}
 
+  '@ioredis/commands@1.5.1': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -5017,12 +5117,44 @@ snapshots:
     dependencies:
       sparse-bitfield: 3.0.3
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nestjs/bull-shared@10.2.3(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      tslib: 2.8.1
+
+  '@nestjs/bullmq@10.2.3(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(bullmq@5.78.0)':
+    dependencies:
+      '@nestjs/bull-shared': 10.2.3(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      bullmq: 5.78.0
+      tslib: 2.8.1
 
   '@nestjs/cli@10.4.9':
     dependencies:
@@ -6424,6 +6556,17 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bullmq@5.78.0:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 2.0.2
+      node-abort-controller: 3.1.1
+      semver: 7.8.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -6601,6 +6744,10 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.7.2
+
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7469,6 +7616,20 @@ snapshots:
       hasown: 2.0.4
       side-channel: 1.1.0
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ioredis@5.11.0:
     dependencies:
       '@ioredis/commands': 1.10.0
@@ -7702,6 +7863,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.18.1: {}
@@ -7726,6 +7891,8 @@ snapshots:
   lucide-react@0.460.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -7810,6 +7977,22 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@2.0.2:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
 
   multer@2.0.2:
     dependencies:
@@ -7914,6 +8097,11 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.46: {}
 
@@ -8432,6 +8620,8 @@ snapshots:
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
   semver@6.3.1: {}
+
+  semver@7.8.0: {}
 
   semver@7.8.1: {}
 


### PR DESCRIPTION
Turn Relay into an automation tool. A "hook" reads rows from a connected database (a whole table, paged in a stable order, or a query result) and POSTs each one to an HTTP endpoint with a customizable payload.

Core (@relay/core):
- Pure, injection-safe payload templating ({{column}}, {{$row}}, {{$table}}, {{$now}}, {{$index}}) with field select/rename and a wrap key, plus tests.
- Zod hook config schemas + shared types.

API (@relay/api):
- Hook / HookRun / HookDelivery Prisma models + migration; auth secret encrypted at rest like connection passwords.
- Durable run engine on BullMQ + Redis (one job per run): resumable after a crash via cursor checkpoint + idempotent (runId, sequence) deliveries, cross-process cancellable, rate-limited, with retries/backoff and a per-delivery log that surfaces the real fetch failure cause.
- Single-active-run guard, payload preview, and graceful degradation when Redis is absent (studio + CRUD + preview still work).

Web (@relay/web):
- Automations primary surface: hook list, tabbed editor with live payload preview, run + delivery viewers; "Create automation" from the schema tree.

Infra: docker-compose Redis, REDIS_URL config, README + .env.example.