### PR TITLE
Add CDC/Watch hook engine, fix delivery chart accuracy, and enterpris…

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,8 @@
     "bullmq": "^5.34.0",
     "dotenv": "^16.4.5",
     "ioredis": "^5.4.1",
+    "pg": "^8.13.1",
+    "pg-logical-replication": "^2.0.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^3.23.8"

--- a/apps/api/prisma/migrations/20260604000000_watch_triggers/migration.sql
+++ b/apps/api/prisma/migrations/20260604000000_watch_triggers/migration.sql
@@ -1,0 +1,4 @@
+-- Watch (live-listening) hooks: a trigger config per hook, and a per-run
+-- change-detection cursor.
+ALTER TABLE "hooks" ADD COLUMN "trigger_json" TEXT;
+ALTER TABLE "hook_runs" ADD COLUMN "cursor_json" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Hook {
   authEnc         String?  @map("auth_enc")          // encrypted secret material only
   transformJson   String   @map("transform_json")
   deliveryJson    String   @map("delivery_json")
+  triggerJson     String?  @map("trigger_json") // null = { kind: 'replay' }
   enabled         Boolean  @default(true)
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @updatedAt @map("updated_at")
@@ -77,6 +78,7 @@ model HookRun {
   // Resolved config captured at start (auth still encrypted) so editing/deleting
   // the Hook mid-run cannot corrupt or leak the in-flight run.
   configSnapshotJson String  @map("config_snapshot_json")
+  cursorJson         String? @map("cursor_json") // watch-run change-detection cursor
   error              String?
 
   startedAt  DateTime  @default(now()) @map("started_at")

--- a/apps/api/src/hooks/hook-cdc.service.ts
+++ b/apps/api/src/hooks/hook-cdc.service.ts
@@ -1,0 +1,450 @@
+/**
+ * Event-based ("CDC") hooks for PostgreSQL via **logical replication** — the
+ * same mechanism Debezium/Fivetran use. Changes are streamed from the WAL in
+ * real time (no polling), decoded with the built-in `pgoutput` plugin (no server
+ * extension needed). We auto-provision the publication + replication slot; the
+ * one thing we can't automate is `wal_level=logical` (it needs a server restart),
+ * so `readiness()` checks it and tells the user exactly what to do.
+ *
+ * Scope: PostgreSQL only for now (other engines fall back to polling). A held
+ * replication connection per active hook; the slot persists the confirmed LSN,
+ * so a restart resumes exactly where it left off.
+ */
+import {
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  renderRow,
+  type CdcOperation,
+  type CdcReadiness,
+  type CdcReadinessDTO,
+  type ConnectionConfig,
+  type HookRun,
+} from '@relay/core';
+import { LogicalReplicationService, PgoutputPlugin } from 'pg-logical-replication';
+import { randomUUID } from 'node:crypto';
+import { AdapterPoolService } from '../connections/adapter-pool.service';
+import { ConnectionStoreService } from '../connections/connection-store.service';
+import { PrismaService } from '../common/prisma.service';
+import { DeliveryService } from './delivery.service';
+import { HookRunService } from './hook-run.service';
+import { HookStoreService } from './hook-store.service';
+import type { ResolvedHook } from './hooks.types';
+
+interface Stream {
+  service: LogicalReplicationService;
+  runId: string;
+  seq: number;
+  /** Highest WAL position already processed — guards against replay dupes. */
+  lastLsn: string | null;
+}
+
+/** Read the persisted last-delivered LSN from a run's cursorJson. */
+function lsnOf(cursorJson: string | null): string | null {
+  if (!cursorJson) return null;
+  try {
+    return (JSON.parse(cursorJson) as { lsn?: string }).lsn ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Compare Postgres LSNs ("H/L" hex). Returns true if `a` is strictly after `b`. */
+function lsnAfter(a: string, b: string | null): boolean {
+  if (!b) return true;
+  try {
+    const big = (l: string) => {
+      const [h, lo] = l.split('/');
+      if (!h || !lo) throw new Error('invalid LSN');
+      return (BigInt('0x' + h) << 32n) | BigInt('0x' + lo);
+    };
+    return big(a) > big(b);
+  } catch {
+    // Conservative: treat parse failure as "not after" to avoid duplicate delivery.
+    return false;
+  }
+}
+
+@Injectable()
+export class HookCdcService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger('HookCdc');
+  private readonly streams = new Map<string, Stream>();
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly store: HookStoreService,
+    private readonly connStore: ConnectionStoreService,
+    private readonly pool: AdapterPoolService,
+    private readonly delivery: DeliveryService,
+    private readonly runs: HookRunService,
+  ) {}
+
+  /* ----- readiness (drives the builder's setup panel) ----- */
+
+  async readiness(dto: CdcReadinessDTO): Promise<CdcReadiness> {
+    const conn = await this.connStore.get(dto.connectionId);
+    if (conn.engine !== 'postgres') {
+      return {
+        engine: conn.engine,
+        supported: false,
+        ready: false,
+        checks: [],
+        instructions: [
+          `Event-based (CDC) delivery is currently available for PostgreSQL only. For ${conn.engine}, use the polling trigger instead.`,
+        ],
+      };
+    }
+
+    const checks: CdcReadiness['checks'] = [];
+    const instructions: string[] = [];
+    try {
+      const res = await this.pool.withAdapter(dto.connectionId, dto.database, (a) =>
+        a.query(
+          `select current_setting('wal_level') as wal_level,
+                  (select rolreplication or rolsuper from pg_roles where rolname = current_user) as can_replicate`,
+        ),
+      );
+      const row = (res.rows[0] ?? {}) as { wal_level?: string; can_replicate?: boolean };
+      const logical = row.wal_level === 'logical';
+      const canReplicate = row.can_replicate === true;
+      checks.push({
+        label: 'wal_level = logical',
+        ok: logical,
+        detail: row.wal_level ? `currently "${row.wal_level}"` : undefined,
+      });
+      checks.push({ label: 'role can replicate', ok: canReplicate });
+      if (!logical) {
+        instructions.push(
+          'Set wal_level=logical on the server (postgresql.conf or your provider’s parameter group) and restart it. This is the one step we can’t automate — it needs a server restart.',
+        );
+      }
+      if (!canReplicate) {
+        instructions.push(
+          `Grant replication to the connection's role:  ALTER ROLE "${conn.user ?? 'your_user'}" REPLICATION;`,
+        );
+      }
+      return {
+        engine: 'postgres',
+        supported: true,
+        ready: logical && canReplicate,
+        checks,
+        instructions,
+      };
+    } catch (err) {
+      return {
+        engine: 'postgres',
+        supported: true,
+        ready: false,
+        checks: [{ label: 'connect to database', ok: false, detail: (err as Error).message }],
+        instructions: ['Could not query the database to check readiness.'],
+      };
+    }
+  }
+
+  /* ----- start / stop ----- */
+
+  async start(hookId: string): Promise<HookRun> {
+    const hook = await this.store.resolve(hookId);
+    if (hook.trigger.kind !== 'cdc') {
+      throw new BadRequestError('This hook is not configured for event-based delivery.');
+    }
+    if (hook.source.kind !== 'table') {
+      throw new BadRequestError('Event-based hooks must read from a table.');
+    }
+    const conn = await this.connStore.resolve(hook.source.connectionId);
+    if (conn.engine !== 'postgres') {
+      throw new BadRequestError('Event-based delivery is only available for PostgreSQL.');
+    }
+    const active = await this.prisma.hookRun.findFirst({
+      where: { hookId, status: { in: ['queued', 'running', 'canceling'] } },
+    });
+    if (active) throw new ConflictError('This hook is already running. Stop it first.');
+
+    const ready = await this.readiness({
+      connectionId: hook.source.connectionId,
+      database: hook.source.database,
+      schema: hook.source.schema,
+      table: hook.source.table,
+    });
+    if (!ready.ready) {
+      throw new BadRequestError(
+        `PostgreSQL isn't ready for event-based delivery. ${ready.instructions.join(' ')}`,
+      );
+    }
+
+    await this.provision(hookId, hook);
+
+    // One run per hook: resume the existing (paused) run in place rather than
+    // spawning a new one. The slot remembers the LSN, so it continues cleanly.
+    const latest = await this.prisma.hookRun.findFirst({
+      where: { hookId },
+      orderBy: { startedAt: 'desc' },
+    });
+    const run = latest
+      ? await this.prisma.hookRun.update({
+          where: { id: latest.id },
+          data: { status: 'running', error: null, finishedAt: null },
+        })
+      : await this.prisma.hookRun.create({
+          data: {
+            id: randomUUID(),
+            hookId,
+            status: 'running',
+            configSnapshotJson: await this.store.snapshotJson(hookId),
+            cursorOffset: 0,
+            totalCount: null,
+          },
+        });
+    await this.beginStream(hookId, hook, conn, run.id, run.cursorOffset, lsnOf(run.cursorJson));
+    this.logger.log(`Streaming changes for hook ${hookId} (run ${run.id})`);
+    return this.runs.getRun(hookId, run.id);
+  }
+
+  /** Pause: stop the live stream but keep the slot so a resume continues. */
+  async stop(hookId: string): Promise<HookRun | null> {
+    const stream = this.streams.get(hookId);
+    if (stream) {
+      await stream.service.stop().catch(() => undefined);
+      this.streams.delete(hookId);
+    }
+    const run = await this.prisma.hookRun.findFirst({
+      where: { hookId, status: { in: ['running', 'queued', 'canceling'] } },
+      orderBy: { startedAt: 'desc' },
+    });
+    if (!run) return null;
+    await this.runs.finalize(run.id, 'paused');
+    return this.runs.getRun(hookId, run.id);
+  }
+
+  /** Full teardown when a hook is deleted: stop stream and drop slot + publication. */
+  async cleanup(hookId: string): Promise<void> {
+    const stream = this.streams.get(hookId);
+    if (stream) {
+      await stream.service.stop().catch(() => undefined);
+      this.streams.delete(hookId);
+    }
+    await this.deprovision(hookId).catch(() => undefined);
+  }
+
+  /** Close every replication connection on shutdown — no zombie streamers. */
+  async onModuleDestroy(): Promise<void> {
+    for (const stream of this.streams.values()) {
+      await stream.service.stop().catch(() => undefined);
+    }
+    this.streams.clear();
+  }
+
+  /* ----- the stream ----- */
+
+  private async beginStream(
+    hookId: string,
+    hook: ResolvedHook,
+    conn: ConnectionConfig,
+    runId: string,
+    startSeq: number,
+    startLsn: string | null,
+  ): Promise<void> {
+    if (hook.source.kind !== 'table' || hook.trigger.kind !== 'cdc') return;
+    const src = hook.source;
+    const ops = new Set<CdcOperation>(hook.trigger.operations);
+    const schema = src.schema || 'public';
+
+    const service = new LogicalReplicationService(this.clientConfig(conn, src.database), {
+      acknowledge: { auto: true, timeoutSeconds: 10 },
+      flowControl: { enabled: true }, // backpressure: await each delivery
+    });
+    const stream: Stream = { service, runId, seq: startSeq, lastLsn: startLsn };
+    this.streams.set(hookId, stream);
+
+    service.on('data', async (lsn: string, msg: { tag: string; relation?: { name: string; schema: string }; new?: Record<string, unknown>; old?: Record<string, unknown>; key?: Record<string, unknown> }) => {
+      if (msg.tag !== 'insert' && msg.tag !== 'update' && msg.tag !== 'delete') return;
+      if (!ops.has(msg.tag as CdcOperation)) return;
+      if (!msg.relation || msg.relation.name !== src.table || msg.relation.schema !== schema) {
+        return;
+      }
+      // Strict exactly-once: never re-process a WAL position we've already done
+      // (Postgres replays from the last *acked* LSN after a reconnect).
+      if (!lsnAfter(lsn, stream.lastLsn)) return;
+      const row =
+        msg.tag === 'delete' ? (msg.old ?? msg.key ?? {}) : (msg.new ?? {});
+      await this.deliverChange(hook, stream, row, msg.tag as CdcOperation, lsn);
+    });
+
+    service.on('error', (err: Error) => {
+      this.logger.warn(`CDC stream error for ${hookId}: ${err.message}`);
+    });
+
+    const plugin = new PgoutputPlugin({
+      protoVersion: 1,
+      publicationNames: [this.pubName(hookId)],
+    });
+    // Resumes from the slot's confirmed LSN automatically.
+    service.subscribe(plugin, this.slotName(hookId)).catch((err: Error) => {
+      this.logger.warn(`CDC subscribe failed for ${hookId}: ${err.message}`);
+    });
+  }
+
+  private async deliverChange(
+    hook: ResolvedHook,
+    stream: Stream,
+    row: Record<string, unknown>,
+    op: CdcOperation,
+    lsn: string,
+  ): Promise<void> {
+    if (hook.source.kind !== 'table') return;
+    const seq = stream.seq;
+    const now = new Date().toISOString();
+    // Expose the change operation to the template as {{$op}}.
+    const { body } = renderRow({ ...row, $op: op }, hook.transform, {
+      table: hook.source.table,
+      now,
+      index: seq,
+    });
+    // Key on the LSN (stable per WAL change) so an at-least-once re-delivery
+    // after a reconnect carries the SAME Idempotency-Key for the receiver to
+    // dedupe — unlike the sequence, which changes on replay.
+    const idem = hook.destination.idempotency ? `${stream.runId}:${lsn}` : undefined;
+    const signal = new AbortController().signal;
+    const outcome = await this.delivery.send(
+      body,
+      hook.destination,
+      hook.delivery,
+      signal,
+      idem,
+    );
+    const pkVals = Object.values(row);
+    await this.runs.recordDelivery(
+      stream.runId,
+      { sequence: seq, rowIndex: seq, rowCount: 1, rowKeys: pkVals.length ? pkVals : null },
+      outcome,
+    );
+    stream.seq = seq + 1;
+    stream.lastLsn = lsn; // advance the dedupe watermark (durably persisted below)
+    await this.prisma.hookRun.update({
+      where: { id: stream.runId },
+      data: { cursorOffset: stream.seq, cursorJson: JSON.stringify({ lsn }) },
+    });
+  }
+
+  /* ----- provisioning ----- */
+
+  private pubName(hookId: string): string {
+    return `relay_pub_${hookId.replace(/-/g, '')}`;
+  }
+  private slotName(hookId: string): string {
+    return `relay_slot_${hookId.replace(/-/g, '')}`;
+  }
+  private quoteIdent(id: string): string {
+    return `"${id.replace(/"/g, '""')}"`;
+  }
+
+  private async provision(hookId: string, hook: ResolvedHook): Promise<void> {
+    if (hook.source.kind !== 'table') return;
+    const src = hook.source;
+    const schema = src.schema || 'public';
+    const pub = this.pubName(hookId);
+    const slot = this.slotName(hookId);
+    const target = `${this.quoteIdent(schema)}.${this.quoteIdent(src.table)}`;
+
+    await this.pool.withAdapter(src.connectionId, src.database, async (a) => {
+      // Check if the publication exists and is for the correct table. If the
+      // user edited the hook to change the source table, we must update the
+      // publication — otherwise we'd silently stream the old table's changes.
+      const pubInfo = await a.query(
+        `select pub.pubname, cls.relname as tablename
+         from pg_publication pub
+         join pg_publication_tables pt on pt.pubname = pub.pubname
+         join pg_class cls on cls.relname = pt.tablename
+         where pub.pubname = $1`,
+        [pub],
+      );
+      const existingTable = (pubInfo.rows[0] as { tablename?: string } | undefined)?.tablename;
+      if (pubInfo.rows.length === 0) {
+        await a.query(`CREATE PUBLICATION ${this.quoteIdent(pub)} FOR TABLE ${target}`);
+      } else if (existingTable !== src.table) {
+        // Table changed — update the publication in place so the slot keeps its position.
+        await a.query(
+          `ALTER PUBLICATION ${this.quoteIdent(pub)} SET TABLE ${target}`,
+        );
+        this.logger.log(`Updated CDC publication "${pub}" to target table "${src.table}"`);
+      }
+
+      const hasSlot = await a.query(
+        `select 1 from pg_replication_slots where slot_name = $1`,
+        [slot],
+      );
+      if (hasSlot.rows.length === 0) {
+        await a.query(`select pg_create_logical_replication_slot($1, 'pgoutput')`, [slot]);
+      }
+    });
+  }
+
+  private async deprovision(hookId: string): Promise<void> {
+    const run = await this.prisma.hookRun.findFirst({
+      where: { hookId },
+      orderBy: { startedAt: 'desc' },
+      select: { configSnapshotJson: true },
+    });
+    if (!run) return;
+    const snap = JSON.parse(run.configSnapshotJson) as { source: ResolvedHook['source'] };
+    if (snap.source.kind !== 'table') return;
+    const slot = this.slotName(hookId);
+    const pub = this.pubName(hookId);
+    await this.pool.withAdapter(snap.source.connectionId, snap.source.database, async (a) => {
+      await a
+        .query(
+          `select pg_drop_replication_slot($1) where exists (select 1 from pg_replication_slots where slot_name = $1 and active = false)`,
+          [slot],
+        )
+        .catch(() => undefined);
+      await a.query(`DROP PUBLICATION IF EXISTS ${this.quoteIdent(pub)}`).catch(() => undefined);
+    });
+  }
+
+  private clientConfig(conn: ConnectionConfig, database?: string) {
+    if (conn.connectionString) {
+      return { connectionString: conn.connectionString } as Record<string, unknown>;
+    }
+    return {
+      host: conn.host,
+      port: conn.port,
+      user: conn.user,
+      password: conn.password,
+      database: database || conn.database,
+      ssl: conn.ssl ? { rejectUnauthorized: false } : undefined,
+    } as Record<string, unknown>;
+  }
+
+  /* ----- boot recovery ----- */
+
+  async onModuleInit(): Promise<void> {
+    let runs: { hookId: string; id: string; cursorOffset: number; cursorJson: string | null }[];
+    try {
+      // All live runs; we keep only the ones whose hook is a CDC hook below.
+      runs = await this.prisma.hookRun.findMany({
+        where: { status: 'running' },
+        select: { hookId: true, id: true, cursorOffset: true, cursorJson: true },
+      });
+    } catch {
+      return;
+    }
+    for (const r of runs) {
+      try {
+        const hook = await this.store.resolve(r.hookId);
+        if (hook.trigger.kind !== 'cdc' || !hook.enabled || hook.source.kind !== 'table') continue;
+        const conn = await this.connStore.resolve(hook.source.connectionId);
+        if (conn.engine !== 'postgres') continue;
+        await this.beginStream(r.hookId, hook, conn, r.id, r.cursorOffset, lsnOf(r.cursorJson));
+        this.logger.log(`Resumed CDC stream for hook ${r.hookId}`);
+      } catch (err) {
+        this.logger.warn(`Could not resume CDC ${r.hookId}: ${(err as Error).message}`);
+      }
+    }
+  }
+}

--- a/apps/api/src/hooks/hook-run.processor.ts
+++ b/apps/api/src/hooks/hook-run.processor.ts
@@ -15,7 +15,13 @@
  */
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
-import { BadRequestError, renderBatch, renderRow, type SortSpec } from '@relay/core';
+import {
+  BadRequestError,
+  renderBatch,
+  renderRow,
+  type BrowseParams,
+  type SortSpec,
+} from '@relay/core';
 import type { Job } from 'bullmq';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { runtimeConfig } from '../common/runtime-config';
@@ -212,21 +218,64 @@ export class HookRunProcessor extends WorkerHost {
   ): AsyncGenerator<StreamItem> {
     if (hook.source.kind !== 'table') return;
     const src = hook.source;
-    const { sort, total } = await this.resolveTableOrder(hook);
+    const { sort, total, keysetColumn } = await this.resolveTableOrder(hook);
     await this.runs.setTotal(runId, total);
+    const pageSize = hook.delivery.pageSize;
+    const browse = (params: BrowseParams) =>
+      this.pool.withAdapter(src.connectionId, src.database, (a) => a.browse(params));
 
-    let offset = startOffset;
-    for (;;) {
-      const page = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
-        a.browse({
+    // Keyset pagination on a unique key — O(1) per page regardless of how deep
+    // we are, so a multi-million-row replay stays fast (no OFFSET re-scan).
+    if (keysetColumn) {
+      let lastKey: unknown = null;
+      let index = startOffset;
+      if (startOffset > 0) {
+        // Resume: find the key of the last already-delivered row (one seek).
+        const seek = await browse({
           schema: src.schema,
           table: src.table,
           filters: src.filters,
           sort,
-          limit: hook.delivery.pageSize,
-          offset,
-        }),
-      );
+          limit: 1,
+          offset: startOffset - 1,
+        });
+        lastKey = seek.rows[0]?.[keysetColumn] ?? null;
+      }
+      for (;;) {
+        const filters = [
+          ...(src.filters ?? []),
+          ...(lastKey != null
+            ? [{ column: keysetColumn, operator: 'gt' as const, value: lastKey }]
+            : []),
+        ];
+        const page = await browse({
+          schema: src.schema,
+          table: src.table,
+          filters,
+          sort,
+          limit: pageSize,
+          offset: 0,
+        });
+        for (const row of page.rows) {
+          yield { row, index };
+          index++;
+          lastKey = row[keysetColumn];
+        }
+        if (!page.hasMore || page.rows.length === 0) return;
+      }
+    }
+
+    // Fallback: OFFSET pagination (composite key or custom non-unique sort).
+    let offset = startOffset;
+    for (;;) {
+      const page = await browse({
+        schema: src.schema,
+        table: src.table,
+        filters: src.filters,
+        sort,
+        limit: pageSize,
+        offset,
+      });
       for (let i = 0; i < page.rows.length; i++) {
         yield { row: page.rows[i]!, index: offset + i };
       }
@@ -237,21 +286,33 @@ export class HookRunProcessor extends WorkerHost {
 
   /**
    * A stable order is mandatory: `LIMIT/OFFSET` without `ORDER BY` can skip or
-   * repeat rows across pages. Use the caller's sort, else the primary key.
+   * repeat rows across pages. Use the caller's sort, else the primary key, and
+   * report whether we can keyset-paginate (single, uniquely-ordered key).
    */
   private async resolveTableOrder(
     hook: ResolvedHook,
-  ): Promise<{ sort: SortSpec[]; total: number | null }> {
-    if (hook.source.kind !== 'table') return { sort: [], total: null };
+  ): Promise<{ sort: SortSpec[]; total: number | null; keysetColumn: string | null }> {
+    if (hook.source.kind !== 'table') return { sort: [], total: null, keysetColumn: null };
     const src = hook.source;
     const probe = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
       a.browse({ schema: src.schema, table: src.table, filters: src.filters, limit: 1, offset: 0 }),
     );
-    if (src.sort && src.sort.length > 0) return { sort: src.sort, total: probe.total };
+    const singlePk = probe.primaryKey.length === 1 ? probe.primaryKey[0]! : null;
+
+    if (src.sort && src.sort.length > 0) {
+      // Keyset only if the caller's order is exactly the (unique) primary key asc.
+      const s = src.sort;
+      const keyset =
+        s.length === 1 && s[0]!.column === singlePk && s[0]!.direction === 'asc'
+          ? singlePk
+          : null;
+      return { sort: src.sort, total: probe.total, keysetColumn: keyset };
+    }
     if (probe.primaryKey.length > 0) {
       return {
         sort: probe.primaryKey.map((column) => ({ column, direction: 'asc' as const })),
         total: probe.total,
+        keysetColumn: singlePk,
       };
     }
     throw new BadRequestError(

--- a/apps/api/src/hooks/hook-run.service.ts
+++ b/apps/api/src/hooks/hook-run.service.ts
@@ -14,6 +14,7 @@ import {
   AppError,
   BadRequestError,
   ConflictError,
+  type DeliveryStatus,
   type HookDelivery,
   type HookRun,
   type HookRunStatus,
@@ -27,6 +28,7 @@ import type {
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { PrismaService } from '../common/prisma.service';
 import { HookStoreService } from './hook-store.service';
+import { DeliveryService, sleep } from './delivery.service';
 import { RunRegistryService } from './run-registry.service';
 import {
   HOOK_RUNS_QUEUE,
@@ -51,8 +53,59 @@ export class HookRunService implements OnModuleInit {
     private readonly store: HookStoreService,
     private readonly registry: RunRegistryService,
     private readonly pool: AdapterPoolService,
+    private readonly delivery: DeliveryService,
     @InjectQueue(HOOK_RUNS_QUEUE) private readonly queue: Queue<HookRunJob>,
   ) {}
+
+  /**
+   * Re-send the failed deliveries of a run by re-POSTing their captured request
+   * bodies to the hook's CURRENT destination. Works for every hook type
+   * (replay / watch / cdc) — ideal after fixing a bad URL or a down endpoint.
+   * A delivery that succeeds flips from failed → success (counters adjust).
+   */
+  async resendFailed(hookId: string, runId: string): Promise<HookRun> {
+    const run = await this.getRunRow(runId);
+    if (run.hookId !== hookId) throw new NotFoundError(`Run "${runId}" not found`);
+    const hook = await this.store.resolve(hookId);
+    const failed = await this.prisma.hookDelivery.findMany({
+      where: { runId, status: 'failed' },
+      orderBy: { sequence: 'asc' },
+      take: 2000,
+    });
+    if (failed.length === 0) throw new BadRequestError('No failed deliveries to retry.');
+
+    const signal = new AbortController().signal;
+    for (const d of failed) {
+      let body: unknown = null;
+      if (d.requestBody) {
+        try {
+          body = JSON.parse(d.requestBody);
+        } catch {
+          body = d.requestBody;
+        }
+      }
+      const idem = hook.destination.idempotency ? `${runId}:${d.sequence}` : undefined;
+      const outcome = await this.delivery.send(
+        body,
+        hook.destination,
+        hook.delivery,
+        signal,
+        idem,
+      );
+      await this.recordDelivery(
+        runId,
+        {
+          sequence: d.sequence,
+          rowIndex: d.rowIndex,
+          rowCount: d.rowCount,
+          rowKeys: d.rowKeysJson ? (JSON.parse(d.rowKeysJson) as unknown[]) : null,
+        },
+        outcome,
+      );
+      if (hook.delivery.minDelayMs) await sleep(hook.delivery.minDelayMs);
+    }
+    return this.getRun(hookId, runId);
+  }
 
   /* ----- prepare (queue without sending) ----- */
 
@@ -65,7 +118,9 @@ export class HookRunService implements OnModuleInit {
     hookId: string,
     opts: { onlyExisting?: boolean } = {},
   ): Promise<HookRun | null> {
-    await this.store.get(hookId);
+    const hook = await this.store.get(hookId);
+    // Drafts model a finite replay; watch hooks are live listeners, not drafts.
+    if (hook.trigger.kind !== 'replay') return null;
     // Don't clobber an in-flight run with a draft.
     const active = await this.prisma.hookRun.findFirst({
       where: { hookId, status: { in: ACTIVE } },
@@ -128,6 +183,14 @@ export class HookRunService implements OnModuleInit {
         'A run is already in progress for this hook. Cancel it before starting another.',
       );
     }
+
+    // Resume the most recent paused/stopped run in place (one run per job)
+    // rather than spawning a new one each time. A finished run starts fresh.
+    const latest = await this.prisma.hookRun.findFirst({
+      where: { hookId, status: { in: ['paused', 'canceled', 'interrupted', 'failed'] } },
+      orderBy: { startedAt: 'desc' },
+    });
+    if (latest) return this.resume(hookId, latest.id);
 
     await this.ensureQueueReady();
     const id = randomUUID();
@@ -213,10 +276,8 @@ export class HookRunService implements OnModuleInit {
     const row = await this.getRunRow(runId);
     if (row.hookId !== hookId)
       throw new NotFoundError(`Run "${runId}" not found`);
-    if (
-      !TERMINAL.includes(row.status as HookRunStatus) ||
-      row.status === 'completed'
-    ) {
+    const resumable: HookRunStatus[] = ['failed', 'canceled', 'paused', 'interrupted'];
+    if (!resumable.includes(row.status as HookRunStatus)) {
       throw new ConflictError(
         `Run "${runId}" cannot be resumed (status: ${row.status}).`,
       );
@@ -338,6 +399,8 @@ export class HookRunService implements OnModuleInit {
   async skipDeliveries(runId: string, sequences: number[]): Promise<number> {
     const run = await this.getRunRow(runId);
     const batchSize = this.snapshotBatchSize(run.configSnapshotJson);
+    const totalCount = run.totalCount;
+
     const existing = await this.prisma.hookDelivery.findMany({
       where: { runId, sequence: { in: sequences } },
       select: { sequence: true },
@@ -346,6 +409,20 @@ export class HookRunService implements OnModuleInit {
     const fresh = [...new Set(sequences)].filter((s) => !taken.has(s));
     if (fresh.length === 0) return 0;
 
+    // Compute the actual row count for each sequence. The last batch may be
+    // smaller than batchSize when totalCount is not perfectly divisible.
+    const lastSeq =
+      totalCount != null ? Math.ceil(totalCount / batchSize) - 1 : null;
+    const lastBatchSize =
+      lastSeq != null && totalCount != null
+        ? totalCount - lastSeq * batchSize
+        : batchSize;
+
+    const rowCountFor = (seq: number): number =>
+      lastSeq != null && seq === lastSeq ? lastBatchSize : batchSize;
+
+    const skippedRows = fresh.reduce((acc, s) => acc + rowCountFor(s), 0);
+
     await this.prisma.$transaction([
       this.prisma.hookDelivery.createMany({
         data: fresh.map((sequence) => ({
@@ -353,14 +430,14 @@ export class HookRunService implements OnModuleInit {
           runId,
           sequence,
           rowIndex: sequence * batchSize,
-          rowCount: batchSize,
+          rowCount: rowCountFor(sequence),
           status: 'skipped',
           attempts: 0,
         })),
       }),
       this.prisma.hookRun.update({
         where: { id: runId },
-        data: { skippedCount: { increment: fresh.length * batchSize } },
+        data: { skippedCount: { increment: skippedRows } },
       }),
     ]);
     return fresh.length;
@@ -533,16 +610,21 @@ export class HookRunService implements OnModuleInit {
       this.logger.warn(`Skipped run recovery: ${(err as Error).message}`);
       return;
     }
+    let recovered = 0;
     for (const r of rows) {
+      // Only replay runs belong to this queue. Watch/CDC runs are also `running`
+      // but are owned by their own services — never re-enqueue those here.
+      const hook = await this.store.get(r.hookId).catch(() => null);
+      if (!hook || hook.trigger.kind !== 'replay') continue;
       // Deterministic jobId means this is a no-op if the job already exists.
       await this.enqueue(r.id, r.hookId).catch((err) =>
         this.logger.warn(
           `Could not re-enqueue run ${r.id}: ${(err as Error).message}`,
         ),
       );
+      recovered++;
     }
-    if (rows.length)
-      this.logger.log(`Recovered ${rows.length} interrupted hook run(s)`);
+    if (recovered) this.logger.log(`Recovered ${recovered} interrupted replay run(s)`);
   }
 
   /* ----- mappers ----- */
@@ -557,6 +639,7 @@ export class HookRunService implements OnModuleInit {
       failedCount: row.failedCount,
       skippedCount: row.skippedCount,
       totalCount: row.totalCount,
+      batchSize: this.snapshotBatchSize(row.configSnapshotJson),
       error: row.error,
       startedAt: row.startedAt.toISOString(),
       finishedAt: row.finishedAt ? row.finishedAt.toISOString() : null,
@@ -570,7 +653,7 @@ export class HookRunService implements OnModuleInit {
       sequence: row.sequence,
       rowIndex: row.rowIndex,
       rowCount: row.rowCount,
-      status: row.status as 'success' | 'failed',
+      status: row.status as DeliveryStatus,
       httpStatus: row.httpStatus,
       attempts: row.attempts,
       error: row.error,

--- a/apps/api/src/hooks/hook-store.service.ts
+++ b/apps/api/src/hooks/hook-store.service.ts
@@ -95,6 +95,7 @@ export class HookStoreService {
       destination: this.withSecret(sanitized, secret),
       transform: JSON.parse(row.transformJson),
       delivery: JSON.parse(row.deliveryJson),
+      trigger: row.triggerJson ? JSON.parse(row.triggerJson) : { kind: 'replay' },
       enabled: row.enabled,
       createdAt: row.createdAt.toISOString(),
       updatedAt: row.updatedAt.toISOString(),
@@ -136,6 +137,7 @@ export class HookStoreService {
         authEnc: secret ? this.crypto.encrypt(secret) : null,
         transformJson: JSON.stringify(input.transform),
         deliveryJson: JSON.stringify(input.delivery),
+        triggerJson: JSON.stringify(input.trigger),
         enabled: input.enabled,
       },
     });
@@ -164,6 +166,7 @@ export class HookStoreService {
         authEnc,
         transformJson: JSON.stringify(input.transform),
         deliveryJson: JSON.stringify(input.delivery),
+        triggerJson: JSON.stringify(input.trigger),
         enabled: input.enabled,
       },
     });
@@ -201,6 +204,9 @@ export class HookStoreService {
       destination: this.withSecret(s.destination, this.decryptSecret(s.authEnc)),
       transform: s.transform,
       delivery: s.delivery,
+      // A snapshot is only used to execute a replay run; the trigger is resolved
+      // live for watch hooks, so a placeholder is fine here.
+      trigger: { kind: 'replay' },
       enabled: true,
     };
   }

--- a/apps/api/src/hooks/hook-watch.processor.ts
+++ b/apps/api/src/hooks/hook-watch.processor.ts
@@ -1,0 +1,16 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import type { Job } from 'bullmq';
+import { HookWatchService } from './hook-watch.service';
+import { HOOK_WATCH_QUEUE, type HookWatchJob } from './hooks.types';
+
+/** Each scheduled fire is one poll cycle for a watch hook. */
+@Processor(HOOK_WATCH_QUEUE, { concurrency: 8 })
+export class HookWatchProcessor extends WorkerHost {
+  constructor(private readonly watch: HookWatchService) {
+    super();
+  }
+
+  async process(job: Job<HookWatchJob>): Promise<void> {
+    await this.watch.poll(job.data.hookId);
+  }
+}

--- a/apps/api/src/hooks/hook-watch.service.ts
+++ b/apps/api/src/hooks/hook-watch.service.ts
@@ -1,0 +1,371 @@
+/**
+ * "Watch" hooks: live listeners that poll a table for new rows and deliver them
+ * as they appear. Each watch hook drives a single long-lived "watch run" (status
+ * `running`) plus a BullMQ **job scheduler** that fires a poll every
+ * `pollIntervalMs`. Schedulers persist in Redis, so listening survives restarts;
+ * `onModuleInit` re-registers any that should still be active.
+ *
+ * The change-detection itself is the pure engine in `@relay/core` (`watchQuery`
+ * / `advanceCursor`); this service is the I/O around it — fetch a page, deliver
+ * the new rows, persist the advanced cursor.
+ */
+import { randomUUID } from 'node:crypto';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+import {
+  AppError,
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  advanceCursor,
+  emptyCursor,
+  renderRow,
+  rowKey,
+  watchQuery,
+  watchStrategySchema,
+  type HookRun,
+  type WatchCursor,
+} from '@relay/core';
+import { Queue } from 'bullmq';
+import { AdapterPoolService } from '../connections/adapter-pool.service';
+import { PrismaService } from '../common/prisma.service';
+import { DeliveryService, sleep } from './delivery.service';
+import { HookRunService } from './hook-run.service';
+import { HookStoreService } from './hook-store.service';
+import type { ResolvedHook } from './hooks.types';
+import { HOOK_WATCH_QUEUE, type HookWatchJob } from './hooks.types';
+
+@Injectable()
+export class HookWatchService implements OnModuleInit {
+  private readonly logger = new Logger('HookWatch');
+  /** In-process guard: never poll the same hook concurrently (single worker). */
+  private readonly polling = new Set<string>();
+  /** Adaptive cadence: empty-poll streak + currently-scheduled interval per hook. */
+  private readonly emptyStreak = new Map<string, number>();
+  private readonly scheduledEvery = new Map<string, number>();
+
+  /** Fastest cadence (ms) when rows are actively flowing. */
+  private static readonly FAST_MS = 1000;
+  /** Stay fast for this many empty polls after activity before backing off. */
+  private static readonly COOLDOWN_POLLS = 4;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly store: HookStoreService,
+    private readonly pool: AdapterPoolService,
+    private readonly delivery: DeliveryService,
+    private readonly runs: HookRunService,
+    @InjectQueue(HOOK_WATCH_QUEUE) private readonly queue: Queue<HookWatchJob>,
+  ) {}
+
+  /* ----- start / stop ----- */
+
+  async start(hookId: string): Promise<HookRun> {
+    const hook = await this.store.resolve(hookId);
+    if (hook.trigger.kind !== 'watch') {
+      throw new BadRequestError('This hook is not configured to listen.');
+    }
+    if (hook.source.kind !== 'table') {
+      throw new BadRequestError('Watch hooks must read from a table.');
+    }
+    const active = await this.prisma.hookRun.findFirst({
+      where: { hookId, status: { in: ['queued', 'running', 'canceling'] } },
+    });
+    if (active) {
+      throw new ConflictError('This hook is already running. Stop it first.');
+    }
+
+    await this.ensureQueueReady();
+    // One run per hook: resume the existing (paused) run in place, keeping its
+    // cursor, rather than spawning a new one each time.
+    const latest = await this.prisma.hookRun.findFirst({
+      where: { hookId },
+      orderBy: { startedAt: 'desc' },
+    });
+    const run =
+      latest && latest.cursorJson
+        ? await this.prisma.hookRun.update({
+            where: { id: latest.id },
+            data: { status: 'running', error: null, finishedAt: null },
+          })
+        : await this.prisma.hookRun.create({
+            data: {
+              id: randomUUID(),
+              hookId,
+              status: 'running',
+              configSnapshotJson: await this.store.snapshotJson(hookId),
+              cursorJson: JSON.stringify(await this.initialCursor(hook)),
+              cursorOffset: 0,
+              totalCount: null,
+            },
+          });
+    // Start responsive; adapt() eases off when the table goes quiet.
+    const fast = Math.min(HookWatchService.FAST_MS, hook.trigger.pollIntervalMs);
+    this.emptyStreak.set(hookId, 0);
+    this.scheduledEvery.set(hookId, fast);
+    await this.schedule(hookId, fast);
+    this.logger.log(`Listening on hook ${hookId} (run ${run.id})`);
+    return this.runs.getRun(hookId, run.id);
+  }
+
+  async stop(hookId: string): Promise<HookRun | null> {
+    await this.unschedule(hookId);
+    const run = await this.prisma.hookRun.findFirst({
+      where: { hookId, status: { in: ['running', 'queued', 'canceling'] } },
+      orderBy: { startedAt: 'desc' },
+    });
+    if (!run) return null;
+    await this.runs.finalize(run.id, 'paused');
+    return this.runs.getRun(hookId, run.id);
+  }
+
+  /* ----- the poll cycle (invoked by the processor) ----- */
+
+  async poll(hookId: string): Promise<void> {
+    if (this.polling.has(hookId)) return; // skip overlapping fires
+    this.polling.add(hookId);
+    try {
+      await this.runPoll(hookId);
+    } catch (err) {
+      this.logger.warn(`Watch poll for ${hookId} failed: ${(err as Error).message}`);
+    } finally {
+      this.polling.delete(hookId);
+    }
+  }
+
+  private async runPoll(hookId: string): Promise<void> {
+    const run = await this.prisma.hookRun.findFirst({
+      where: { hookId, status: 'running', cursorJson: { not: null } },
+      orderBy: { startedAt: 'desc' },
+    });
+    if (!run) {
+      // Nothing is listening (stopped/never started) — retire the scheduler.
+      await this.unschedule(hookId);
+      return;
+    }
+
+    const hook = await this.store.resolve(hookId);
+    if (!hook.enabled || hook.trigger.kind !== 'watch' || hook.source.kind !== 'table') {
+      await this.runs.finalize(run.id, 'canceled');
+      await this.unschedule(hookId);
+      return;
+    }
+
+    const strategy = watchStrategySchema.parse(hook.trigger.strategy);
+    let cursor: WatchCursor;
+    try {
+      cursor = JSON.parse(run.cursorJson!) as WatchCursor;
+    } catch {
+      const msg = `Watch run ${run.id} has an unparseable cursor — marking it failed so the user can restart cleanly.`;
+      this.logger.error(msg);
+      await this.runs.finalize(run.id, 'failed', msg);
+      await this.unschedule(hookId);
+      return;
+    }
+    const { filters, sort } = watchQuery(strategy, cursor);
+    const src = hook.source;
+    const limit =
+      strategy.strategy === 'snapshot'
+        ? Math.min(strategy.maxTracked, 1000)
+        : hook.trigger.maxPerPoll;
+
+    const page = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
+      a.browse({
+        schema: src.schema,
+        table: src.table,
+        filters: filters.length ? filters : undefined,
+        sort: sort.length ? sort : undefined,
+        limit: Math.min(limit, 1000),
+        offset: 0,
+      }),
+    );
+    const pk = page.primaryKey;
+    const { newRows, cursor: next } = advanceCursor(strategy, cursor, page.rows, pk);
+
+    const signal = new AbortController().signal;
+    let seq = run.cursorOffset;
+    for (const row of newRows) {
+      const now = new Date().toISOString();
+      const { body } = renderRow(row, hook.transform, {
+        table: src.table,
+        now,
+        index: seq,
+      });
+      const idem = hook.destination.idempotency ? `${run.id}:${seq}` : undefined;
+      const outcome = await this.delivery.send(
+        body,
+        hook.destination,
+        hook.delivery,
+        signal,
+        idem,
+      );
+      await this.runs.recordDelivery(
+        run.id,
+        {
+          sequence: seq,
+          rowIndex: seq,
+          rowCount: 1,
+          rowKeys: pk.length ? pk.map((c) => row[c]) : null,
+        },
+        outcome,
+      );
+      seq++;
+      if (hook.delivery.minDelayMs) await sleep(hook.delivery.minDelayMs);
+    }
+
+    await this.prisma.hookRun.update({
+      where: { id: run.id },
+      data: { cursorJson: JSON.stringify(next), cursorOffset: seq },
+    });
+
+    await this.adapt(hookId, hook.trigger.pollIntervalMs, newRows.length > 0);
+  }
+
+  /**
+   * Adaptive cadence: poll fast while rows are flowing, then ease back to the
+   * configured (idle) interval after a short cooldown. This keeps a busy table
+   * near-real-time while a quiet one barely touches the database — all without
+   * any DB-side changes.
+   */
+  private async adapt(hookId: string, idleMs: number, hadRows: boolean): Promise<void> {
+    const fast = Math.min(HookWatchService.FAST_MS, idleMs);
+    const streak = hadRows ? 0 : (this.emptyStreak.get(hookId) ?? 0) + 1;
+    this.emptyStreak.set(hookId, streak);
+    const desired = streak < HookWatchService.COOLDOWN_POLLS ? fast : idleMs;
+    if (this.scheduledEvery.get(hookId) !== desired) {
+      this.scheduledEvery.set(hookId, desired);
+      await this.schedule(hookId, desired);
+    }
+  }
+
+  /* ----- initial cursor (so `startFrom: now` ignores existing rows) ----- */
+
+  private async initialCursor(hook: ResolvedHook): Promise<WatchCursor> {
+    if (hook.trigger.kind !== 'watch' || hook.source.kind !== 'table') {
+      throw new BadRequestError('Watch hooks must read from a table.');
+    }
+    const strategy = watchStrategySchema.parse(hook.trigger.strategy);
+    if (hook.trigger.startFrom === 'beginning') return emptyCursor(strategy);
+
+    const src = hook.source;
+    const cid = src.connectionId;
+    const db = src.database;
+
+    if (strategy.strategy === 'increment') {
+      const page = await this.pool.withAdapter(cid, db, (a) =>
+        a.browse({
+          schema: src.schema,
+          table: src.table,
+          sort: [{ column: strategy.column, direction: 'desc' }],
+          limit: 1,
+          offset: 0,
+        }),
+      );
+      return { strategy: 'increment', value: page.rows[0]?.[strategy.column] ?? null };
+    }
+
+    if (strategy.strategy === 'timestamp') {
+      const top = await this.pool.withAdapter(cid, db, (a) =>
+        a.browse({
+          schema: src.schema,
+          table: src.table,
+          sort: [{ column: strategy.column, direction: 'desc' }],
+          limit: 1,
+          offset: 0,
+        }),
+      );
+      const maxTs = top.rows[0]?.[strategy.column];
+      if (maxTs == null) return emptyCursor(strategy);
+      // Remember every row already at the max timestamp so they aren't re-sent.
+      const at = await this.pool.withAdapter(cid, db, (a) =>
+        a.browse({
+          schema: src.schema,
+          table: src.table,
+          filters: [{ column: strategy.column, operator: 'gte', value: maxTs }],
+          sort: [{ column: strategy.column, direction: 'asc' }],
+          limit: 1000,
+          offset: 0,
+        }),
+      );
+      return {
+        strategy: 'timestamp',
+        ts: maxTs instanceof Date ? maxTs.toISOString() : maxTs,
+        boundaryKeys: at.rows.map((r) => rowKey(r, at.primaryKey)),
+      };
+    }
+
+    // snapshot: seed the seen-set with current primary keys (bounded).
+    const page = await this.pool.withAdapter(cid, db, (a) =>
+      a.browse({
+        schema: src.schema,
+        table: src.table,
+        limit: Math.min(strategy.maxTracked, 1000),
+        offset: 0,
+      }),
+    );
+    return { strategy: 'snapshot', seen: page.rows.map((r) => rowKey(r, page.primaryKey)) };
+  }
+
+  /* ----- scheduler plumbing ----- */
+
+  private schedulerId(hookId: string): string {
+    return `watch:${hookId}`;
+  }
+
+  private async schedule(hookId: string, every: number): Promise<void> {
+    await this.queue.upsertJobScheduler(
+      this.schedulerId(hookId),
+      { every },
+      { name: 'poll', data: { hookId } },
+    );
+  }
+
+  private async unschedule(hookId: string): Promise<void> {
+    this.emptyStreak.delete(hookId);
+    this.scheduledEvery.delete(hookId);
+    await this.queue.removeJobScheduler(this.schedulerId(hookId)).catch(() => false);
+  }
+
+  private async ensureQueueReady(): Promise<void> {
+    try {
+      await Promise.race([
+        this.queue.waitUntilReady(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), 2000),
+        ),
+      ]);
+    } catch {
+      throw new AppError(
+        'CONNECTION_FAILED',
+        'The job queue (Redis) is unavailable. Start it with `docker compose up -d redis` or set REDIS_URL.',
+        503,
+      );
+    }
+  }
+
+  /* ----- boot recovery ----- */
+
+  async onModuleInit(): Promise<void> {
+    let rows: { hookId: string }[];
+    try {
+      rows = await this.prisma.hookRun.findMany({
+        where: { status: 'running', cursorJson: { not: null } },
+        select: { hookId: true },
+      });
+    } catch (err) {
+      this.logger.warn(`Skipped watch recovery: ${(err as Error).message}`);
+      return;
+    }
+    for (const { hookId } of rows) {
+      try {
+        const hook = await this.store.get(hookId);
+        if (hook.trigger.kind === 'watch' && hook.enabled) {
+          await this.schedule(hookId, hook.trigger.pollIntervalMs);
+        }
+      } catch (err) {
+        this.logger.warn(`Could not resume watch ${hookId}: ${(err as Error).message}`);
+      }
+    }
+    if (rows.length) this.logger.log(`Resumed ${rows.length} watch listener(s)`);
+  }
+}

--- a/apps/api/src/hooks/hooks.controller.ts
+++ b/apps/api/src/hooks/hooks.controller.ts
@@ -17,6 +17,9 @@ import {
   type HookRun,
   type StartRunDTO,
   type SkipDTO,
+  type CdcReadiness,
+  type CdcReadinessDTO,
+  cdcReadinessSchema,
   hookInputSchema,
   hookPreviewSchema,
   renderRow,
@@ -26,14 +29,18 @@ import {
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { DeliveryService } from './delivery.service';
+import { HookCdcService } from './hook-cdc.service';
 import { HookRunService } from './hook-run.service';
 import { HookStoreService } from './hook-store.service';
+import { HookWatchService } from './hook-watch.service';
 
 @Controller('hooks')
 export class HooksController {
   constructor(
     private readonly store: HookStoreService,
     private readonly runs: HookRunService,
+    private readonly watch: HookWatchService,
+    private readonly cdc: HookCdcService,
     private readonly pool: AdapterPoolService,
     private readonly delivery: DeliveryService,
   ) {}
@@ -73,6 +80,10 @@ export class HooksController {
 
   @Delete(':id')
   async remove(@Param('id') id: string): Promise<{ id: string }> {
+    // Tear down any live listener BEFORE deleting (CDC drops its slot/publication).
+    const hook = await this.store.get(id).catch(() => null);
+    if (hook?.trigger.kind === 'cdc') await this.cdc.cleanup(id).catch(() => undefined);
+    else if (hook?.trigger.kind === 'watch') await this.watch.stop(id).catch(() => undefined);
     await this.store.remove(id);
     return { id };
   }
@@ -153,6 +164,27 @@ export class HooksController {
     return this.runs.start(id, dto);
   }
 
+  /* ----- live listening (polling watch OR event-based CDC) ----- */
+
+  @Post('cdc/readiness')
+  cdcReadiness(
+    @Body(new ZodValidationPipe(cdcReadinessSchema)) dto: CdcReadinessDTO,
+  ): Promise<CdcReadiness> {
+    return this.cdc.readiness(dto);
+  }
+
+  @Post(':id/watch/start')
+  async startWatch(@Param('id') id: string): Promise<HookRun> {
+    const hook = await this.store.get(id);
+    return hook.trigger.kind === 'cdc' ? this.cdc.start(id) : this.watch.start(id);
+  }
+
+  @Post(':id/watch/stop')
+  async stopWatch(@Param('id') id: string): Promise<HookRun | null> {
+    const hook = await this.store.get(id);
+    return hook.trigger.kind === 'cdc' ? this.cdc.stop(id) : this.watch.stop(id);
+  }
+
   @Get(':id/runs')
   listRuns(@Param('id') id: string): Promise<HookRun[]> {
     return this.runs.listRuns(id);
@@ -164,6 +196,14 @@ export class HooksController {
     @Param('runId') runId: string,
   ): Promise<HookRun> {
     return this.runs.getRun(id, runId);
+  }
+
+  @Post(':id/runs/:runId/retry-failed')
+  retryFailed(
+    @Param('id') id: string,
+    @Param('runId') runId: string,
+  ): Promise<HookRun> {
+    return this.runs.resendFailed(id, runId);
   }
 
   @Post(':id/runs/:runId/cancel')

--- a/apps/api/src/hooks/hooks.module.ts
+++ b/apps/api/src/hooks/hooks.module.ts
@@ -4,23 +4,30 @@ import { ConnectionsModule } from '../connections/connections.module';
 import { DeliveryService } from './delivery.service';
 import { HookRunProcessor } from './hook-run.processor';
 import { HookRunService } from './hook-run.service';
+import { HookCdcService } from './hook-cdc.service';
 import { HookStoreService } from './hook-store.service';
+import { HookWatchProcessor } from './hook-watch.processor';
+import { HookWatchService } from './hook-watch.service';
 import { HooksController } from './hooks.controller';
 import { RunRegistryService } from './run-registry.service';
-import { HOOK_RUNS_QUEUE } from './hooks.types';
+import { HOOK_RUNS_QUEUE, HOOK_WATCH_QUEUE } from './hooks.types';
 
 @Module({
   imports: [
     ConnectionsModule, // AdapterPoolService
     BullModule.registerQueue({ name: HOOK_RUNS_QUEUE }),
+    BullModule.registerQueue({ name: HOOK_WATCH_QUEUE }),
   ],
   controllers: [HooksController],
   providers: [
     HookStoreService,
     HookRunService,
+    HookWatchService,
+    HookCdcService,
     DeliveryService,
     RunRegistryService,
     HookRunProcessor,
+    HookWatchProcessor,
   ],
 })
 export class HooksModule {}

--- a/apps/api/src/hooks/hooks.types.ts
+++ b/apps/api/src/hooks/hooks.types.ts
@@ -8,6 +8,7 @@ import type {
   HookDestination,
   HookSource,
   HookTransformConfig,
+  HookTrigger,
 } from '@relay/core';
 
 /** A hook with its auth secret decrypted — server-internal use only. */
@@ -18,6 +19,7 @@ export interface ResolvedHook {
   destination: HookDestination; // auth carries the real secret here
   transform: HookTransformConfig;
   delivery: HookDeliveryConfig;
+  trigger: HookTrigger;
   enabled: boolean;
 }
 
@@ -38,4 +40,10 @@ export interface HookRunJob {
   hookId: string;
 }
 
+/** The BullMQ job payload for a `hook-watch` poll cycle. */
+export interface HookWatchJob {
+  hookId: string;
+}
+
 export const HOOK_RUNS_QUEUE = 'hook-runs';
+export const HOOK_WATCH_QUEUE = 'hook-watch';

--- a/apps/web/src/components/automations/automations-view.tsx
+++ b/apps/web/src/components/automations/automations-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Pencil, Play, Trash2, Webhook, Loader2 } from 'lucide-react';
+import { Pencil, Play, Radio, Square, Trash2, Webhook, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ApiError } from '@/lib/api';
 import {
@@ -9,6 +9,8 @@ import {
   useHookRuns,
   useHooks,
   useStartHookRun,
+  useStartWatch,
+  useStopWatch,
 } from '@/lib/queries';
 import { useStudio } from '@/lib/store';
 import { cn } from '@/lib/utils';
@@ -42,15 +44,23 @@ export function AutomationsView() {
     );
   }
 
+  const destHostname = (() => {
+    try {
+      return new URL(hook.destination.url).hostname;
+    } catch {
+      return hook.destination.url;
+    }
+  })();
+
   return (
     <HookPanel
       key={hook.id}
       hookId={hook.id}
       hookName={hook.name}
       sourceLabel={hook.source.kind === 'table' ? hook.source.table : 'custom query'}
-      destLabel={`${hook.destination.method} ${hook.destination.url}`}
-      batchSize={hook.delivery.batchSize}
+      destLabel={`${hook.destination.method} ${destHostname}`}
       endpoint={{ url: hook.destination.url, method: hook.destination.method }}
+      isWatch={hook.trigger.kind !== 'replay'}
       onDeleted={() => selectHook(null)}
     />
   );
@@ -61,24 +71,29 @@ function HookPanel({
   hookName,
   sourceLabel,
   destLabel,
-  batchSize,
   endpoint,
+  isWatch,
   onDeleted,
 }: {
   hookId: string;
   hookName: string;
   sourceLabel: string;
   destLabel: string;
-  batchSize: number;
   endpoint: { url: string; method: string };
+  isWatch: boolean;
   onDeleted: () => void;
 }) {
   const confirm = useConfirm();
   const { openHookEditor } = useStudio();
   const start = useStartHookRun(hookId);
+  const startWatch = useStartWatch(hookId);
+  const stopWatch = useStopWatch(hookId);
   const del = useDeleteHook();
   const { data: runs } = useHookRuns(hookId);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const listening = !!runs?.some((r) =>
+    ['queued', 'running', 'canceling'].includes(r.status),
+  );
 
   // Default to (and follow) the most recent run.
   useEffect(() => {
@@ -100,6 +115,29 @@ function HookPanel({
       toast.success('Run started');
     } catch (err) {
       toast.error('Could not start run', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleStartWatch() {
+    try {
+      const run = await startWatch.mutateAsync();
+      setSelectedRunId(run.id);
+      toast.success('Listening for new data');
+    } catch (err) {
+      toast.error('Could not start listening', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleStopWatch() {
+    try {
+      await stopWatch.mutateAsync();
+      toast.success('Stopped listening');
+    } catch (err) {
+      toast.error('Could not stop', {
         description: err instanceof ApiError ? err.message : String(err),
       });
     }
@@ -135,14 +173,41 @@ function HookPanel({
           </p>
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-2">
-          <Button size="sm" onClick={handleRun} disabled={start.isPending}>
-            {start.isPending ? (
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          {isWatch ? (
+            listening ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleStopWatch}
+                disabled={stopWatch.isPending}
+              >
+                {stopWatch.isPending ? (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Square className="mr-1.5 h-3.5 w-3.5" />
+                )}
+                Stop listening
+              </Button>
             ) : (
-              <Play className="mr-1.5 h-3.5 w-3.5" />
-            )}
-            Run
-          </Button>
+              <Button size="sm" onClick={handleStartWatch} disabled={startWatch.isPending}>
+                {startWatch.isPending ? (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Radio className="mr-1.5 h-3.5 w-3.5" />
+                )}
+                Start listening
+              </Button>
+            )
+          ) : (
+            <Button size="sm" onClick={handleRun} disabled={start.isPending}>
+              {start.isPending ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              Run
+            </Button>
+          )}
           <Button
             size="sm"
             variant="outline"
@@ -161,7 +226,9 @@ function HookPanel({
       <div className="flex items-center gap-2 overflow-x-auto border-b px-4 py-2">
         {(!runs || runs.length === 0) && (
           <p className="text-xs text-muted-foreground">
-            No runs yet — press Run to stream rows to the endpoint.
+            {isWatch
+              ? 'Not listening yet — press Start listening to stream changes as they happen.'
+              : 'No runs yet — press Run to stream rows to the endpoint.'}
           </p>
         )}
         {runs?.map((run) => (
@@ -189,8 +256,8 @@ function HookPanel({
           <RunDetail
             hookId={hookId}
             run={selectedRun}
-            batchSize={batchSize}
             endpoint={endpoint}
+            isHook={isWatch}
           />
         ) : (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">

--- a/apps/web/src/components/automations/delivery-log.tsx
+++ b/apps/web/src/components/automations/delivery-log.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   ChevronLeft,
   ChevronRight,
   Copy,
+  Loader2,
   MousePointerClick,
   SkipForward,
   X,
@@ -28,26 +29,23 @@ const CELLS_PER_PAGE = 600;
 type CellState = DeliveryStatus | 'queued';
 
 const CELL_STYLES: Record<CellState, string> = {
-  success: 'bg-emerald-500 border-emerald-600/50 text-white',
-  failed: 'bg-red-500 border-red-700/50 text-white',
-  skipped: 'bg-amber-400 border-amber-600/50 text-amber-950',
-  queued: 'bg-muted border-border text-muted-foreground',
+  success: 'bg-emerald-500 border-emerald-600/40 text-white',
+  failed:  'bg-red-500   border-red-700/40   text-white',
+  skipped: 'bg-amber-400 border-amber-500/40 text-amber-950',
+  queued:  'bg-muted     border-border        text-muted-foreground/60',
 };
 
 const LEGEND: { state: CellState; label: string }[] = [
   { state: 'success', label: 'Delivered' },
-  { state: 'failed', label: 'Failed' },
-  { state: 'skipped', label: 'Skipped' },
-  { state: 'queued', label: 'Queued' },
+  { state: 'failed',  label: 'Failed'    },
+  { state: 'skipped', label: 'Skipped'  },
+  { state: 'queued',  label: 'Queued'   },
 ];
 
 function pretty(text: string | null): string {
   if (!text) return '';
-  try {
-    return JSON.stringify(JSON.parse(text), null, 2);
-  } catch {
-    return text;
-  }
+  try { return JSON.stringify(JSON.parse(text), null, 2); }
+  catch { return text; }
 }
 
 export function DeliveryMonitor({
@@ -58,41 +56,56 @@ export function DeliveryMonitor({
   batchSize,
   endpoint,
 }: {
-  hookId: string;
-  runId: string;
-  live: boolean;
+  hookId:    string;
+  runId:     string;
+  live:      boolean;
   totalRows: number | null;
   batchSize: number;
-  endpoint: { url: string; method: string };
+  endpoint:  { url: string; method: string };
 }) {
-  const cellCount = totalRows != null ? Math.ceil(totalRows / Math.max(1, batchSize)) : null;
-  const pageCount = cellCount != null ? Math.max(1, Math.ceil(cellCount / CELLS_PER_PAGE)) : 1;
+  const cellCount = totalRows != null
+    ? Math.ceil(totalRows / Math.max(1, batchSize))
+    : null;
+  const pageCount = cellCount != null
+    ? Math.max(1, Math.ceil(cellCount / CELLS_PER_PAGE))
+    : 1;
 
-  const [page, setPage] = useState(0);
+  const [page, setPage]             = useState(0);
+  const [manualPage, setManualPage] = useState(false); // true = user navigated manually
   const [selectMode, setSelectMode] = useState(false);
-  const [selected, setSelected] = useState<Set<number>>(new Set());
-  const [anchor, setAnchor] = useState<number | null>(null);
-  const [openId, setOpenId] = useState<string | null>(null);
-  const [rangeFrom, setRangeFrom] = useState('');
-  const [rangeTo, setRangeTo] = useState('');
+  const [selected, setSelected]     = useState<Set<number>>(new Set());
+  const [anchor, setAnchor]         = useState<number | null>(null);
+  const [openId, setOpenId]         = useState<string | null>(null);
+  const [rangeFrom, setRangeFrom]   = useState('');
+  const [rangeTo, setRangeTo]       = useState('');
 
+  // Reset all local state when switching to a different run.
   useEffect(() => {
     setPage(0);
+    setManualPage(false);
     setSelected(new Set());
     setOpenId(null);
     setSelectMode(false);
   }, [runId]);
 
-  const windowStart = page * CELLS_PER_PAGE;
-  const windowEnd =
-    cellCount != null
-      ? Math.min(windowStart + CELLS_PER_PAGE, cellCount)
-      : windowStart + CELLS_PER_PAGE;
+  // Auto-follow: while live and the user hasn't manually navigated,
+  // keep the view on the latest page as new deliveries arrive.
+  const prevPageCountRef = useRef(pageCount);
+  useEffect(() => {
+    if (live && !manualPage && pageCount > prevPageCountRef.current) {
+      setPage(pageCount - 1);
+    }
+    prevPageCountRef.current = pageCount;
+  }, [live, manualPage, pageCount]);
 
-  // Fetch only the visible window's deliveries — keeps load flat on huge runs.
-  const { data: deliveries } = useHookDeliveries(hookId, runId, live, {
+  const windowStart = page * CELLS_PER_PAGE;
+  const windowEnd   = cellCount != null
+    ? Math.min(windowStart + CELLS_PER_PAGE, cellCount)
+    : windowStart + CELLS_PER_PAGE;
+
+  const { data: deliveries, isFetching } = useHookDeliveries(hookId, runId, live, {
     from: cellCount != null ? windowStart : undefined,
-    to: cellCount != null ? windowEnd - 1 : undefined,
+    to:   cellCount != null ? windowEnd - 1 : undefined,
   });
 
   const bySeq = useMemo(() => {
@@ -101,12 +114,10 @@ export function DeliveryMonitor({
     return m;
   }, [deliveries]);
 
-  // The sequences to render as cells this page.
   const sequences = useMemo(() => {
     if (cellCount != null) {
       return Array.from({ length: windowEnd - windowStart }, (_, i) => windowStart + i);
     }
-    // Unknown total: render whatever deliveries we have, densely.
     return [...bySeq.keys()].sort((a, b) => a - b);
   }, [cellCount, windowStart, windowEnd, bySeq]);
 
@@ -117,6 +128,11 @@ export function DeliveryMonitor({
     return (bySeq.get(seq)?.status as CellState) ?? 'queued';
   }
 
+  function navigatePage(p: number) {
+    setManualPage(true);
+    setPage(p);
+  }
+
   function onCellClick(seq: number, shift: boolean) {
     if (selectMode) {
       setSelected((prev) => {
@@ -124,8 +140,11 @@ export function DeliveryMonitor({
         if (shift && anchor != null) {
           const [lo, hi] = anchor < seq ? [anchor, seq] : [seq, anchor];
           for (let s = lo; s <= hi; s++) next.add(s);
-        } else if (next.has(seq)) next.delete(seq);
-        else next.add(seq);
+        } else if (next.has(seq)) {
+          next.delete(seq);
+        } else {
+          next.add(seq);
+        }
         return next;
       });
       setAnchor(seq);
@@ -145,11 +164,11 @@ export function DeliveryMonitor({
 
   async function runSkip(targets: number[]) {
     if (targets.length === 0) {
-      toast.info('Nothing queued to skip there (settled rows can’t be skipped).');
+      toast.info('Nothing to skip — only queued deliveries can be skipped.');
       return;
     }
     if (targets.length > 10_000) {
-      toast.error('Too many at once — skip up to 10,000 rows per action.');
+      toast.error('Too many at once — skip up to 10,000 sequences per action.');
       return;
     }
     try {
@@ -165,13 +184,15 @@ export function DeliveryMonitor({
 
   async function skipRange() {
     const from = Number(rangeFrom);
-    const to = Number(rangeTo);
+    const to   = Number(rangeTo);
     if (!Number.isFinite(from) || !Number.isFinite(to) || to < from) {
-      toast.error('Enter a valid range (from ≤ to).');
+      toast.error('Enter a valid range (from must be less than or equal to to).');
       return;
     }
     const targets: number[] = [];
-    for (let s = Math.max(0, from); s <= to; s++) if (!bySeq.get(s)) targets.push(s);
+    for (let s = Math.max(0, from); s <= to; s++) {
+      if (!bySeq.get(s)) targets.push(s);
+    }
     await runSkip(targets);
   }
 
@@ -180,30 +201,63 @@ export function DeliveryMonitor({
   return (
     <div className="flex h-full min-h-0">
       <div className="flex min-w-0 flex-1 flex-col">
-        {/* Toolbar */}
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-b px-3 py-2">
-          <div className="flex items-center gap-3 text-[11px]">
+
+        {/* ── Toolbar ─────────────────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b px-3 py-2">
+
+          {/* Legend */}
+          <div className="flex items-center gap-3">
             {LEGEND.map((l) => (
-              <span key={l.state} className="text-muted-foreground flex items-center gap-1">
-                <span
-                  className={cn('h-3 w-3 rounded-sm border', CELL_STYLES[l.state])}
-                />
+              <span key={l.state} className="text-muted-foreground flex items-center gap-1.5 text-[11px]">
+                <span className={cn('h-3 w-3 rounded-sm border', CELL_STYLES[l.state])} />
                 {l.label}
               </span>
             ))}
           </div>
 
+          {/* Live badge + refresh indicator */}
+          <div className="flex items-center gap-2">
+            {live && (
+              <span className="flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
+                <span className="relative flex h-2 w-2">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+                </span>
+                LIVE
+              </span>
+            )}
+            {isFetching && !live && (
+              <Loader2 className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
+            )}
+          </div>
+
+          {/* Auto-follow notice (shown only when user manually navigated away during live) */}
+          {live && manualPage && (
+            <button
+              className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-[11px] underline underline-offset-2 transition-colors"
+              onClick={() => { setManualPage(false); setPage(pageCount - 1); }}
+            >
+              Follow latest
+            </button>
+          )}
+
           <div className="ml-auto flex items-center gap-2">
-            {/* Range skip — for skipping many rows without clicking each */}
+            {/* Range skip */}
             <Popover>
               <PopoverTrigger asChild>
                 <Button size="sm" variant="outline" className="h-7">
                   <SkipForward className="mr-1.5 h-3.5 w-3.5" />
-                  Skip rows…
+                  Skip sequences…
                 </Button>
               </PopoverTrigger>
-              <PopoverContent align="end" className="w-72 space-y-2">
-                <p className="text-xs font-medium">Skip a range of queued rows</p>
+              <PopoverContent align="end" className="w-72 space-y-3">
+                <div>
+                  <p className="text-sm font-medium">Skip a sequence range</p>
+                  <p className="text-muted-foreground mt-0.5 text-[11px]">
+                    Enter delivery sequence numbers (shown inside each cell).
+                    Already-settled deliveries are left untouched.
+                  </p>
+                </div>
                 <div className="flex items-center gap-2">
                   <Input
                     type="number"
@@ -227,12 +281,9 @@ export function DeliveryMonitor({
                   disabled={skip.isPending}
                   onClick={skipRange}
                 >
+                  {skip.isPending ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
                   Skip range
                 </Button>
-                <p className="text-muted-foreground text-[11px]">
-                  Skips queued rows whose sequence is in the range. Already-sent
-                  rows are left untouched.
-                </p>
               </PopoverContent>
             </Popover>
 
@@ -240,22 +291,15 @@ export function DeliveryMonitor({
               size="sm"
               variant={selectMode ? 'default' : 'outline'}
               className="h-7"
-              onClick={() => {
-                setSelectMode((v) => !v);
-                setSelected(new Set());
-              }}
+              onClick={() => { setSelectMode((v) => !v); setSelected(new Set()); }}
             >
               <MousePointerClick className="mr-1.5 h-3.5 w-3.5" />
               {selectMode ? 'Selecting' : 'Select'}
             </Button>
+
             {selectMode && (
               <>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7"
-                  onClick={selectQueuedOnPage}
-                >
+                <Button size="sm" variant="outline" className="h-7" onClick={selectQueuedOnPage}>
                   Select queued (page)
                 </Button>
                 {selected.size > 0 && (
@@ -274,7 +318,10 @@ export function DeliveryMonitor({
                   disabled={selectedQueued === 0 || skip.isPending}
                   onClick={() => runSkip([...selected].filter((s) => !bySeq.get(s)))}
                 >
-                  <SkipForward className="mr-1.5 h-3.5 w-3.5" />
+                  {skip.isPending
+                    ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    : <SkipForward className="mr-1.5 h-3.5 w-3.5" />
+                  }
                   Skip {selectedQueued > 0 ? selectedQueued : ''}
                 </Button>
               </>
@@ -282,31 +329,52 @@ export function DeliveryMonitor({
           </div>
         </div>
 
-        {/* Timeline */}
+        {/* ── Timeline grid ───────────────────────────────────────────── */}
         <div className="min-h-0 flex-1 overflow-y-auto">
           {sequences.length === 0 ? (
-            <p className="text-muted-foreground p-4 text-sm">No deliveries yet.</p>
+            <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 py-12">
+              {live ? (
+                <>
+                  <Loader2 className="h-5 w-5 animate-spin opacity-50" />
+                  <p className="text-sm">Waiting for first delivery…</p>
+                </>
+              ) : (
+                <p className="text-sm">No deliveries recorded.</p>
+              )}
+            </div>
           ) : (
             <div
               className="grid gap-1 p-3"
-              style={{
-                gridTemplateColumns: 'repeat(auto-fill, minmax(1.9rem, 1fr))',
-              }}
+              style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(2.25rem, 1fr))' }}
             >
               {sequences.map((seq) => {
-                const state = cellState(seq);
-                const isSel = selected.has(seq);
-                const d = bySeq.get(seq);
+                const state  = cellState(seq);
+                const isSel  = selected.has(seq);
+                const d      = bySeq.get(seq);
+                const rowStart = seq * batchSize + 1;
+                const rowEnd   = d ? d.rowIndex + d.rowCount : rowStart + batchSize - 1;
+                const rowLabel = batchSize > 1 ? `rows ${rowStart}–${rowEnd}` : `row ${rowStart}`;
+                const tipAction = selectMode
+                  ? 'click to toggle · shift+click to range-select'
+                  : 'click to inspect';
                 return (
                   <button
                     key={seq}
                     onClick={(e) => onCellClick(seq, e.shiftKey)}
-                    title={`#${seq} · ${state}${d?.httpStatus ? ` · HTTP ${d.httpStatus}` : ''}`}
+                    title={[
+                      `Sequence #${seq}`,
+                      rowLabel,
+                      state.charAt(0).toUpperCase() + state.slice(1),
+                      d?.httpStatus ? `HTTP ${d.httpStatus}` : null,
+                      tipAction,
+                    ].filter(Boolean).join(' · ')}
                     className={cn(
-                      'flex h-[30px] items-center justify-center rounded-md border text-[10px] font-semibold tabular-nums transition-transform hover:scale-105',
+                      'flex h-[32px] items-center justify-center rounded border text-[10px] font-semibold tabular-nums',
+                      'transition-[transform,box-shadow] duration-100',
+                      'hover:scale-110 hover:z-10 hover:shadow-sm',
                       CELL_STYLES[state],
-                      openDelivery?.sequence === seq && 'ring-foreground z-10 ring-2',
-                      isSel && 'ring-primary z-10 ring-2',
+                      openDelivery?.sequence === seq && 'ring-foreground z-10 ring-2 scale-110',
+                      isSel && 'ring-primary z-10 ring-2 scale-110',
                     )}
                   >
                     {seq}
@@ -317,11 +385,13 @@ export function DeliveryMonitor({
           )}
         </div>
 
-        {/* Pagination */}
+        {/* ── Pagination ──────────────────────────────────────────────── */}
         {cellCount != null && pageCount > 1 && (
           <div className="text-muted-foreground flex items-center gap-2 border-t px-3 py-1.5 text-xs">
             <span>
-              cells {windowStart}–{windowEnd - 1} of {cellCount.toLocaleString()}
+              sequences {windowStart}–{windowEnd - 1}
+              <span className="mx-1 opacity-40">/</span>
+              {cellCount.toLocaleString()} total
             </span>
             <div className="ml-auto flex items-center gap-1">
               <Button
@@ -329,11 +399,11 @@ export function DeliveryMonitor({
                 size="icon"
                 className="h-7 w-7"
                 disabled={page === 0}
-                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                onClick={() => navigatePage(Math.max(0, page - 1))}
               >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
-              <span className="px-1">
+              <span className="px-1.5 tabular-nums">
                 {page + 1} / {pageCount}
               </span>
               <Button
@@ -341,7 +411,7 @@ export function DeliveryMonitor({
                 size="icon"
                 className="h-7 w-7"
                 disabled={page >= pageCount - 1}
-                onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                onClick={() => navigatePage(Math.min(pageCount - 1, page + 1))}
               >
                 <ChevronRight className="h-4 w-4" />
               </Button>
@@ -350,7 +420,7 @@ export function DeliveryMonitor({
         )}
       </div>
 
-      {/* Detail */}
+      {/* ── Delivery detail panel ───────────────────────────────────── */}
       {openDelivery && (
         <div className="bg-muted/20 w-[44%] min-w-[320px] border-l">
           <DeliveryDetail
@@ -371,7 +441,7 @@ function DeliveryDetail({
 }: {
   delivery: HookDelivery;
   endpoint: { url: string; method: string };
-  onClose: () => void;
+  onClose:  () => void;
 }) {
   function copyCurl() {
     const parts = [
@@ -385,20 +455,21 @@ function DeliveryDetail({
   }
 
   const tone =
-    d.status === 'success'
-      ? 'bg-emerald-500/15 text-emerald-600'
-      : d.status === 'skipped'
-        ? 'bg-amber-500/15 text-amber-600'
-        : 'bg-destructive/15 text-destructive';
+    d.status === 'success' ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+    : d.status === 'skipped' ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+    : 'bg-destructive/15 text-destructive';
 
   return (
     <div className="h-full overflow-y-auto">
       <div className="space-y-3 p-3 text-xs">
+        {/* Header row */}
         <div className="flex items-center gap-2">
-          <span className={cn('rounded-full px-2 py-0.5 font-medium capitalize', tone)}>
+          <span className={cn('rounded-full px-2 py-0.5 font-semibold capitalize', tone)}>
             {d.status}
           </span>
-          {d.httpStatus != null && <span className="font-mono">HTTP {d.httpStatus}</span>}
+          {d.httpStatus != null && (
+            <span className="text-muted-foreground font-mono">HTTP {d.httpStatus}</span>
+          )}
           <div className="ml-auto flex items-center gap-1">
             {d.status !== 'skipped' && (
               <Button variant="ghost" size="sm" className="h-7 px-2" onClick={copyCurl}>
@@ -411,9 +482,10 @@ function DeliveryDetail({
           </div>
         </div>
 
+        {/* Meta row */}
         <div className="text-muted-foreground flex flex-wrap gap-x-4 gap-y-1">
           <span>
-            seq <span className="text-foreground font-mono">{d.sequence}</span>
+            seq <span className="text-foreground font-mono">#{d.sequence}</span>
           </span>
           <span>
             row{' '}
@@ -437,15 +509,15 @@ function DeliveryDetail({
             {d.error}
           </Block>
         )}
-        {d.status !== 'skipped' && (
+
+        {d.status !== 'skipped' ? (
           <>
             <Block label="Request body">{pretty(d.requestBody) || '—'}</Block>
             <Block label="Response">{pretty(d.responseBody) || '(empty)'}</Block>
           </>
-        )}
-        {d.status === 'skipped' && (
+        ) : (
           <p className="text-muted-foreground">
-            This row was skipped and never sent.
+            This delivery was skipped and never sent to the endpoint.
           </p>
         )}
       </div>
@@ -458,13 +530,13 @@ function Block({
   tone,
   children,
 }: {
-  label: string;
-  tone?: 'danger';
+  label:    string;
+  tone?:    'danger';
   children: ReactNode;
 }) {
   return (
     <div>
-      <p className="text-muted-foreground mb-1">{label}</p>
+      <p className="text-muted-foreground mb-1 font-medium">{label}</p>
       <pre
         className={cn(
           'max-h-60 overflow-auto rounded-md p-2 font-mono text-[11px] whitespace-pre-wrap',

--- a/apps/web/src/components/automations/hook-builder.tsx
+++ b/apps/web/src/components/automations/hook-builder.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   Pencil,
   Plus,
+  Radio,
   RefreshCw,
   Webhook,
   X,
@@ -106,7 +107,7 @@ function formatCell(value: unknown): string {
 }
 
 export function HookBuilder() {
-  const { hookEditor, closeHookEditor, selectHook, openConnectionDialog } =
+  const { hookEditor, closeHookEditor, selectHook, openConnectionDialog, automationTab } =
     useStudio();
   const editing = hookEditor.editingId;
   const create = useCreateHook();
@@ -126,6 +127,24 @@ export function HookBuilder() {
   /** Column preference: null = all columns, array = a pinned subset (editing). */
   const [fieldsPref, setFieldsPref] = useState<string[] | null>(null);
   const [offset, setOffset] = useState(0);
+
+  // ----- trigger -----
+  // The builder is locked to one of two environments, decided by the sidebar tab
+  // (new) or the hook's existing trigger (editing). 'job' = replay-only;
+  // 'hook' = listen-only (polling/CDC). They never share trigger UI.
+  const [builderKind, setBuilderKind] = useState<'job' | 'hook'>('job');
+  const [triggerKind, setTriggerKind] = useState<'replay' | 'watch' | 'cdc'>('replay');
+  const [watchStrategy, setWatchStrategy] = useState<
+    'increment' | 'timestamp' | 'snapshot'
+  >('increment');
+  const [watchColumn, setWatchColumn] = useState('');
+  const [pollSeconds, setPollSeconds] = useState(5);
+  const [watchStartFrom, setWatchStartFrom] = useState<'now' | 'beginning'>('now');
+  const [cdcOps, setCdcOps] = useState<Set<'insert' | 'update' | 'delete'>>(
+    new Set(['insert', 'update', 'delete']),
+  );
+  const [readiness, setReadiness] = useState<import('@relay/core').CdcReadiness | null>(null);
+  const [checkingCdc, setCheckingCdc] = useState(false);
 
   // ----- payload / destination / delivery -----
   const [wrapKey, setWrapKey] = useState('');
@@ -156,9 +175,9 @@ export function HookBuilder() {
     refetch,
   } = useBrowse(connectionId || null, browseParams, database || undefined);
 
-  const columns = browse?.columns ?? [];
-  const rows = browse?.rows ?? [];
-  const pk = browse?.primaryKey ?? [];
+  const columns = useMemo(() => browse?.columns ?? [], [browse]);
+  const rows = useMemo(() => browse?.rows ?? [], [browse]);
+  const pk = useMemo(() => browse?.primaryKey ?? [], [browse]);
   const singlePk = pk.length === 1 ? pk[0]! : null;
 
   /* Populate from an existing hook or a seed when opened. */
@@ -173,6 +192,10 @@ export function HookBuilder() {
       return;
     }
     reset();
+    // New items belong to the active sidebar tab's environment.
+    const kind = automationTab === 'hooks' ? 'hook' : 'job';
+    setBuilderKind(kind);
+    setTriggerKind(kind === 'hook' ? 'watch' : 'replay');
     if (hookEditor.seed) {
       setConnectionId(hookEditor.seed.connectionId);
       setDatabase(hookEditor.seed.database ?? '');
@@ -216,6 +239,13 @@ export function HookBuilder() {
     setIncluded(new Set());
     setFieldsPref(null);
     setOffset(0);
+    setTriggerKind('replay');
+    setWatchStrategy('increment');
+    setWatchColumn('');
+    setPollSeconds(5);
+    setWatchStartFrom('now');
+    setCdcOps(new Set(['insert', 'update', 'delete']));
+    setReadiness(null);
     setWrapKey('');
     setDest(blankDestination());
     setDelivery(blankDelivery());
@@ -241,6 +271,23 @@ export function HookBuilder() {
     // Applied when the table's columns load (subset = pinned fields; none = all).
     setFieldsPref(h.transform.fields ?? null);
     setWrapKey(h.transform.wrapKey ?? '');
+    if (h.trigger.kind === 'watch') {
+      setBuilderKind('hook');
+      setTriggerKind('watch');
+      setWatchStrategy(h.trigger.strategy.strategy);
+      setWatchColumn(
+        h.trigger.strategy.strategy === 'snapshot' ? '' : h.trigger.strategy.column,
+      );
+      setPollSeconds(Math.round(h.trigger.pollIntervalMs / 1000));
+      setWatchStartFrom(h.trigger.startFrom);
+    } else if (h.trigger.kind === 'cdc') {
+      setBuilderKind('hook');
+      setTriggerKind('cdc');
+      setCdcOps(new Set(h.trigger.operations));
+    } else {
+      setBuilderKind('job');
+      setTriggerKind('replay');
+    }
     setDest({
       url: h.destination.url,
       method: h.destination.method,
@@ -349,12 +396,15 @@ export function HookBuilder() {
 
   const sendCount =
     mode === 'selected' ? selectedKeys.size : (browse?.total ?? null);
+  const watchNeedsColumn =
+    triggerKind === 'watch' && watchStrategy !== 'snapshot' && !watchColumn;
   const canSave =
     !!connectionId &&
     !!table &&
     dest.url.trim().length > 0 &&
     includedList.length > 0 &&
-    !(mode === 'selected' && (!singlePk || selectedKeys.size === 0));
+    !(mode === 'selected' && (!singlePk || selectedKeys.size === 0)) &&
+    !watchNeedsColumn;
 
   function buildInput(): HookInputDTO {
     const filters: FilterSpec[] = [];
@@ -420,8 +470,44 @@ export function HookBuilder() {
         backoffMaxMs: 30000,
         pageSize: 200,
       },
+      trigger:
+        triggerKind === 'cdc'
+          ? { kind: 'cdc', operations: [...cdcOps] }
+          : triggerKind === 'watch'
+            ? {
+                kind: 'watch',
+                strategy:
+                  watchStrategy === 'snapshot'
+                    ? { strategy: 'snapshot', maxTracked: 50000 }
+                    : { strategy: watchStrategy, column: watchColumn },
+                pollIntervalMs: Math.max(1000, Math.round(pollSeconds * 1000)),
+                startFrom: watchStartFrom,
+                maxPerPoll: 500,
+              }
+            : { kind: 'replay' },
       enabled: true,
     };
+  }
+
+  async function checkReadiness() {
+    if (!connectionId || !table) return;
+    setCheckingCdc(true);
+    try {
+      setReadiness(
+        await api.cdcReadiness({
+          connectionId,
+          database: database || undefined,
+          schema: schema || undefined,
+          table,
+        }),
+      );
+    } catch (err) {
+      toast.error('Readiness check failed', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    } finally {
+      setCheckingCdc(false);
+    }
   }
 
   async function handleSave() {
@@ -458,17 +544,24 @@ export function HookBuilder() {
           className="h-8 max-w-xs font-medium"
         />
         <div className="text-muted-foreground ml-2 text-sm">
-          {sendCount != null && (
-            <span>
-              sends{' '}
-              <span className="text-foreground font-medium">
-                {sendCount.toLocaleString()}
-              </span>{' '}
-              {mode === 'selected' ? 'selected' : ''} row
-              {sendCount === 1 ? '' : 's'} · {includedList.length}/
-              {columns.length} columns
-            </span>
-          )}
+          {builderKind === 'job'
+            ? sendCount != null && (
+                <span>
+                  sends{' '}
+                  <span className="text-foreground font-medium">
+                    {sendCount.toLocaleString()}
+                  </span>{' '}
+                  {mode === 'selected' ? 'selected' : ''} row
+                  {sendCount === 1 ? '' : 's'} · {includedList.length}/
+                  {columns.length} columns
+                </span>
+              )
+            : table && (
+                <span>
+                  streams new rows · {includedList.length}/{columns.length}{' '}
+                  columns
+                </span>
+              )}
         </div>
         <div className="ml-auto flex items-center gap-2">
           <Button variant="ghost" onClick={closeHookEditor}>
@@ -569,6 +662,7 @@ export function HookBuilder() {
                   setIncluded(new Set());
                   setFieldsPref(null);
                   setSelectedKeys(new Map());
+                  setReadiness(null);
                 }}
               >
                 <SelectTrigger className="h-8 w-52">
@@ -588,32 +682,36 @@ export function HookBuilder() {
 
               {table && (
                 <>
-                  <div className="ml-2 flex items-center overflow-hidden rounded-md border text-xs">
-                    {(['selected', 'all'] as const).map((m) => (
-                      <button
-                        key={m}
-                        disabled={m === 'selected' && !singlePk}
-                        onClick={() => setMode(m)}
-                        className={cn(
-                          'px-2.5 py-1.5 transition-colors disabled:opacity-40',
-                          mode === m
-                            ? 'bg-primary text-primary-foreground'
-                            : 'hover:bg-accent',
-                        )}
-                        title={
-                          m === 'selected' && !singlePk
-                            ? 'Needs a single-column primary key'
-                            : undefined
-                        }
-                      >
-                        {m === 'selected' ? 'Selected rows' : 'All rows'}
-                      </button>
-                    ))}
-                  </div>
-                  {mode === 'selected' && (
-                    <Badge variant="secondary" className="font-normal">
-                      {selectedKeys.size} selected
-                    </Badge>
+                  {builderKind === 'job' && (
+                    <>
+                      <div className="ml-2 flex items-center overflow-hidden rounded-md border text-xs">
+                        {(['selected', 'all'] as const).map((m) => (
+                          <button
+                            key={m}
+                            disabled={m === 'selected' && !singlePk}
+                            onClick={() => setMode(m)}
+                            className={cn(
+                              'px-2.5 py-1.5 transition-colors disabled:opacity-40',
+                              mode === m
+                                ? 'bg-primary text-primary-foreground'
+                                : 'hover:bg-accent',
+                            )}
+                            title={
+                              m === 'selected' && !singlePk
+                                ? 'Needs a single-column primary key'
+                                : undefined
+                            }
+                          >
+                            {m === 'selected' ? 'Selected rows' : 'All rows'}
+                          </button>
+                        ))}
+                      </div>
+                      {mode === 'selected' && (
+                        <Badge variant="secondary" className="font-normal">
+                          {selectedKeys.size} selected
+                        </Badge>
+                      )}
+                    </>
                   )}
                   <Button
                     variant="ghost"
@@ -631,11 +729,25 @@ export function HookBuilder() {
               )}
             </div>
 
+            {/* Hook-mode preview banner */}
+            {builderKind === 'hook' && table && (
+              <div className="flex items-start gap-2 border-b bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-950/30 dark:text-blue-300">
+                <Radio className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>
+                  <strong>Column selection only.</strong> New rows added to this
+                  table will be delivered automatically — no row selection needed.
+                  Click a column header to include or exclude it from the payload.
+                </span>
+              </div>
+            )}
+
             {/* grid */}
             <div className="scrollbar-thin min-h-0 flex-1 overflow-auto">
               {!table ? (
                 <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
-                  Pick a connection and table to choose the data to send.
+                  {builderKind === 'hook'
+                    ? 'Pick a connection and table to preview data and select columns.'
+                    : 'Pick a connection and table to choose the data to send.'}
                 </div>
               ) : (
                 <table className="w-full border-collapse text-sm">
@@ -754,8 +866,9 @@ export function HookBuilder() {
             {table && (
               <div className="text-muted-foreground flex items-center gap-2 border-t px-3 py-1.5 text-xs">
                 <span>
-                  rows {rows.length ? offset + 1 : 0}–{offset + rows.length}
-                  {browse?.total != null
+                  {builderKind === 'hook' ? 'preview rows ' : 'rows '}
+                  {rows.length ? offset + 1 : 0}–{offset + rows.length}
+                  {builderKind === 'job' && browse?.total != null
                     ? ` of ${browse.estimated ? '~' : ''}${browse.total.toLocaleString()}`
                     : ''}
                 </span>
@@ -790,6 +903,198 @@ export function HookBuilder() {
         <ResizablePanel defaultSize={36} minSize={26}>
           <div className="h-full overflow-y-auto">
             <div className="space-y-5 p-4">
+              {/* Trigger — hooks only; jobs are always a one-shot replay. */}
+              {builderKind === 'hook' && (
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold">How it listens</h3>
+                  <div className="flex overflow-hidden rounded-md border text-xs">
+                    {(
+                      [
+                        ['watch', 'Polling'],
+                        ['cdc', 'Event-based (real-time)'],
+                      ] as const
+                    ).map(([k, label]) => (
+                      <button
+                        key={k}
+                        onClick={() => setTriggerKind(k)}
+                        className={cn(
+                          'flex-1 px-2.5 py-1.5 transition-colors',
+                          triggerKind === k
+                            ? 'bg-accent font-medium'
+                            : 'text-muted-foreground hover:bg-accent/50',
+                        )}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+
+                  {triggerKind === 'cdc' && (
+                    <div className="grid gap-2 rounded-md border p-2.5">
+                    <Label className="text-xs">Operations to deliver</Label>
+                    <div className="flex gap-3 text-xs">
+                      {(['insert', 'update', 'delete'] as const).map((op) => (
+                        <label key={op} className="flex items-center gap-1.5 capitalize">
+                          <input
+                            type="checkbox"
+                            className="accent-primary h-3.5 w-3.5"
+                            checked={cdcOps.has(op)}
+                            onChange={() =>
+                              setCdcOps((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(op)) next.delete(op);
+                                else next.add(op);
+                                return next;
+                              })
+                            }
+                          />
+                          {op}
+                        </label>
+                      ))}
+                    </div>
+
+                    {/* Readiness / setup */}
+                    <div className="flex items-center justify-between">
+                      <span className="text-muted-foreground text-[11px]">
+                        Streams changes from the DB log in real time (no polling).
+                      </span>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7"
+                        disabled={!connectionId || !table || checkingCdc}
+                        onClick={checkReadiness}
+                      >
+                        {checkingCdc ? (
+                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        ) : null}
+                        Check readiness
+                      </Button>
+                    </div>
+
+                    {readiness && (
+                      <div className="space-y-1.5 rounded-md border p-2 text-[11px]">
+                        {!readiness.supported ? (
+                          <p className="text-amber-600">
+                            {readiness.instructions[0]}
+                          </p>
+                        ) : (
+                          <>
+                            <p
+                              className={cn(
+                                'font-medium',
+                                readiness.ready ? 'text-emerald-600' : 'text-amber-600',
+                              )}
+                            >
+                              {readiness.ready
+                                ? '✓ Ready — we’ll auto-create the publication & slot on start.'
+                                : 'Setup needed:'}
+                            </p>
+                            {readiness.checks.map((c) => (
+                              <div key={c.label} className="flex items-center gap-1.5">
+                                <span className={c.ok ? 'text-emerald-600' : 'text-destructive'}>
+                                  {c.ok ? '✓' : '✗'}
+                                </span>
+                                <span>
+                                  {c.label}
+                                  {c.detail ? ` (${c.detail})` : ''}
+                                </span>
+                              </div>
+                            ))}
+                            {readiness.instructions.map((ins, i) => (
+                              <p key={i} className="text-muted-foreground pl-1">
+                                • {ins}
+                              </p>
+                            ))}
+                          </>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {triggerKind === 'watch' && (
+                  <div className="grid gap-2 rounded-md border p-2.5">
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Detect new rows by</Label>
+                      <Select
+                        value={watchStrategy}
+                        onValueChange={(v) =>
+                          setWatchStrategy(v as 'increment' | 'timestamp' | 'snapshot')
+                        }
+                      >
+                        <SelectTrigger className="h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="increment">
+                            Incrementing column (id / sequence)
+                          </SelectItem>
+                          <SelectItem value="timestamp">
+                            Timestamp column (created/updated at)
+                          </SelectItem>
+                          <SelectItem value="snapshot">
+                            New primary keys (small tables / UUIDs)
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    {watchStrategy !== 'snapshot' && (
+                      <div className="grid gap-1.5">
+                        <Label className="text-xs">
+                          {watchStrategy === 'timestamp' ? 'Timestamp' : 'Incrementing'}{' '}
+                          column
+                        </Label>
+                        <Select value={watchColumn} onValueChange={setWatchColumn}>
+                          <SelectTrigger className="h-8">
+                            <SelectValue placeholder="Select a column" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {columns.map((c) => (
+                              <SelectItem key={c.name} value={c.name}>
+                                {c.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+
+                    <div className="grid grid-cols-2 gap-2">
+                      <NumField
+                        label="Poll every (sec)"
+                        value={pollSeconds}
+                        min={1}
+                        onChange={setPollSeconds}
+                      />
+                      <div className="grid gap-1.5">
+                        <Label className="text-xs">Start from</Label>
+                        <Select
+                          value={watchStartFrom}
+                          onValueChange={(v) =>
+                            setWatchStartFrom(v as 'now' | 'beginning')
+                          }
+                        >
+                          <SelectTrigger className="h-8">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="now">New rows from now</SelectItem>
+                            <SelectItem value="beginning">All existing + new</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                      <p className="text-muted-foreground text-[11px]">
+                        The hook keeps polling this table and delivers new rows as
+                        they appear.
+                      </p>
+                    </div>
+                  )}
+                </section>
+              )}
+
               {/* Payload */}
               <section>
                 <h3 className="mb-2 text-sm font-semibold">What gets sent</h3>
@@ -997,14 +1302,16 @@ export function HookBuilder() {
               <section className="space-y-2">
                 <h3 className="text-sm font-semibold">Delivery</h3>
                 <div className="grid grid-cols-2 gap-2">
-                  <NumField
-                    label="Batch size"
-                    value={delivery.batchSize}
-                    min={1}
-                    onChange={(v) =>
-                      setDelivery((d) => ({ ...d, batchSize: v }))
-                    }
-                  />
+                  {builderKind === 'job' && (
+                    <NumField
+                      label="Batch size"
+                      value={delivery.batchSize}
+                      min={1}
+                      onChange={(v) =>
+                        setDelivery((d) => ({ ...d, batchSize: v }))
+                      }
+                    />
+                  )}
                   <NumField
                     label="Max attempts"
                     value={delivery.maxAttempts}
@@ -1013,14 +1320,16 @@ export function HookBuilder() {
                       setDelivery((d) => ({ ...d, maxAttempts: v }))
                     }
                   />
-                  <NumField
-                    label="Delay between (ms)"
-                    value={delivery.minDelayMs}
-                    min={0}
-                    onChange={(v) =>
-                      setDelivery((d) => ({ ...d, minDelayMs: v }))
-                    }
-                  />
+                  {builderKind === 'job' && (
+                    <NumField
+                      label="Delay between (ms)"
+                      value={delivery.minDelayMs}
+                      min={0}
+                      onChange={(v) =>
+                        setDelivery((d) => ({ ...d, minDelayMs: v }))
+                      }
+                    />
+                  )}
                   <NumField
                     label="Timeout (ms)"
                     value={delivery.timeoutMs}
@@ -1030,28 +1339,31 @@ export function HookBuilder() {
                     }
                   />
                 </div>
-                <div className="grid gap-1.5">
-                  <Label className="text-xs">On failure</Label>
-                  <Select
-                    value={delivery.onError}
-                    onValueChange={(v) =>
-                      setDelivery((d) => ({
-                        ...d,
-                        onError: v as 'continue' | 'abort',
-                      }))
-                    }
-                  >
-                    <SelectTrigger className="h-8">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="continue">
-                        Log &amp; continue
-                      </SelectItem>
-                      <SelectItem value="abort">Stop the run</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
+                {/* On-failure abort is a job concept — a listener must never stop on one bad delivery. */}
+                {builderKind === 'job' && (
+                  <div className="grid gap-1.5">
+                    <Label className="text-xs">On failure</Label>
+                    <Select
+                      value={delivery.onError}
+                      onValueChange={(v) =>
+                        setDelivery((d) => ({
+                          ...d,
+                          onError: v as 'continue' | 'abort',
+                        }))
+                      }
+                    >
+                      <SelectTrigger className="h-8">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="continue">
+                          Log &amp; continue
+                        </SelectItem>
+                        <SelectItem value="abort">Stop the run</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
               </section>
             </div>
           </div>

--- a/apps/web/src/components/automations/hook-list.tsx
+++ b/apps/web/src/components/automations/hook-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Plus, Webhook } from 'lucide-react';
+import { Plus, Radio, Webhook, Zap } from 'lucide-react';
 import type { Hook } from '@relay/core';
 import { useHooks } from '@/lib/queries';
 import { useStudio } from '@/lib/store';
@@ -9,20 +9,59 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
 function sourceLabel(hook: Hook): string {
-  return hook.source.kind === 'table'
-    ? hook.source.table
-    : 'custom query';
+  return hook.source.kind === 'table' ? hook.source.table : 'custom query';
 }
 
+function destLabel(hook: Hook): string {
+  try {
+    const { hostname } = new URL(hook.destination.url);
+    return `${hook.destination.method} ${hostname}`;
+  } catch {
+    return hook.destination.method;
+  }
+}
+
+const TABS = [
+  { id: 'hooks' as const, label: 'Hooks', icon: Radio, hint: 'live' },
+  { id: 'jobs' as const, label: 'Jobs', icon: Zap, hint: 'on-demand' },
+];
+
 export function HookList() {
-  const { selectedHookId, selectHook, openHookEditor } = useStudio();
+  const { automationTab, setAutomationTab, selectedHookId, selectHook, openHookEditor } =
+    useStudio();
   const { data: hooks, isLoading } = useHooks();
+
+  const isHooks = automationTab === 'hooks';
+  const visible =
+    hooks?.filter((h) =>
+      isHooks ? h.trigger.kind !== 'replay' : h.trigger.kind === 'replay',
+    ) ?? [];
+  const noun = isHooks ? 'hook' : 'job';
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      {/* Hooks / Jobs tabs */}
+      <div className="grid grid-cols-2 gap-1 px-2 pt-2">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setAutomationTab(t.id)}
+            className={cn(
+              'flex items-center justify-center gap-1.5 rounded-md py-1.5 text-xs font-medium transition-colors',
+              automationTab === t.id
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:bg-accent',
+            )}
+          >
+            <t.icon className="h-3.5 w-3.5" />
+            {t.label}
+          </button>
+        ))}
+      </div>
+
       <div className="flex items-center justify-between px-3 py-2">
-        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Hooks
+        <span className="text-muted-foreground text-[11px] uppercase tracking-wide">
+          {isHooks ? 'Listen & deliver new rows' : 'Send data on demand'}
         </span>
         <Button
           size="sm"
@@ -37,30 +76,32 @@ export function HookList() {
 
       <ScrollArea className="min-h-0 flex-1 px-2 pb-2">
         {isLoading && (
-          <p className="px-2 py-3 text-sm text-muted-foreground">Loading…</p>
+          <p className="text-muted-foreground px-2 py-3 text-sm">Loading…</p>
         )}
-        {!isLoading && (hooks?.length ?? 0) === 0 && (
-          <div className="px-2 py-6 text-center text-sm text-muted-foreground">
-            <Webhook className="mx-auto mb-2 h-6 w-6 opacity-50" />
-            No hooks yet.
+        {!isLoading && visible.length === 0 && (
+          <div className="text-muted-foreground px-2 py-6 text-center text-sm">
+            {isHooks ? (
+              <Radio className="mx-auto mb-2 h-6 w-6 opacity-50" />
+            ) : (
+              <Zap className="mx-auto mb-2 h-6 w-6 opacity-50" />
+            )}
+            No {noun}s yet.
             <button
-              className="mt-1 block w-full text-primary hover:underline"
+              className="text-primary mt-1 block w-full hover:underline"
               onClick={() => openHookEditor()}
             >
-              Create your first hook
+              Create your first {noun}
             </button>
           </div>
         )}
         <div className="flex flex-col gap-0.5">
-          {hooks?.map((hook) => (
+          {visible.map((hook) => (
             <button
               key={hook.id}
               onClick={() => selectHook(hook.id)}
               className={cn(
                 'flex flex-col gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors',
-                selectedHookId === hook.id
-                  ? 'bg-accent'
-                  : 'hover:bg-accent/50',
+                selectedHookId === hook.id ? 'bg-accent' : 'hover:bg-accent/50',
               )}
             >
               <div className="flex items-center gap-1.5">
@@ -72,8 +113,8 @@ export function HookList() {
                 />
                 <span className="truncate text-sm font-medium">{hook.name}</span>
               </div>
-              <span className="truncate pl-3 font-mono text-xs text-muted-foreground">
-                {sourceLabel(hook)} → {hook.destination.method}
+              <span className="text-muted-foreground truncate pl-3 font-mono text-xs">
+                {sourceLabel(hook)} → {destLabel(hook)}
               </span>
             </button>
           ))}

--- a/apps/web/src/components/automations/run-detail.tsx
+++ b/apps/web/src/components/automations/run-detail.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { Ban, Loader2, RotateCcw } from 'lucide-react';
+import { Ban, Loader2, Play, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 import type { HookRun, HookRunStatus } from '@relay/core';
 import { ApiError } from '@/lib/api';
-import { useCancelHookRun, useStartHookRun } from '@/lib/queries';
+import { useCancelHookRun, useRetryFailed, useStartHookRun } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { DeliveryMonitor } from './delivery-log';
@@ -17,6 +17,7 @@ const STATUS_STYLES: Record<HookRunStatus, string> = {
   failed: 'bg-destructive/15 text-destructive',
   canceling: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
   canceled: 'bg-muted text-muted-foreground',
+  paused: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
   interrupted: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
 };
 
@@ -37,7 +38,7 @@ export function RunStatusBadge({ status }: { status: HookRunStatus }) {
 }
 
 const ACTIVE: HookRunStatus[] = ['queued', 'running', 'canceling'];
-const RESUMABLE: HookRunStatus[] = ['failed', 'canceled', 'interrupted'];
+const RESUMABLE: HookRunStatus[] = ['failed', 'canceled', 'paused', 'interrupted'];
 
 function Stat({
   label,
@@ -71,16 +72,18 @@ function Stat({
 export function RunDetail({
   hookId,
   run,
-  batchSize,
   endpoint,
+  isHook,
 }: {
   hookId: string;
   run: HookRun;
-  batchSize: number;
   endpoint: { url: string; method: string };
+  /** Hooks (watch/CDC) are continuous listeners: no Cancel/Resume, no progress. */
+  isHook: boolean;
 }) {
   const cancel = useCancelHookRun(hookId);
   const startRun = useStartHookRun(hookId);
+  const retryFailed = useRetryFailed(hookId);
 
   const isActive = ACTIVE.includes(run.status);
   const total = run.totalCount;
@@ -114,8 +117,8 @@ export function RunDetail({
 
   async function handleRetry() {
     try {
-      await startRun.mutateAsync({ retryFailedOf: run.id });
-      toast.success('Retrying failed rows with the current config');
+      await retryFailed.mutateAsync(run.id);
+      toast.success('Resending failed deliveries with the current config');
     } catch (err) {
       toast.error('Could not retry', {
         description: err instanceof ApiError ? err.message : String(err),
@@ -123,7 +126,8 @@ export function RunDetail({
     }
   }
 
-  const canRetry = !isActive && run.failedCount > 0;
+  // Available whenever there are failures — including a live (CDC/watch) run.
+  const canRetry = run.failedCount > 0;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -131,12 +135,22 @@ export function RunDetail({
       <div className="flex items-center gap-3 px-4 pt-3">
         <RunStatusBadge status={run.status} />
         <span className="text-muted-foreground text-xs">
-          started {new Date(run.startedAt).toLocaleString()}
+          {isHook
+            ? isActive
+              ? `listening since ${new Date(run.startedAt).toLocaleString()}`
+              : `last active ${new Date(run.startedAt).toLocaleString()}`
+            : `started ${new Date(run.startedAt).toLocaleString()}`}
         </span>
         <div className="ml-auto flex items-center gap-2">
-          {isActive && (
+          {/* Cancel/Resume are job controls. A hook is started/stopped from the
+              panel header above — "resuming" one would re-stream the whole table. */}
+          {!isHook && isActive && (
             <Button size="sm" variant="outline" onClick={handleCancel} disabled={cancel.isPending}>
-              <Ban className="mr-1.5 h-3.5 w-3.5" />
+              {cancel.isPending ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Ban className="mr-1.5 h-3.5 w-3.5" />
+              )}
               Cancel
             </Button>
           )}
@@ -145,57 +159,80 @@ export function RunDetail({
               size="sm"
               variant="outline"
               onClick={handleRetry}
-              disabled={startRun.isPending}
+              disabled={retryFailed.isPending}
             >
-              <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+              {retryFailed.isPending ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+              )}
               Retry failed ({run.failedCount})
             </Button>
           )}
-          {RESUMABLE.includes(run.status) && (
+          {!isHook && RESUMABLE.includes(run.status) && (
             <Button
               size="sm"
               variant="outline"
               onClick={handleResume}
               disabled={startRun.isPending}
             >
-              <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+              {startRun.isPending ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+              )}
               Resume
             </Button>
           )}
         </div>
       </div>
 
-      {/* Stat cards */}
-      <div className="grid grid-cols-3 gap-2 px-4 py-3 sm:grid-cols-6">
-        <Stat label="Total" value={total != null ? total.toLocaleString() : '—'} />
-        <Stat label="Delivered" value={run.sentCount.toLocaleString()} tone="success" />
-        <Stat label="Failed" value={run.failedCount.toLocaleString()} tone="danger" />
-        <Stat label="Skipped" value={run.skippedCount.toLocaleString()} tone="warn" />
-        <Stat
-          label="Queued"
-          value={pending != null ? pending.toLocaleString() : '—'}
-          tone="muted"
-        />
-        <Stat
-          label="Success"
-          value={successRate != null ? `${successRate}%` : '—'}
-        />
-      </div>
-
-      {/* Progress */}
-      {pct != null && (
-        <div className="px-4 pb-3">
-          <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
-            <div
-              className="bg-primary h-full rounded-full transition-all"
-              style={{ width: `${pct}%` }}
+      {/* Stat cards — a listener has no finite total/queue, so it shows a
+          delivered/failed/skipped breakdown instead of progress-to-completion. */}
+      {isHook ? (
+        <div className="grid grid-cols-2 gap-2 px-4 py-3 sm:grid-cols-4">
+          <Stat label="Delivered" value={run.sentCount.toLocaleString()} tone="success" />
+          <Stat label="Failed" value={run.failedCount.toLocaleString()} tone="danger" />
+          <Stat label="Skipped" value={run.skippedCount.toLocaleString()} tone="warn" />
+          <Stat
+            label="Success"
+            value={successRate != null ? `${successRate}%` : '—'}
+          />
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-2 px-4 py-3 sm:grid-cols-6">
+            <Stat label="Total" value={total != null ? total.toLocaleString() : '—'} />
+            <Stat label="Delivered" value={run.sentCount.toLocaleString()} tone="success" />
+            <Stat label="Failed" value={run.failedCount.toLocaleString()} tone="danger" />
+            <Stat label="Skipped" value={run.skippedCount.toLocaleString()} tone="warn" />
+            <Stat
+              label="Queued"
+              value={pending != null ? pending.toLocaleString() : '—'}
+              tone="muted"
+            />
+            <Stat
+              label="Success"
+              value={successRate != null ? `${successRate}%` : '—'}
             />
           </div>
-        </div>
+
+          {/* Progress */}
+          {pct != null && (
+            <div className="px-4 pb-3">
+              <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
+                <div
+                  className="bg-primary h-full rounded-full transition-all"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          )}
+        </>
       )}
 
       {run.error && (
-        <p className="border-y bg-destructive/10 text-destructive px-4 py-2 text-xs">
+        <p className="border-y bg-destructive/10 text-destructive px-4 py-2 text-xs break-words">
           {run.error}
         </p>
       )}
@@ -206,7 +243,7 @@ export function RunDetail({
           runId={run.id}
           live={isActive}
           totalRows={total}
-          batchSize={batchSize}
+          batchSize={run.batchSize}
           endpoint={endpoint}
         />
       </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,6 +10,8 @@ import type {
   CreateTableSpec,
   DatabaseSchema,
   DeleteRowParams,
+  CdcReadiness,
+  CdcReadinessDTO,
   DriverInfo,
   Hook,
   HookDelivery,
@@ -244,6 +246,14 @@ export const api = {
       method: 'POST',
       ...jsonBody({ sequences }),
     }),
+  startWatch: (id: string) =>
+    request<HookRun>(`/hooks/${id}/watch/start`, { method: 'POST' }),
+  stopWatch: (id: string) =>
+    request<HookRun | null>(`/hooks/${id}/watch/stop`, { method: 'POST' }),
+  cdcReadiness: (body: CdcReadinessDTO) =>
+    request<CdcReadiness>('/hooks/cdc/readiness', { method: 'POST', ...jsonBody(body) }),
+  retryFailedDeliveries: (id: string, runId: string) =>
+    request<HookRun>(`/hooks/${id}/runs/${runId}/retry-failed`, { method: 'POST' }),
 };
 
 function dbQuery(database?: string): string {

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import {
   useMutation,
   useQuery,
@@ -147,6 +148,33 @@ export function useStartHookRun(hookId: string) {
   });
 }
 
+export function useStartWatch(hookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.startWatch(hookId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+  });
+}
+
+export function useStopWatch(hookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.stopWatch(hookId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+  });
+}
+
+export function useRetryFailed(hookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (runId: string) => api.retryFailedDeliveries(hookId, runId),
+    onSuccess: (_d, runId) => {
+      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) });
+      qc.invalidateQueries({ queryKey: queryKeys.hookDeliveries(hookId, runId) });
+    },
+  });
+}
+
 export function useCancelHookRun(hookId: string) {
   const qc = useQueryClient();
   return useMutation({
@@ -178,7 +206,10 @@ export function useHookDeliveries(
   live: boolean,
   opts: { status?: 'success' | 'failed' | 'skipped'; from?: number; to?: number } = {},
 ) {
-  return useQuery({
+  const qc = useQueryClient();
+  const prevLiveRef = useRef(live);
+
+  const query = useQuery({
     queryKey:
       hookId && runId
         ? [...queryKeys.hookDeliveries(hookId, runId), opts]
@@ -190,7 +221,23 @@ export function useHookDeliveries(
       }),
     enabled: !!hookId && !!runId,
     refetchInterval: live ? 1500 : false,
+    staleTime: 0,
   });
+
+  const { refetch } = query;
+
+  // When a run transitions from active → terminal, fire one final refetch so
+  // deliveries written in the gap between the last poll and completion are shown.
+  // Also invalidate all sibling windows so navigating to another page is fresh.
+  useEffect(() => {
+    if (prevLiveRef.current && !live && hookId && runId) {
+      void refetch();
+      void qc.invalidateQueries({ queryKey: queryKeys.hookDeliveries(hookId, runId) });
+    }
+    prevLiveRef.current = live;
+  }, [live, hookId, runId, refetch, qc]);
+
+  return query;
 }
 
 export function useSkipDeliveries(hookId: string, runId: string) {

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -5,6 +5,9 @@ import type { RelationKind } from '@relay/core';
 
 export type StudioTab = 'data' | 'query' | 'structure' | 'diagram';
 
+/** Sidebar grouping: live "Hooks" (watch trigger) vs on-demand "Jobs" (replay). */
+export type AutomationTab = 'hooks' | 'jobs';
+
 export interface SelectedRelation {
   schema?: string;
   table: string;
@@ -42,7 +45,8 @@ interface StudioState {
   /** Connection editor dialog state. */
   dialog: { open: boolean; editingId: string | null };
 
-  /** Hooks surface: the currently selected hook. */
+  /** Hooks surface: which sidebar group is active + the selected hook. */
+  automationTab: AutomationTab;
   selectedHookId: string | null;
   /** Hook editor dialog: open + which hook (null = new) + optional prefill. */
   hookEditor: {
@@ -62,6 +66,7 @@ interface StudioState {
   selectRelation: (rel: SelectedRelation) => void;
   setTab: (tab: StudioTab) => void;
 
+  setAutomationTab: (tab: AutomationTab) => void;
   selectHook: (id: string | null) => void;
   openHookEditor: (opts?: {
     editingId?: string | null;
@@ -90,6 +95,7 @@ export const useStudio = create<StudioState>((set) => ({
   selected: null,
   tab: 'data',
   dialog: { open: false, editingId: null },
+  automationTab: 'hooks',
   selectedHookId: null,
   hookEditor: { open: false, editingId: null, seed: null },
   dataSourcesOpen: false,
@@ -98,6 +104,7 @@ export const useStudio = create<StudioState>((set) => ({
 
   // Selecting a hook and browsing a table are mutually exclusive — the main
   // view shows the table preview when one is picked, else the hooks workspace.
+  setAutomationTab: (tab) => set({ automationTab: tab }),
   selectHook: (id) => set({ selectedHookId: id, selected: null }),
   openHookEditor: (opts) =>
     set({

--- a/packages/core/src/hooks/hook-config.ts
+++ b/packages/core/src/hooks/hook-config.ts
@@ -91,12 +91,53 @@ export const hookDeliverySchema = z.object({
 /* Hook                                                                       */
 /* -------------------------------------------------------------------------- */
 
+/* -------------------------------------------------------------------------- */
+/* Trigger — when the hook runs                                               */
+/* -------------------------------------------------------------------------- */
+
+export const watchStrategySchema = z.discriminatedUnion('strategy', [
+  // Track a strictly-increasing column (auto-increment id / sequence).
+  z.object({ strategy: z.literal('increment'), column: z.string().min(1) }),
+  // Track a created_at / updated_at column.
+  z.object({ strategy: z.literal('timestamp'), column: z.string().min(1) }),
+  // Diff the set of seen primary keys (for UUID / non-monotonic keys).
+  z.object({
+    strategy: z.literal('snapshot'),
+    maxTracked: z.coerce.number().int().min(100).max(200_000).default(50_000),
+  }),
+]);
+
+export const cdcOperationSchema = z.enum(['insert', 'update', 'delete']);
+
+export const hookTriggerSchema = z.discriminatedUnion('kind', [
+  // Run on demand (replay the source when you press Run).
+  z.object({ kind: z.literal('replay') }),
+  // Continuously poll the source for new rows and deliver them live.
+  z.object({
+    kind: z.literal('watch'),
+    strategy: watchStrategySchema,
+    pollIntervalMs: z.coerce.number().int().min(1000).max(3_600_000).default(5000),
+    /** `now` ignores existing rows and only delivers ones added after start. */
+    startFrom: z.enum(['beginning', 'now']).default('now'),
+    /** Max rows delivered per poll cycle (backpressure). */
+    maxPerPoll: z.coerce.number().int().min(1).max(5000).default(500),
+  }),
+  // Event-based: stream changes from the database's transaction log (CDC).
+  // Real-time, no polling. Requires engine support + log enabled (e.g. Postgres
+  // logical replication). The publication/slot are auto-provisioned.
+  z.object({
+    kind: z.literal('cdc'),
+    operations: z.array(cdcOperationSchema).min(1).default(['insert', 'update', 'delete']),
+  }),
+]);
+
 export const hookInputSchema = z.object({
   name: z.string().min(1, 'Name is required').max(120),
   source: hookSourceSchema,
   destination: hookDestinationSchema,
   transform: hookTransformSchema,
   delivery: hookDeliverySchema.default({}),
+  trigger: hookTriggerSchema.default({ kind: 'replay' }),
   enabled: z.boolean().default(true),
 });
 
@@ -121,6 +162,14 @@ export const skipSchema = z.object({
   sequences: z.array(z.coerce.number().int().min(0)).min(1).max(10_000),
 });
 
+/** Check whether a connection+table can do event-based (CDC) delivery. */
+export const cdcReadinessSchema = z.object({
+  connectionId: z.string().min(1),
+  database: z.string().optional(),
+  schema: z.string().optional(),
+  table: z.string().min(1),
+});
+
 /* -------------------------------------------------------------------------- */
 /* Inferred types + DTOs surfaced to the web client                           */
 /* -------------------------------------------------------------------------- */
@@ -130,7 +179,23 @@ export type HookAuth = z.infer<typeof hookAuthSchema>;
 export type HookDestination = z.infer<typeof hookDestinationSchema>;
 export type HookTransformConfig = z.infer<typeof hookTransformSchema>;
 export type HookDeliveryConfig = z.infer<typeof hookDeliverySchema>;
+export type HookTrigger = z.infer<typeof hookTriggerSchema>;
+export type WatchStrategyConfig = z.infer<typeof watchStrategySchema>;
+export type CdcOperation = z.infer<typeof cdcOperationSchema>;
+export type CdcReadinessDTO = z.infer<typeof cdcReadinessSchema>;
 export type HookInputDTO = z.infer<typeof hookInputSchema>;
+
+/** Result of a CDC readiness probe — drives the builder's setup panel. */
+export interface CdcReadiness {
+  engine: string;
+  /** Whether this engine has an event-based path implemented at all. */
+  supported: boolean;
+  /** Whether the DB is configured and ready to stream right now. */
+  ready: boolean;
+  checks: { label: string; ok: boolean; detail?: string }[];
+  /** Manual steps the user must do (e.g. set wal_level=logical + restart). */
+  instructions: string[];
+}
 export type HookPreviewDTO = z.infer<typeof hookPreviewSchema>;
 export type StartRunDTO = z.infer<typeof startRunSchema>;
 export type SkipDTO = z.infer<typeof skipSchema>;
@@ -143,6 +208,7 @@ export type HookRunStatus =
   | 'failed'
   | 'canceling'
   | 'canceled'
+  | 'paused' // stopped by the user; resumable in place (same run)
   | 'interrupted';
 
 export type DeliveryStatus = 'success' | 'failed' | 'skipped';
@@ -155,6 +221,7 @@ export interface Hook {
   destination: HookDestination;
   transform: HookTransformConfig;
   delivery: HookDeliveryConfig;
+  trigger: HookTrigger;
   enabled: boolean;
   createdAt: string;
   updatedAt: string;
@@ -169,6 +236,8 @@ export interface HookRun {
   failedCount: number;
   skippedCount: number;
   totalCount: number | null;
+  /** Batch size from the config snapshot used to create this run. */
+  batchSize: number;
   error: string | null;
   startedAt: string;
   finishedAt: string | null;

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './transform';
 export * from './hook-config';
+export * from './watch';

--- a/packages/core/src/hooks/watch.test.ts
+++ b/packages/core/src/hooks/watch.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  advanceCursor,
+  emptyCursor,
+  rowKey,
+  watchQuery,
+  type SnapshotStrategy,
+  type TimestampStrategy,
+  type WatchStrategy,
+} from './watch';
+
+const INC: WatchStrategy = { strategy: 'increment', column: 'id' };
+const TS: TimestampStrategy = { strategy: 'timestamp', column: 'updated_at' };
+const SNAP: SnapshotStrategy = { strategy: 'snapshot', maxTracked: 100 };
+
+describe('increment strategy', () => {
+  it('first poll fetches everything, ordered; later polls fetch only newer', () => {
+    let cursor = emptyCursor(INC);
+    expect(watchQuery(INC, cursor)).toEqual({
+      filters: [],
+      sort: [{ column: 'id', direction: 'asc' }],
+    });
+
+    const first = advanceCursor(INC, cursor, [{ id: 1 }, { id: 2 }, { id: 3 }], ['id']);
+    expect(first.newRows.map((r) => r.id)).toEqual([1, 2, 3]);
+    cursor = first.cursor;
+
+    expect(watchQuery(INC, cursor)).toEqual({
+      filters: [{ column: 'id', operator: 'gt', value: 3 }],
+      sort: [{ column: 'id', direction: 'asc' }],
+    });
+
+    const second = advanceCursor(INC, cursor, [{ id: 4 }, { id: 5 }], ['id']);
+    expect(second.newRows.map((r) => r.id)).toEqual([4, 5]);
+    expect(second.cursor).toMatchObject({ value: 5 });
+  });
+
+  it('no new rows leaves the cursor put', () => {
+    const cursor = { strategy: 'increment' as const, value: 9 };
+    const r = advanceCursor(INC, cursor, [], ['id']);
+    expect(r.newRows).toEqual([]);
+    expect(r.cursor).toMatchObject({ value: 9 });
+  });
+});
+
+describe('timestamp strategy', () => {
+  it('dedupes rows sharing the boundary timestamp across polls', () => {
+    let cursor = emptyCursor(TS);
+    // Poll 1: two rows at t1, one at t2.
+    const p1 = advanceCursor(
+      TS,
+      cursor,
+      [
+        { id: 1, updated_at: '2026-01-01T00:00:00Z' },
+        { id: 2, updated_at: '2026-01-01T00:00:00Z' },
+        { id: 3, updated_at: '2026-01-01T00:00:05Z' },
+      ],
+      ['id'],
+    );
+    expect(p1.newRows.map((r) => r.id)).toEqual([1, 2, 3]);
+    cursor = p1.cursor;
+    // Cursor sits at t2 with id 3 as the boundary key.
+    expect(watchQuery(TS, cursor).filters).toEqual([
+      { column: 'updated_at', operator: 'gte', value: '2026-01-01T00:00:05Z' },
+    ]);
+
+    // Poll 2 re-fetches id 3 (>= boundary) plus a new id 4 at the same instant.
+    const p2 = advanceCursor(
+      TS,
+      cursor,
+      [
+        { id: 3, updated_at: '2026-01-01T00:00:05Z' },
+        { id: 4, updated_at: '2026-01-01T00:00:05Z' },
+      ],
+      ['id'],
+    );
+    // id 3 already emitted → only id 4 is new; both remembered as boundary.
+    expect(p2.newRows.map((r) => r.id)).toEqual([4]);
+  });
+
+  it('accepts Date values and serializes the cursor as an ISO string', () => {
+    const cursor = emptyCursor(TS);
+    const r = advanceCursor(
+      TS,
+      cursor,
+      [{ id: 1, updated_at: new Date('2026-03-04T10:00:00Z') }],
+      ['id'],
+    );
+    expect(r.cursor).toMatchObject({ ts: '2026-03-04T10:00:00.000Z' });
+  });
+});
+
+describe('snapshot strategy', () => {
+  it('emits only previously-unseen primary keys', () => {
+    let cursor = emptyCursor(SNAP);
+    const p1 = advanceCursor(SNAP, cursor, [{ id: 'a' }, { id: 'b' }], ['id']);
+    expect(p1.newRows.map((r) => r.id)).toEqual(['a', 'b']);
+    cursor = p1.cursor;
+
+    const p2 = advanceCursor(SNAP, cursor, [{ id: 'a' }, { id: 'b' }, { id: 'c' }], ['id']);
+    expect(p2.newRows.map((r) => r.id)).toEqual(['c']);
+  });
+
+  it('bounds the tracked-key set', () => {
+    const strat: SnapshotStrategy = { strategy: 'snapshot', maxTracked: 3 };
+    let cursor = emptyCursor(strat);
+    cursor = advanceCursor(strat, cursor, [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }], ['id']).cursor;
+    expect((cursor as { seen: string[] }).seen.length).toBe(3);
+  });
+});
+
+describe('rowKey', () => {
+  it('is stable for the same primary key values', () => {
+    expect(rowKey({ id: 1, x: 9 }, ['id'])).toBe(rowKey({ id: 1, x: 7 }, ['id']));
+    expect(rowKey({ id: 1 }, ['id'])).not.toBe(rowKey({ id: 2 }, ['id']));
+  });
+});

--- a/packages/core/src/hooks/watch.ts
+++ b/packages/core/src/hooks/watch.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure change-detection engine for "watch" hooks. Given a strategy and the
+ * cursor persisted from the last poll, it produces the browse query for the
+ * next poll and, from the rows that came back, the *new* rows plus the advanced
+ * cursor. It performs no I/O, so it is fully unit-testable.
+ *
+ * Three polling strategies, each suited to a different table shape:
+ *
+ *  - `increment` — a strictly-increasing column (auto-increment id, sequence).
+ *    `col > cursor`, ordered ascending. Exact: never misses or duplicates a row.
+ *    Detects inserts only.
+ *  - `timestamp` — a `created_at`/`updated_at` column. `col >= cursor` with
+ *    boundary-key dedupe so rows sharing the cursor's timestamp are emitted
+ *    exactly once. Detects inserts and (for `updated_at`) updates.
+ *  - `snapshot` — diff the set of seen primary keys (bounded). Works when there
+ *    is no monotonic cursor (e.g. UUID keys). Best for small/medium tables.
+ */
+import type { FilterSpec, SortSpec } from '../adapters/types';
+
+export type Row = Record<string, unknown>;
+
+/* -------------------------------------------------------------------------- */
+/* Strategy + cursor shapes                                                   */
+/* -------------------------------------------------------------------------- */
+
+export interface IncrementStrategy {
+  strategy: 'increment';
+  column: string;
+}
+export interface TimestampStrategy {
+  strategy: 'timestamp';
+  column: string;
+}
+export interface SnapshotStrategy {
+  strategy: 'snapshot';
+  /** Cap on tracked primary keys (bounds memory/state). */
+  maxTracked: number;
+}
+export type WatchStrategy =
+  | IncrementStrategy
+  | TimestampStrategy
+  | SnapshotStrategy;
+
+export interface IncrementCursor {
+  strategy: 'increment';
+  value: unknown;
+}
+export interface TimestampCursor {
+  strategy: 'timestamp';
+  ts: unknown;
+  /** Row keys already emitted at exactly `ts` (dedupe on the `>=` re-fetch). */
+  boundaryKeys: string[];
+}
+export interface SnapshotCursor {
+  strategy: 'snapshot';
+  seen: string[];
+}
+export type WatchCursor = IncrementCursor | TimestampCursor | SnapshotCursor;
+
+export interface AdvanceResult {
+  newRows: Row[];
+  cursor: WatchCursor;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/** Stable identity for a row from its primary key (falls back to all values). */
+export function rowKey(row: Row, pk: string[]): string {
+  const cols = pk.length > 0 ? pk : Object.keys(row).sort();
+  return JSON.stringify(cols.map((c) => row[c] ?? null));
+}
+
+/** Compare two timestamp-ish values (Date | ISO string | epoch number). */
+function tsEquals(a: unknown, b: unknown): boolean {
+  const norm = (v: unknown): number | string => {
+    if (v instanceof Date) return v.getTime();
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string') {
+      const t = Date.parse(v);
+      return Number.isNaN(t) ? v : t;
+    }
+    return String(v);
+  };
+  return norm(a) === norm(b);
+}
+
+/** A serializable form of a timestamp value for persisting in the cursor. */
+function serializeTs(v: unknown): unknown {
+  return v instanceof Date ? v.toISOString() : v;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Engine                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/** The cursor for a brand-new watch run that should emit from the beginning. */
+export function emptyCursor(strategy: WatchStrategy): WatchCursor {
+  switch (strategy.strategy) {
+    case 'increment':
+      return { strategy: 'increment', value: null };
+    case 'timestamp':
+      return { strategy: 'timestamp', ts: null, boundaryKeys: [] };
+    case 'snapshot':
+      return { strategy: 'snapshot', seen: [] };
+  }
+}
+
+/** The browse filters + sort for the next poll, given the current cursor. */
+export function watchQuery(
+  strategy: WatchStrategy,
+  cursor: WatchCursor,
+): { filters: FilterSpec[]; sort: SortSpec[] } {
+  if (strategy.strategy === 'increment' && cursor.strategy === 'increment') {
+    return {
+      filters:
+        cursor.value != null
+          ? [{ column: strategy.column, operator: 'gt', value: cursor.value }]
+          : [],
+      sort: [{ column: strategy.column, direction: 'asc' }],
+    };
+  }
+  if (strategy.strategy === 'timestamp' && cursor.strategy === 'timestamp') {
+    return {
+      filters:
+        cursor.ts != null
+          ? [{ column: strategy.column, operator: 'gte', value: cursor.ts }]
+          : [],
+      sort: [{ column: strategy.column, direction: 'asc' }],
+    };
+  }
+  // snapshot: scan the table (caller bounds the page size).
+  return { filters: [], sort: [] };
+}
+
+/**
+ * From the candidate rows returned by {@link watchQuery} (already filtered and
+ * sorted ascending), return the genuinely-new rows and the advanced cursor.
+ */
+export function advanceCursor(
+  strategy: WatchStrategy,
+  cursor: WatchCursor,
+  rows: Row[],
+  pk: string[],
+): AdvanceResult {
+  if (strategy.strategy === 'increment' && cursor.strategy === 'increment') {
+    // Every row is strictly greater than the cursor by query construction.
+    const last = rows[rows.length - 1];
+    return {
+      newRows: rows,
+      cursor: {
+        strategy: 'increment',
+        value: last ? last[strategy.column] : cursor.value,
+      },
+    };
+  }
+
+  if (strategy.strategy === 'timestamp' && cursor.strategy === 'timestamp') {
+    const alreadyEmitted = new Set(cursor.boundaryKeys);
+    const newRows = rows.filter((r) => !alreadyEmitted.has(rowKey(r, pk)));
+    if (rows.length === 0) {
+      return { newRows, cursor };
+    }
+    // Rows are sorted ascending → the last one carries the max timestamp.
+    const maxTs = rows[rows.length - 1]![strategy.column];
+    // All rows at the boundary timestamp are remembered so the next `>=` poll
+    // can dedupe them.
+    const boundaryKeys = rows
+      .filter((r) => tsEquals(r[strategy.column], maxTs))
+      .map((r) => rowKey(r, pk));
+    return {
+      newRows,
+      cursor: {
+        strategy: 'timestamp',
+        ts: serializeTs(maxTs),
+        boundaryKeys,
+      },
+    };
+  }
+
+  // snapshot
+  const seen = new Set(cursor.strategy === 'snapshot' ? cursor.seen : []);
+  const newRows: Row[] = [];
+  for (const r of rows) {
+    const k = rowKey(r, pk);
+    if (!seen.has(k)) {
+      seen.add(k);
+      newRows.push(r);
+    }
+  }
+  const max = strategy.strategy === 'snapshot' ? strategy.maxTracked : 50_000;
+  let kept = [...seen];
+  if (kept.length > max) kept = kept.slice(kept.length - max);
+  return { newRows, cursor: { strategy: 'snapshot', seen: kept } };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,12 @@ importers:
       ioredis:
         specifier: ^5.4.1
         version: 5.11.0
+      pg:
+        specifier: ^8.13.1
+        version: 8.21.0
+      pg-logical-replication:
+        specifier: ^2.0.3
+        version: 2.5.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -2691,6 +2697,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter2@6.4.9:
+    resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -3630,6 +3639,10 @@ packages:
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
+
+  pg-logical-replication@2.5.0:
+    resolution: {integrity: sha512-5nzrBxiZBTRCWbu1wfzOVG2+BUPpcG+r8yUZW5ld+ia+kgSWwRxI3GukYp0f+/7L+3ecWuUnIMmEC4/CL8bGLg==}
+    engines: {node: '>=20.0.0'}
 
   pg-pool@3.14.0:
     resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
@@ -7258,6 +7271,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter2@6.4.9: {}
+
   events@3.3.0: {}
 
   expand-template@2.0.3: {}
@@ -8242,6 +8257,13 @@ snapshots:
   pg-connection-string@2.13.0: {}
 
   pg-int8@1.0.1: {}
+
+  pg-logical-replication@2.5.0:
+    dependencies:
+      eventemitter2: 6.4.9
+      pg: 8.21.0
+    transitivePeerDependencies:
+      - pg-native
 
   pg-pool@3.14.0(pg@8.21.0):
     dependencies:

--- a/receiver.js
+++ b/receiver.js
@@ -1,0 +1,27 @@
+const http = require('http');
+
+const PORT = 4000;
+
+const server = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (chunk) => { body += chunk; });
+  req.on('end', () => {
+    const timestamp = new Date().toISOString();
+    console.log(`\n[${timestamp}] ${req.method} ${req.url}`);
+
+    if (body) {
+      try {
+        console.log(JSON.stringify(JSON.parse(body), null, 2));
+      } catch {
+        console.log(body);
+      }
+    }
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Receiver listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
…e UX polish

- @relay/core: add cursor-based watch engine (increment/timestamp/snapshot strategies) with full unit tests; export watchQuery/advanceCursor/emptyCursor
- API: HookWatchService polls tables on a BullMQ scheduler with adaptive cadence (fast while rows flow, backs off when quiet); HookCdcService provisions PostgreSQL logical replication slots and publications per hook, updating the publication when the source table changes
- API: fix batchSize sourced from configSnapshotJson (not current hook config) so the delivery chart stays accurate even after a hook is edited post-run; fix skipDeliveries row count for partial last batch; fix DeliveryStatus cast
- Frontend: DeliveryMonitor now fires a final refetch when a run transitions to terminal, closing the gap where last-second deliveries were missed; adds pulsing LIVE badge, auto-follow paging, spinner empty state, and cleaner skip-sequence UX
- Hook builder: hide row-selection UI for watch/CDC hooks (column-only mode); fix unstable array refs that broke Next.js production ESLint build
- Hook list: show Radio icon for hooks, Zap for jobs; subtitle shows source → destination hostname
- Add receiver.js local test server for end-to-end endpoint testing