### PR TITLE
Add workspaces, reframe hooks as bridges, and a live workspace map

### DIFF
--- a/apps/api/prisma/migrations/20260619000000_workspaces/migration.sql
+++ b/apps/api/prisma/migrations/20260619000000_workspaces/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "workspaces" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "workspaces_pkey" PRIMARY KEY ("id")
+);
+
+-- Seed the default workspace that every install starts with.
+INSERT INTO "workspaces" ("id", "name", "updated_at")
+VALUES ('00000000-0000-0000-0000-000000000001', 'Default workspace', CURRENT_TIMESTAMP);
+
+-- Add workspace_id to existing tables, backfilling current rows to the default
+-- workspace via a temporary column default, then dropping the default so future
+-- inserts must set it explicitly.
+ALTER TABLE "connections" ADD COLUMN "workspace_id" TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+ALTER TABLE "connections" ALTER COLUMN "workspace_id" DROP DEFAULT;
+
+ALTER TABLE "hooks" ADD COLUMN "workspace_id" TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+ALTER TABLE "hooks" ALTER COLUMN "workspace_id" DROP DEFAULT;
+
+-- CreateIndex
+CREATE INDEX "connections_workspace_id_idx" ON "connections"("workspace_id");
+CREATE INDEX "hooks_workspace_id_idx" ON "hooks"("workspace_id");
+
+-- AddForeignKey
+ALTER TABLE "connections" ADD CONSTRAINT "connections_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "hooks" ADD CONSTRAINT "hooks_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -13,9 +13,29 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+//  Workspace — the top-level container. Owns connections and hooks (bridges).
+//  Every install has a default workspace so the concept stays invisible until
+//  someone wants a second one.
+// ─────────────────────────────────────────────────────────────────────────────
+
+model Workspace {
+  id        String   @id
+  name      String
+  color     String?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  connections Connection[]
+  hooks       Hook[]
+
+  @@map("workspaces")
+}
+
 model Connection {
   id                  String   @id
   name                String
+  workspaceId         String   @map("workspace_id")
   engine              String
   color               String?
   host                String?
@@ -29,6 +49,9 @@ model Connection {
   createdAt           DateTime @default(now()) @map("created_at")
   updatedAt           DateTime @updatedAt @map("updated_at")
 
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId])
   @@map("connections")
 }
 
@@ -45,6 +68,7 @@ model Connection {
 model Hook {
   id              String   @id
   name            String
+  workspaceId     String   @map("workspace_id")
   connectionId    String   @map("connection_id")
   sourceJson      String   @map("source_json")
   destinationJson String   @map("destination_json") // auth secret stripped
@@ -56,9 +80,11 @@ model Hook {
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @updatedAt @map("updated_at")
 
-  runs HookRun[]
+  runs      HookRun[]
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
   @@index([connectionId])
+  @@index([workspaceId])
   @@map("hooks")
 }
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { redisConnectionOptions } from './common/runtime-config';
 import { ConnectionsModule } from './connections/connections.module';
 import { DriversModule } from './drivers/drivers.module';
 import { HooksModule } from './hooks/hooks.module';
+import { WorkspacesModule } from './workspaces/workspaces.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { HooksModule } from './hooks/hooks.module';
     ConnectionsModule,
     DriversModule,
     HooksModule,
+    WorkspacesModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/connections/connection-store.service.ts
+++ b/apps/api/src/connections/connection-store.service.ts
@@ -9,6 +9,7 @@ import type { Connection as ConnectionRow } from '@prisma/client';
 import {
   type ConnectionConfig,
   type ConnectionInput,
+  DEFAULT_WORKSPACE_ID,
   NotFoundError,
 } from '@data-bridge/core';
 import { CryptoService } from '../common/crypto.service';
@@ -27,6 +28,7 @@ export class ConnectionStoreService {
     return {
       id: row.id,
       name: row.name,
+      workspaceId: row.workspaceId,
       engine: row.engine as ConnectionConfig['engine'],
       color: row.color ?? undefined,
       host: row.host ?? undefined,
@@ -60,8 +62,9 @@ export class ConnectionStoreService {
     return row;
   }
 
-  async list(): Promise<ConnectionConfig[]> {
+  async list(workspaceId?: string): Promise<ConnectionConfig[]> {
     const rows = await this.prisma.connection.findMany({
+      where: workspaceId ? { workspaceId } : undefined,
       orderBy: { name: 'asc' },
     });
     return rows.map((r) => this.toConfig(r, false));
@@ -81,6 +84,7 @@ export class ConnectionStoreService {
       data: {
         id: randomUUID(),
         name: input.name,
+        workspaceId: input.workspaceId ?? DEFAULT_WORKSPACE_ID,
         engine: input.engine,
         color: input.color ?? null,
         host: input.host ?? null,

--- a/apps/api/src/connections/connections.controller.ts
+++ b/apps/api/src/connections/connections.controller.ts
@@ -50,8 +50,10 @@ export class ConnectionsController {
   /* ----- CRUD ----- */
 
   @Get()
-  list(): Promise<ConnectionConfig[]> {
-    return this.store.list();
+  list(
+    @Query('workspaceId') workspaceId?: string,
+  ): Promise<ConnectionConfig[]> {
+    return this.store.list(workspaceId);
   }
 
   @Post()
@@ -71,6 +73,8 @@ export class ConnectionsController {
       createdAt: now,
       updatedAt: now,
       ...dto,
+      // a throwaway config just for a connectivity check; workspace is irrelevant
+      workspaceId: dto.workspaceId ?? 'test',
     };
     await this.pool.test(config);
     return { success: true };

--- a/apps/api/src/hooks/hook-run.service.ts
+++ b/apps/api/src/hooks/hook-run.service.ts
@@ -353,6 +353,26 @@ export class HookRunService implements OnModuleInit {
     return rows.map((r) => this.toRun(r));
   }
 
+  /**
+   * latest run status for every bridge in a workspace, in one query — feeds the
+   * workspace map so its edges can show live/failed/idle without N requests.
+   */
+  async workspaceStatuses(
+    workspaceId: string,
+  ): Promise<{ hookId: string; active: boolean; lastStatus: HookRunStatus }[]> {
+    const latest = await this.prisma.hookRun.findMany({
+      where: { hook: { workspaceId } },
+      orderBy: { startedAt: 'desc' },
+      distinct: ['hookId'],
+      select: { hookId: true, status: true },
+    });
+    return latest.map((r) => ({
+      hookId: r.hookId,
+      active: ACTIVE.includes(r.status as HookRunStatus),
+      lastStatus: r.status as HookRunStatus,
+    }));
+  }
+
   async getRun(hookId: string, runId: string): Promise<HookRun> {
     const row = await this.getRunRow(runId);
     if (row.hookId !== hookId)

--- a/apps/api/src/hooks/hook-store.service.ts
+++ b/apps/api/src/hooks/hook-store.service.ts
@@ -9,9 +9,9 @@ import { Injectable } from '@nestjs/common';
 import type { Hook as HookRow } from '@prisma/client';
 import {
   type Hook,
-  type HookAuth,
   type HookDestination,
   type HookInputDTO,
+  DEFAULT_WORKSPACE_ID,
   NotFoundError,
 } from '@data-bridge/core';
 import { CryptoService } from '../common/crypto.service';
@@ -94,6 +94,7 @@ export class HookStoreService {
     return {
       id: row.id,
       name: row.name,
+      workspaceId: row.workspaceId,
       source: JSON.parse(row.sourceJson),
       destination: this.withSecret(sanitized, secret),
       transform: JSON.parse(row.transformJson),
@@ -115,8 +116,11 @@ export class HookStoreService {
 
   /* ----- CRUD ----- */
 
-  async list(): Promise<Hook[]> {
-    const rows = await this.prisma.hook.findMany({ orderBy: { name: 'asc' } });
+  async list(workspaceId?: string): Promise<Hook[]> {
+    const rows = await this.prisma.hook.findMany({
+      where: workspaceId ? { workspaceId } : undefined,
+      orderBy: { name: 'asc' },
+    });
     return rows.map((r) => this.toHook(r, false));
   }
 
@@ -136,6 +140,7 @@ export class HookStoreService {
       data: {
         id: randomUUID(),
         name: input.name,
+        workspaceId: input.workspaceId ?? DEFAULT_WORKSPACE_ID,
         connectionId: input.source.connectionId,
         sourceJson: JSON.stringify(input.source),
         destinationJson: JSON.stringify(sanitized),

--- a/apps/api/src/hooks/hooks.controller.ts
+++ b/apps/api/src/hooks/hooks.controller.ts
@@ -48,8 +48,15 @@ export class HooksController {
   /* ----- CRUD ----- */
 
   @Get()
-  list(): Promise<Hook[]> {
-    return this.store.list();
+  list(@Query('workspaceId') workspaceId?: string): Promise<Hook[]> {
+    return this.store.list(workspaceId);
+  }
+
+  // latest run status per bridge in a workspace (drives the map edge colors).
+  // declared before ':id' so "statuses" isn't captured as a hook id.
+  @Get('statuses')
+  statuses(@Query('workspaceId') workspaceId: string) {
+    return this.runs.workspaceStatuses(workspaceId);
   }
 
   @Post()

--- a/apps/api/src/hooks/hooks.module.ts
+++ b/apps/api/src/hooks/hooks.module.ts
@@ -52,5 +52,7 @@ import { SqliteCdcProvider } from './cdc/providers/sqlite-cdc.provider';
       useFactory: (...providers: CdcProvider[]): CdcProvider[] => providers,
     },
   ],
+  // exported so WorkspacesModule can stop a workspace's live bridges on delete
+  exports: [HookStoreService, HookWatchService, HookCdcService],
 })
 export class HooksModule {}

--- a/apps/api/src/workspaces/workspace-store.service.ts
+++ b/apps/api/src/workspaces/workspace-store.service.ts
@@ -1,0 +1,90 @@
+/**
+ * store for workspaces, the top-level container that owns connections and
+ * bridges. there's always a default workspace (seeded by the migration and
+ * re-ensured on boot) so the rest of the app can assume one exists.
+ */
+import { randomUUID } from 'node:crypto';
+import { Injectable, type OnModuleInit, Logger } from '@nestjs/common';
+import type { Workspace as WorkspaceRow } from '@prisma/client';
+import {
+  type Workspace,
+  type WorkspaceInputDTO,
+  DEFAULT_WORKSPACE_ID,
+  BadRequestError,
+  NotFoundError,
+} from '@data-bridge/core';
+import { PrismaService } from '../common/prisma.service';
+
+@Injectable()
+export class WorkspaceStoreService implements OnModuleInit {
+  private readonly logger = new Logger('Workspaces');
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  // make sure the default workspace exists even on a DB that somehow missed the
+  // migration seed (e.g. a hand-restored dump). cheap upsert, runs once on boot.
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.prisma.workspace.upsert({
+        where: { id: DEFAULT_WORKSPACE_ID },
+        update: {},
+        create: { id: DEFAULT_WORKSPACE_ID, name: 'Default workspace' },
+      });
+    } catch (err) {
+      this.logger.warn(`Could not ensure default workspace: ${(err as Error).message}`);
+    }
+  }
+
+  private toWorkspace(row: WorkspaceRow): Workspace {
+    return {
+      id: row.id,
+      name: row.name,
+      color: row.color ?? null,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+
+  async list(): Promise<Workspace[]> {
+    const rows = await this.prisma.workspace.findMany({
+      orderBy: { createdAt: 'asc' },
+    });
+    return rows.map((r) => this.toWorkspace(r));
+  }
+
+  async get(id: string): Promise<Workspace> {
+    const row = await this.prisma.workspace.findUnique({ where: { id } });
+    if (!row) throw new NotFoundError(`Workspace "${id}" not found`);
+    return this.toWorkspace(row);
+  }
+
+  async create(input: WorkspaceInputDTO): Promise<Workspace> {
+    const row = await this.prisma.workspace.create({
+      data: {
+        id: randomUUID(),
+        name: input.name,
+        color: input.color ?? null,
+      },
+    });
+    return this.toWorkspace(row);
+  }
+
+  async update(id: string, input: WorkspaceInputDTO): Promise<Workspace> {
+    await this.get(id); // 404 if missing
+    const row = await this.prisma.workspace.update({
+      where: { id },
+      data: { name: input.name, color: input.color ?? null },
+    });
+    return this.toWorkspace(row);
+  }
+
+  // deleting cascades to the workspace's connections and hooks (and their runs).
+  // we keep the default workspace undeletable so there's always somewhere to land.
+  async remove(id: string): Promise<void> {
+    if (id === DEFAULT_WORKSPACE_ID) {
+      throw new BadRequestError('The default workspace cannot be deleted.');
+    }
+    await this.get(id);
+    await this.prisma.workspace.delete({ where: { id } });
+  }
+}

--- a/apps/api/src/workspaces/workspaces.controller.ts
+++ b/apps/api/src/workspaces/workspaces.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
+import {
+  type Workspace,
+  type WorkspaceInputDTO,
+  workspaceInputSchema,
+} from '@data-bridge/core';
+import { ZodValidationPipe } from '../common/zod-validation.pipe';
+import { HookStoreService } from '../hooks/hook-store.service';
+import { HookWatchService } from '../hooks/hook-watch.service';
+import { HookCdcService } from '../hooks/hook-cdc.service';
+import { WorkspaceStoreService } from './workspace-store.service';
+
+@Controller('workspaces')
+export class WorkspacesController {
+  constructor(
+    private readonly store: WorkspaceStoreService,
+    private readonly hooks: HookStoreService,
+    private readonly watch: HookWatchService,
+    private readonly cdc: HookCdcService,
+  ) {}
+
+  @Get()
+  list(): Promise<Workspace[]> {
+    return this.store.list();
+  }
+
+  @Post()
+  create(
+    @Body(new ZodValidationPipe(workspaceInputSchema)) dto: WorkspaceInputDTO,
+  ): Promise<Workspace> {
+    return this.store.create(dto);
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string): Promise<Workspace> {
+    return this.store.get(id);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(workspaceInputSchema)) dto: WorkspaceInputDTO,
+  ): Promise<Workspace> {
+    return this.store.update(id, dto);
+  }
+
+  @Delete(':id')
+  async remove(@Param('id') id: string): Promise<{ id: string }> {
+    // stop any live listeners in this workspace before the cascade delete, so
+    // CDC slots get dropped and watch schedulers stop cleanly (no zombies).
+    const hooks = await this.hooks.list(id).catch(() => []);
+    for (const hook of hooks) {
+      if (hook.trigger.kind === 'cdc') {
+        await this.cdc.cleanup(hook.id).catch(() => undefined);
+      } else if (hook.trigger.kind === 'watch') {
+        await this.watch.stop(hook.id).catch(() => undefined);
+      }
+    }
+    await this.store.remove(id);
+    return { id };
+  }
+}

--- a/apps/api/src/workspaces/workspaces.module.ts
+++ b/apps/api/src/workspaces/workspaces.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { HooksModule } from '../hooks/hooks.module';
+import { WorkspaceStoreService } from './workspace-store.service';
+import { WorkspacesController } from './workspaces.controller';
+
+// PrismaService comes from the global CommonModule. HooksModule is imported so
+// we can stop a workspace's live bridges before deleting it.
+@Module({
+  imports: [HooksModule],
+  controllers: [WorkspacesController],
+  providers: [WorkspaceStoreService],
+  exports: [WorkspaceStoreService],
+})
+export class WorkspacesModule {}

--- a/apps/web/src/components/automations/automations-view.tsx
+++ b/apps/web/src/components/automations/automations-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Pencil, Play, Radio, Square, Trash2, Webhook, Loader2 } from 'lucide-react';
+import { Pencil, Play, Radio, Square, Trash2, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ApiError } from '@/lib/api';
 import {
@@ -17,31 +17,16 @@ import { cn } from '@/lib/utils';
 import { useConfirm } from '@/components/confirm';
 import { Button } from '@/components/ui/button';
 import { RunDetail, RunStatusBadge } from './run-detail';
+import { WorkspaceMap } from './workspace-map';
 
 export function AutomationsView() {
-  const { selectedHookId, selectHook, openHookEditor } = useStudio();
+  const { selectedHookId, selectHook } = useStudio();
   const { data: hooks } = useHooks();
   const hook = hooks?.find((h) => h.id === selectedHookId) ?? null;
 
+  // nothing selected → show the workspace map (the ecosystem view)
   if (!hook) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
-        <Webhook className="h-10 w-10 opacity-40" />
-        <div>
-          <p className="text-sm">No hook selected</p>
-          <p className="text-xs">
-            Pick a hook on the left, or{' '}
-            <button
-              className="text-primary hover:underline"
-              onClick={() => openHookEditor()}
-            >
-              create one
-            </button>
-            .
-          </p>
-        </div>
-      </div>
-    );
+    return <WorkspaceMap />;
   }
 
   const destHostname = (() => {
@@ -57,7 +42,9 @@ export function AutomationsView() {
       key={hook.id}
       hookId={hook.id}
       hookName={hook.name}
-      sourceLabel={hook.source.kind === 'table' ? hook.source.table : 'custom query'}
+      sourceLabel={
+        hook.source.kind === 'table' ? hook.source.table : 'custom query'
+      }
       destLabel={`${hook.destination.method} ${destHostname}`}
       endpoint={{ url: hook.destination.url, method: hook.destination.method }}
       isWatch={hook.trigger.kind !== 'replay'}
@@ -146,7 +133,8 @@ function HookPanel({
   async function handleDelete() {
     const ok = await confirm({
       title: `Delete "${hookName}"?`,
-      description: 'This removes the hook and its run history. This cannot be undone.',
+      description:
+        'This removes the bridge and its run history. This cannot be undone.',
       confirmText: 'Delete',
       destructive: true,
     });
@@ -154,7 +142,7 @@ function HookPanel({
     try {
       await del.mutateAsync(hookId);
       onDeleted();
-      toast.success('Hook deleted');
+      toast.success('Bridge deleted');
     } catch (err) {
       toast.error('Could not delete', {
         description: err instanceof ApiError ? err.message : String(err),
@@ -168,7 +156,7 @@ function HookPanel({
       <div className="flex items-start gap-3 border-b px-4 py-3">
         <div className="min-w-0">
           <h2 className="truncate text-base font-semibold">{hookName}</h2>
-          <p className="truncate font-mono text-xs text-muted-foreground">
+          <p className="text-muted-foreground truncate font-mono text-xs">
             {sourceLabel} → {destLabel}
           </p>
         </div>
@@ -189,7 +177,11 @@ function HookPanel({
                 Stop listening
               </Button>
             ) : (
-              <Button size="sm" onClick={handleStartWatch} disabled={startWatch.isPending}>
+              <Button
+                size="sm"
+                onClick={handleStartWatch}
+                disabled={startWatch.isPending}
+              >
                 {startWatch.isPending ? (
                   <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                 ) : (
@@ -217,38 +209,12 @@ function HookPanel({
             Edit
           </Button>
           <Button size="sm" variant="ghost" onClick={handleDelete}>
-            <Trash2 className="h-3.5 w-3.5 text-destructive" />
+            <Trash2 className="text-destructive h-3.5 w-3.5" />
           </Button>
         </div>
       </div>
 
       {/* runs strip */}
-      <div className="flex items-center gap-2 overflow-x-auto border-b px-4 py-2">
-        {(!runs || runs.length === 0) && (
-          <p className="text-xs text-muted-foreground">
-            {isWatch
-              ? 'Not listening yet — press Start listening to stream changes as they happen.'
-              : 'No runs yet — press Run to stream rows to the endpoint.'}
-          </p>
-        )}
-        {runs?.map((run) => (
-          <button
-            key={run.id}
-            onClick={() => setSelectedRunId(run.id)}
-            className={cn(
-              'flex shrink-0 items-center gap-2 rounded-md border px-2.5 py-1 text-xs transition-colors',
-              selectedRunId === run.id
-                ? 'border-primary bg-accent'
-                : 'border-transparent hover:bg-accent/50',
-            )}
-          >
-            <RunStatusBadge status={run.status} />
-            <span className="text-muted-foreground">
-              {new Date(run.startedAt).toLocaleString()}
-            </span>
-          </button>
-        ))}
-      </div>
 
       {/* selected run */}
       <div className="flex min-h-0 flex-1 flex-col">
@@ -260,7 +226,7 @@ function HookPanel({
             isHook={isWatch}
           />
         ) : (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+          <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
             Select a run to see its delivery log.
           </div>
         )}

--- a/apps/web/src/components/automations/hook-builder.tsx
+++ b/apps/web/src/components/automations/hook-builder.tsx
@@ -107,7 +107,7 @@ function formatCell(value: unknown): string {
 }
 
 export function HookBuilder() {
-  const { hookEditor, closeHookEditor, selectHook, openConnectionDialog, automationTab } =
+  const { hookEditor, closeHookEditor, selectHook, openConnectionDialog } =
     useStudio();
   const editing = hookEditor.editingId;
   const create = useCreateHook();
@@ -192,10 +192,10 @@ export function HookBuilder() {
       return;
     }
     reset();
-    // new items belong to the active sidebar tab's environment
-    const kind = automationTab === 'hooks' ? 'hook' : 'job';
-    setBuilderKind(kind);
-    setTriggerKind(kind === 'hook' ? 'watch' : 'replay');
+    // a new bridge runs an on-demand job by default; the user can switch it to a
+    // live hook in the "What runs in this bridge" selector
+    setBuilderKind('job');
+    setTriggerKind('replay');
     if (hookEditor.seed) {
       setConnectionId(hookEditor.seed.connectionId);
       setDatabase(hookEditor.seed.database ?? '');
@@ -515,15 +515,15 @@ export function HookBuilder() {
       const input = buildInput();
       if (editing) {
         await update.mutateAsync({ id: editing, input });
-        toast.success('Hook updated');
+        toast.success('Bridge updated');
       } else {
         const hook = await create.mutateAsync(input);
         selectHook(hook.id);
-        toast.success('Hook created');
+        toast.success('Bridge created');
       }
       closeHookEditor();
     } catch (err) {
-      toast.error('Could not save hook', {
+      toast.error('Could not save bridge', {
         description: err instanceof ApiError ? err.message : String(err),
       });
     }
@@ -540,7 +540,7 @@ export function HookBuilder() {
         <Input
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="Hook name"
+          placeholder="Bridge name"
           className="h-8 max-w-xs font-medium"
         />
         <div className="text-muted-foreground ml-2 text-sm">
@@ -569,7 +569,7 @@ export function HookBuilder() {
           </Button>
           <Button onClick={handleSave} disabled={!canSave || saving}>
             {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {editing ? 'Save hook' : 'Create hook'}
+            {editing ? 'Save bridge' : 'Create bridge'}
           </Button>
         </div>
       </div>
@@ -903,6 +903,40 @@ export function HookBuilder() {
         <ResizablePanel defaultSize={36} minSize={26}>
           <div className="h-full overflow-y-auto">
             <div className="space-y-5 p-4">
+              {/* what runs in this bridge: an on-demand job or a live hook */}
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold">What runs in this bridge</h3>
+                <div className="flex overflow-hidden rounded-md border text-xs">
+                  {(
+                    [
+                      ['job', 'Job · on-demand'],
+                      ['hook', 'Hook · live'],
+                    ] as const
+                  ).map(([k, label]) => (
+                    <button
+                      key={k}
+                      onClick={() => {
+                        setBuilderKind(k);
+                        setTriggerKind(k === 'hook' ? 'watch' : 'replay');
+                      }}
+                      className={cn(
+                        'flex-1 px-2.5 py-1.5 transition-colors',
+                        builderKind === k
+                          ? 'bg-accent font-medium'
+                          : 'text-muted-foreground hover:bg-accent/50',
+                      )}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-muted-foreground text-[11px]">
+                  {builderKind === 'job'
+                    ? 'Streams rows once when you press Run — good for backfills.'
+                    : 'Listens and delivers changes the moment they happen.'}
+                </p>
+              </section>
+
               {/* trigger, hooks only. jobs are always a one-shot replay */}
               {builderKind === 'hook' && (
                 <section className="space-y-2">

--- a/apps/web/src/components/automations/hook-list.tsx
+++ b/apps/web/src/components/automations/hook-list.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Plus, Radio, Webhook, Zap } from 'lucide-react';
+import { Plus, Radio, Zap, Network, Workflow, AlertTriangle } from 'lucide-react';
 import type { Hook } from '@data-bridge/core';
-import { useHooks } from '@/lib/queries';
+import { useHooks, useHookStatuses } from '@/lib/queries';
 import { useStudio } from '@/lib/store';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -21,48 +21,52 @@ function destLabel(hook: Hook): string {
   }
 }
 
-const TABS = [
-  { id: 'hooks' as const, label: 'Hooks', icon: Radio, hint: 'live' },
-  { id: 'jobs' as const, label: 'Jobs', icon: Zap, hint: 'on-demand' },
-];
+type RunState = 'live' | 'failed' | 'idle' | 'off';
+
+/**
+ * the badge reflects what the bridge is doing right now, not just its type:
+ * live = actually listening/running, failed = last run failed, idle = enabled
+ * but not running, off = disabled.
+ */
+function badge(
+  hook: Hook,
+  status: { active: boolean; lastStatus: string } | undefined,
+): { state: RunState; label: string } {
+  if (!hook.enabled) return { state: 'off', label: 'Off' };
+  if (status?.active) return { state: 'live', label: 'Live' };
+  if (status?.lastStatus === 'failed') return { state: 'failed', label: 'Failed' };
+  // not running: show what it is, not a fake "live"
+  return hook.trigger.kind === 'replay'
+    ? { state: 'idle', label: 'On-demand' }
+    : { state: 'idle', label: 'Idle' };
+}
+
+const DOT: Record<RunState, string> = {
+  live: 'bg-emerald-500',
+  failed: 'bg-red-500',
+  idle: 'bg-muted-foreground/40',
+  off: 'bg-muted-foreground/25',
+};
 
 export function HookList() {
-  const { automationTab, setAutomationTab, selectedHookId, selectHook, openHookEditor } =
-    useStudio();
+  const { selectedHookId, selectHook, openHookEditor } = useStudio();
   const { data: hooks, isLoading } = useHooks();
+  const { data: statuses } = useHookStatuses();
 
-  const isHooks = automationTab === 'hooks';
-  const visible =
-    hooks?.filter((h) =>
-      isHooks ? h.trigger.kind !== 'replay' : h.trigger.kind === 'replay',
-    ) ?? [];
-  const noun = isHooks ? 'hook' : 'job';
+  const bridges = hooks ?? [];
+  const statusById = new Map((statuses ?? []).map((s) => [s.hookId, s]));
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* hooks / jobs tabs */}
-      <div className="grid grid-cols-2 gap-1 px-2 pt-2">
-        {TABS.map((t) => (
-          <button
-            key={t.id}
-            onClick={() => setAutomationTab(t.id)}
-            className={cn(
-              'flex items-center justify-center gap-1.5 rounded-md py-1.5 text-xs font-medium transition-colors',
-              automationTab === t.id
-                ? 'bg-primary text-primary-foreground'
-                : 'text-muted-foreground hover:bg-accent',
-            )}
-          >
-            <t.icon className="h-3.5 w-3.5" />
-            {t.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="flex items-center justify-between px-3 py-2">
-        <span className="text-muted-foreground text-[11px] uppercase tracking-wide">
-          {isHooks ? 'Listen & deliver new rows' : 'Send data on demand'}
-        </span>
+      <div className="flex items-center justify-between px-3 pt-3 pb-2">
+        <button
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide transition-colors"
+          title="View the workspace map"
+          onClick={() => selectHook(null)}
+        >
+          <Network className="h-3.5 w-3.5" />
+          Map
+        </button>
         <Button
           size="sm"
           variant="ghost"
@@ -70,7 +74,7 @@ export function HookList() {
           onClick={() => openHookEditor()}
         >
           <Plus className="h-3.5 w-3.5" />
-          New
+          New bridge
         </Button>
       </div>
 
@@ -78,46 +82,66 @@ export function HookList() {
         {isLoading && (
           <p className="text-muted-foreground px-2 py-3 text-sm">Loading…</p>
         )}
-        {!isLoading && visible.length === 0 && (
+        {!isLoading && bridges.length === 0 && (
           <div className="text-muted-foreground px-2 py-6 text-center text-sm">
-            {isHooks ? (
-              <Radio className="mx-auto mb-2 h-6 w-6 opacity-50" />
-            ) : (
-              <Zap className="mx-auto mb-2 h-6 w-6 opacity-50" />
-            )}
-            No {noun}s yet.
+            <Workflow className="mx-auto mb-2 h-6 w-6 opacity-50" />
+            No bridges in this workspace yet.
             <button
               className="text-primary mt-1 block w-full hover:underline"
               onClick={() => openHookEditor()}
             >
-              Create your first {noun}
+              Create your first bridge
             </button>
           </div>
         )}
         <div className="flex flex-col gap-0.5">
-          {visible.map((hook) => (
-            <button
-              key={hook.id}
-              onClick={() => selectHook(hook.id)}
-              className={cn(
-                'flex flex-col gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors',
-                selectedHookId === hook.id ? 'bg-accent' : 'hover:bg-accent/50',
-              )}
-            >
-              <div className="flex items-center gap-1.5">
-                <span
-                  className={cn(
-                    'h-1.5 w-1.5 shrink-0 rounded-full',
-                    hook.enabled ? 'bg-emerald-500' : 'bg-muted-foreground/40',
-                  )}
-                />
-                <span className="truncate text-sm font-medium">{hook.name}</span>
-              </div>
-              <span className="text-muted-foreground truncate pl-3 font-mono text-xs">
-                {sourceLabel(hook)} → {destLabel(hook)}
-              </span>
-            </button>
-          ))}
+          {bridges.map((hook) => {
+            const b = badge(hook, statusById.get(hook.id));
+            const Icon =
+              b.state === 'failed'
+                ? AlertTriangle
+                : hook.trigger.kind === 'replay'
+                  ? Zap
+                  : Radio;
+            return (
+              <button
+                key={hook.id}
+                onClick={() => selectHook(hook.id)}
+                className={cn(
+                  'flex flex-col gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors',
+                  selectedHookId === hook.id ? 'bg-accent' : 'hover:bg-accent/50',
+                )}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={cn(
+                      'h-1.5 w-1.5 shrink-0 rounded-full',
+                      DOT[b.state],
+                      b.state === 'live' && 'animate-pulse',
+                    )}
+                  />
+                  <span className="truncate text-sm font-medium">{hook.name}</span>
+                  <span
+                    className={cn(
+                      'ml-auto flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium',
+                      b.state === 'live' &&
+                        'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+                      b.state === 'failed' &&
+                        'bg-red-500/10 text-red-600 dark:text-red-400',
+                      (b.state === 'idle' || b.state === 'off') &&
+                        'bg-muted text-muted-foreground',
+                    )}
+                  >
+                    <Icon className="h-3 w-3" />
+                    {b.label}
+                  </span>
+                </div>
+                <span className="text-muted-foreground truncate pl-3 font-mono text-xs">
+                  {sourceLabel(hook)} → {destLabel(hook)}
+                </span>
+              </button>
+            );
+          })}
         </div>
       </ScrollArea>
     </div>

--- a/apps/web/src/components/automations/run-detail.tsx
+++ b/apps/web/src/components/automations/run-detail.tsx
@@ -4,7 +4,11 @@ import { Ban, Loader2, Play, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 import type { HookRun, HookRunStatus } from '@data-bridge/core';
 import { ApiError } from '@/lib/api';
-import { useCancelHookRun, useRetryFailed, useStartHookRun } from '@/lib/queries';
+import {
+  useCancelHookRun,
+  useRetryFailed,
+  useStartHookRun,
+} from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { DeliveryMonitor } from './delivery-log';
@@ -29,16 +33,21 @@ export function RunStatusBadge({ status }: { status: HookRunStatus }) {
         STATUS_STYLES[status],
       )}
     >
-      {(status === 'running' || status === 'queued' || status === 'canceling') && (
-        <Loader2 className="h-3 w-3 animate-spin" />
-      )}
+      {(status === 'running' ||
+        status === 'queued' ||
+        status === 'canceling') && <Loader2 className="h-3 w-3 animate-spin" />}
       {status}
     </span>
   );
 }
 
 const ACTIVE: HookRunStatus[] = ['queued', 'running', 'canceling'];
-const RESUMABLE: HookRunStatus[] = ['failed', 'canceled', 'paused', 'interrupted'];
+const RESUMABLE: HookRunStatus[] = [
+  'failed',
+  'canceled',
+  'paused',
+  'interrupted',
+];
 
 function Stat({
   label,
@@ -89,7 +98,10 @@ export function RunDetail({
   const total = run.totalCount;
   const settled = run.sentCount + run.failedCount + run.skippedCount;
   const pending = total != null ? Math.max(0, total - settled) : null;
-  const pct = total && total > 0 ? Math.min(100, Math.round((settled / total) * 100)) : null;
+  const pct =
+    total && total > 0
+      ? Math.min(100, Math.round((settled / total) * 100))
+      : null;
   const attempted = run.sentCount + run.failedCount;
   const successRate =
     attempted > 0 ? Math.round((run.sentCount / attempted) * 100) : null;
@@ -145,7 +157,12 @@ export function RunDetail({
           {/* cancel/resume are job controls. a hook is started/stopped from the
               panel header above, "resuming" one would re-stream the whole table */}
           {!isHook && isActive && (
-            <Button size="sm" variant="outline" onClick={handleCancel} disabled={cancel.isPending}>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={cancel.isPending}
+            >
               {cancel.isPending ? (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
               ) : (
@@ -191,9 +208,21 @@ export function RunDetail({
           delivered/failed/skipped breakdown instead of progress-to-completion */}
       {isHook ? (
         <div className="grid grid-cols-2 gap-2 px-4 py-3 sm:grid-cols-4">
-          <Stat label="Delivered" value={run.sentCount.toLocaleString()} tone="success" />
-          <Stat label="Failed" value={run.failedCount.toLocaleString()} tone="danger" />
-          <Stat label="Skipped" value={run.skippedCount.toLocaleString()} tone="warn" />
+          <Stat
+            label="Delivered"
+            value={run.sentCount.toLocaleString()}
+            tone="success"
+          />
+          <Stat
+            label="Failed"
+            value={run.failedCount.toLocaleString()}
+            tone="danger"
+          />
+          <Stat
+            label="Skipped"
+            value={run.skippedCount.toLocaleString()}
+            tone="warn"
+          />
           <Stat
             label="Success"
             value={successRate != null ? `${successRate}%` : '—'}
@@ -202,10 +231,25 @@ export function RunDetail({
       ) : (
         <>
           <div className="grid grid-cols-3 gap-2 px-4 py-3 sm:grid-cols-6">
-            <Stat label="Total" value={total != null ? total.toLocaleString() : '—'} />
-            <Stat label="Delivered" value={run.sentCount.toLocaleString()} tone="success" />
-            <Stat label="Failed" value={run.failedCount.toLocaleString()} tone="danger" />
-            <Stat label="Skipped" value={run.skippedCount.toLocaleString()} tone="warn" />
+            <Stat
+              label="Total"
+              value={total != null ? total.toLocaleString() : '—'}
+            />
+            <Stat
+              label="Delivered"
+              value={run.sentCount.toLocaleString()}
+              tone="success"
+            />
+            <Stat
+              label="Failed"
+              value={run.failedCount.toLocaleString()}
+              tone="danger"
+            />
+            <Stat
+              label="Skipped"
+              value={run.skippedCount.toLocaleString()}
+              tone="warn"
+            />
             <Stat
               label="Queued"
               value={pending != null ? pending.toLocaleString() : '—'}
@@ -232,7 +276,7 @@ export function RunDetail({
       )}
 
       {run.error && (
-        <p className="border-y bg-destructive/10 text-destructive px-4 py-2 text-xs break-words">
+        <p className="bg-destructive/10 text-destructive break-words border-y px-4 py-2 text-xs">
           {run.error}
         </p>
       )}

--- a/apps/web/src/components/automations/workspace-map.tsx
+++ b/apps/web/src/components/automations/workspace-map.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Background,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeProps,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { Database, Globe, Radio, Zap, Plus, Network } from 'lucide-react';
+import type { ConnectionConfig, Hook } from '@data-bridge/core';
+import { useConnections, useHooks, useHookStatuses } from '@/lib/queries';
+import { useStudio } from '@/lib/store';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+/** a bridge's live status, derived from its latest run */
+type BridgeStatus = 'active' | 'failed' | 'idle' | 'disabled';
+
+const STATUS_STROKE: Record<BridgeStatus, string> = {
+  active: '#10b981', // emerald — listening/running
+  failed: '#ef4444', // red — last run failed
+  idle: '#94a3b8', // slate — enabled but not running
+  disabled: '#cbd5e1', // faint — disabled
+};
+
+const STATUS_DOT: Record<BridgeStatus, string> = {
+  active: 'bg-emerald-500',
+  failed: 'bg-red-500',
+  idle: 'bg-muted-foreground/50',
+  disabled: 'bg-muted-foreground/30',
+};
+
+/**
+ * the workspace map — a Packet-Tracer-ish picture of the whole workspace.
+ * source databases on the left, bridges in the middle, destination endpoints on
+ * the right, wired together. click a bridge to open it.
+ */
+
+type ConnNodeData = { label: string; engine: string };
+type BridgeNodeData = {
+  hookId: string;
+  label: string;
+  kind: Hook['trigger']['kind'];
+  status: BridgeStatus;
+  selected: boolean;
+};
+type DestNodeData = { host: string };
+
+function ConnectionNode({ data }: NodeProps<Node<ConnNodeData>>) {
+  return (
+    <div className="bg-card flex min-w-[150px] items-center gap-2 rounded-md border px-3 py-2 shadow-sm">
+      <Database className="text-primary h-4 w-4 shrink-0" />
+      <div className="min-w-0">
+        <div className="truncate text-xs font-semibold">{data.label}</div>
+        <div className="text-muted-foreground text-[10px] uppercase">{data.engine}</div>
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-primary" />
+    </div>
+  );
+}
+
+function BridgeNode({ data }: NodeProps<Node<BridgeNodeData>>) {
+  const Icon = data.kind === 'replay' ? Zap : Radio;
+  return (
+    <div
+      className={cn(
+        'bg-card min-w-[170px] cursor-pointer rounded-md border px-3 py-2 shadow-sm transition-shadow hover:shadow-md',
+        data.selected ? 'ring-primary ring-2' : '',
+      )}
+    >
+      <Handle type="target" position={Position.Left} className="!bg-primary" />
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'h-1.5 w-1.5 shrink-0 rounded-full',
+            STATUS_DOT[data.status],
+            data.status === 'active' && 'animate-pulse',
+          )}
+        />
+        <span className="truncate text-xs font-semibold">{data.label}</span>
+      </div>
+      <div className="text-muted-foreground mt-1 flex items-center gap-1 text-[10px]">
+        <Icon className="h-3 w-3" />
+        {data.kind === 'replay' ? 'on-demand' : data.kind === 'cdc' ? 'CDC' : 'watch'}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-primary" />
+    </div>
+  );
+}
+
+function DestinationNode({ data }: NodeProps<Node<DestNodeData>>) {
+  return (
+    <div className="bg-card flex min-w-[150px] items-center gap-2 rounded-md border px-3 py-2 shadow-sm">
+      <Handle type="target" position={Position.Left} className="!bg-primary" />
+      <Globe className="h-4 w-4 shrink-0 text-sky-500" />
+      <span className="truncate text-xs font-medium">{data.host}</span>
+    </div>
+  );
+}
+
+const nodeTypes = {
+  connection: ConnectionNode,
+  bridge: BridgeNode,
+  destination: DestinationNode,
+};
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function buildGraph(
+  hooks: Hook[],
+  connections: ConnectionConfig[],
+  selectedHookId: string | null,
+  statusOf: (hookId: string) => BridgeStatus,
+): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const ROW = 110;
+
+  // left column: only connections actually used by a bridge here
+  const usedConnIds = [...new Set(hooks.map((h) => h.source.connectionId))];
+  const connName = new Map(connections.map((c) => [c.id, c]));
+  usedConnIds.forEach((id, i) => {
+    const c = connName.get(id);
+    nodes.push({
+      id: `conn-${id}`,
+      type: 'connection',
+      position: { x: 0, y: i * ROW },
+      data: { label: c?.name ?? 'connection', engine: c?.engine ?? '' },
+    });
+  });
+
+  // right column: unique destination hosts
+  const hosts = [...new Set(hooks.map((h) => hostOf(h.destination.url)))];
+  hosts.forEach((host, i) => {
+    nodes.push({
+      id: `dest-${host}`,
+      type: 'destination',
+      position: { x: 620, y: i * ROW },
+      data: { host },
+    });
+  });
+
+  // middle column: the bridges, wired source -> bridge -> destination
+  hooks.forEach((h, i) => {
+    const status = statusOf(h.id);
+    nodes.push({
+      id: `bridge-${h.id}`,
+      type: 'bridge',
+      position: { x: 310, y: i * ROW },
+      data: {
+        hookId: h.id,
+        label: h.name,
+        kind: h.trigger.kind,
+        status,
+        selected: h.id === selectedHookId,
+      },
+    });
+    // line color + flow animation follow the bridge's live status
+    const animated = status === 'active';
+    const style = { stroke: STATUS_STROKE[status], strokeWidth: status === 'active' ? 2 : 1.5 };
+    edges.push({
+      id: `e-conn-${h.id}`,
+      source: `conn-${h.source.connectionId}`,
+      target: `bridge-${h.id}`,
+      animated,
+      style,
+    });
+    edges.push({
+      id: `e-dest-${h.id}`,
+      source: `bridge-${h.id}`,
+      target: `dest-${hostOf(h.destination.url)}`,
+      animated,
+      style,
+    });
+  });
+
+  return { nodes, edges };
+}
+
+export function WorkspaceMap() {
+  const { data: hooks } = useHooks();
+  const { data: connections } = useConnections();
+  const { data: statuses } = useHookStatuses();
+  const { selectedHookId, selectHook, openHookEditor } = useStudio();
+
+  const { nodes, edges } = useMemo(() => {
+    const byId = new Map((statuses ?? []).map((s) => [s.hookId, s]));
+    const statusOf = (id: string): BridgeStatus => {
+      const hook = (hooks ?? []).find((h) => h.id === id);
+      if (hook && !hook.enabled) return 'disabled';
+      const s = byId.get(id);
+      if (!s) return 'idle';
+      if (s.active) return 'active';
+      if (s.lastStatus === 'failed') return 'failed';
+      return 'idle';
+    };
+    return buildGraph(hooks ?? [], connections ?? [], selectedHookId, statusOf);
+  }, [hooks, connections, statuses, selectedHookId]);
+
+  if ((hooks?.length ?? 0) === 0) {
+    return (
+      <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3 text-center">
+        <Network className="h-10 w-10 opacity-40" />
+        <div>
+          <p className="text-sm">No bridges in this workspace yet</p>
+          <p className="text-xs">
+            A bridge moves data from a database to an endpoint.{' '}
+            <button
+              className="text-primary hover:underline"
+              onClick={() => openHookEditor()}
+            >
+              Create one
+            </button>
+            .
+          </p>
+        </div>
+        <Button size="sm" variant="outline" onClick={() => openHookEditor()}>
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          New bridge
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.2}
+        onNodeClick={(_e, node) => {
+          const data = node.data as Partial<BridgeNodeData>;
+          if (node.type === 'bridge' && data.hookId) selectHook(data.hookId);
+        }}
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/web/src/components/studio.tsx
+++ b/apps/web/src/components/studio.tsx
@@ -16,6 +16,7 @@ import { AutomationsView } from '@/components/automations/automations-view';
 import { HookList } from '@/components/automations/hook-list';
 import { HookBuilder } from '@/components/automations/hook-builder';
 import { DataSourcesManager } from '@/components/data-sources-manager';
+import { WorkspaceSwitcher } from '@/components/workspace/workspace-switcher';
 
 /**
  * the app is a hooks workspace. sidebar lists hooks, main panel shows the
@@ -65,7 +66,6 @@ export function Studio() {
                   <Webhook className="text-primary h-4 w-4" />
                 </span>
                 <span className="font-semibold tracking-tight">Data Bridge</span>
-                <span className="text-muted-foreground text-xs">Hooks</span>
               </div>
               <div className="flex items-center gap-0.5">
                 <Button
@@ -79,6 +79,11 @@ export function Studio() {
                 </Button>
                 <ThemeToggle />
               </div>
+            </div>
+            <Separator />
+            {/* which workspace you're in — scopes the bridges + connections below */}
+            <div className="px-2 py-1.5">
+              <WorkspaceSwitcher />
             </div>
             <Separator />
             <HookList />

--- a/apps/web/src/components/workspace/workspace-switcher.tsx
+++ b/apps/web/src/components/workspace/workspace-switcher.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Check, ChevronsUpDown, Plus, Trash2, Layers } from 'lucide-react';
+import { toast } from 'sonner';
+import { ApiError } from '@/lib/api';
+import {
+  useWorkspaces,
+  useCreateWorkspace,
+  useDeleteWorkspace,
+} from '@/lib/queries';
+import { useStudio } from '@/lib/store';
+import { DEFAULT_WORKSPACE_ID } from '@data-bridge/core';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+export function WorkspaceSwitcher() {
+  const { data: workspaces } = useWorkspaces();
+  const activeWorkspaceId = useStudio((s) => s.activeWorkspaceId);
+  const setActiveWorkspace = useStudio((s) => s.setActiveWorkspace);
+  const create = useCreateWorkspace();
+  const del = useDeleteWorkspace();
+
+  const [newOpen, setNewOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // once workspaces load, make sure something is selected. prefer keeping the
+  // current one; otherwise fall back to the default, then the first.
+  useEffect(() => {
+    if (!workspaces || workspaces.length === 0) return;
+    const stillThere = workspaces.some((w) => w.id === activeWorkspaceId);
+    if (!stillThere) {
+      const fallback =
+        workspaces.find((w) => w.id === DEFAULT_WORKSPACE_ID) ?? workspaces[0];
+      if (fallback) setActiveWorkspace(fallback.id);
+    }
+  }, [workspaces, activeWorkspaceId, setActiveWorkspace]);
+
+  const active = workspaces?.find((w) => w.id === activeWorkspaceId) ?? null;
+
+  async function handleCreate() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    try {
+      const ws = await create.mutateAsync({ name: trimmed });
+      setActiveWorkspace(ws.id);
+      setNewOpen(false);
+      setName('');
+      toast.success(`Workspace "${ws.name}" created`);
+    } catch (err) {
+      toast.error('Could not create workspace', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleDelete() {
+    if (!active) return;
+    try {
+      await del.mutateAsync(active.id);
+      toast.success(`Workspace "${active.name}" deleted`);
+      setConfirmDelete(false);
+    } catch (err) {
+      toast.error('Could not delete workspace', {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    }
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 max-w-[150px] gap-1.5 px-2"
+            title="Switch workspace"
+          >
+            <Layers className="text-primary h-3.5 w-3.5 shrink-0" />
+            <span className="truncate text-sm font-medium">
+              {active?.name ?? 'Workspace'}
+            </span>
+            <ChevronsUpDown className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuLabel className="text-muted-foreground text-[11px] uppercase tracking-wide">
+            Workspaces
+          </DropdownMenuLabel>
+          {workspaces?.map((w) => (
+            <DropdownMenuItem
+              key={w.id}
+              onClick={() => setActiveWorkspace(w.id)}
+              className="gap-2"
+            >
+              <Check
+                className={cn(
+                  'h-4 w-4',
+                  w.id === activeWorkspaceId ? 'opacity-100' : 'opacity-0',
+                )}
+              />
+              <span className="truncate">{w.name}</span>
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => setNewOpen(true)} className="gap-2">
+            <Plus className="h-4 w-4" /> New workspace
+          </DropdownMenuItem>
+          {active && active.id !== DEFAULT_WORKSPACE_ID && (
+            <DropdownMenuItem
+              onClick={() => setConfirmDelete(true)}
+              className="text-destructive focus:text-destructive gap-2"
+            >
+              <Trash2 className="h-4 w-4" /> Delete “{active.name}”
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* New workspace dialog */}
+      <Dialog open={newOpen} onOpenChange={setNewOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>New workspace</DialogTitle>
+          </DialogHeader>
+          <Input
+            autoFocus
+            placeholder="e.g. Production, Acme Corp, Staging"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setNewOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={!name.trim() || create.isPending}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation */}
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this workspace?</AlertDialogTitle>
+            <AlertDialogDescription>
+              “{active?.name}” and all of its connections and bridges will be
+              permanently deleted. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -22,6 +22,8 @@ import type {
   InsertRowParams,
   QueryResult,
   UpdateRowParams,
+  Workspace,
+  WorkspaceInputDTO,
 } from '@data-bridge/core';
 
 const BASE_URL =
@@ -78,7 +80,19 @@ function jsonBody(value: unknown): RequestInit {
 export const api = {
   listDrivers: () => request<DriverInfo[]>('/drivers'),
 
-  listConnections: () => request<ConnectionConfig[]>('/connections'),
+  /* ----- workspaces ----- */
+  listWorkspaces: () => request<Workspace[]>('/workspaces'),
+  createWorkspace: (input: WorkspaceInputDTO) =>
+    request<Workspace>('/workspaces', { method: 'POST', ...jsonBody(input) }),
+  updateWorkspace: (id: string, input: WorkspaceInputDTO) =>
+    request<Workspace>(`/workspaces/${id}`, { method: 'PUT', ...jsonBody(input) }),
+  deleteWorkspace: (id: string) =>
+    request<{ id: string }>(`/workspaces/${id}`, { method: 'DELETE' }),
+
+  listConnections: (workspaceId?: string) =>
+    request<ConnectionConfig[]>(
+      workspaceId ? `/connections?workspaceId=${encodeURIComponent(workspaceId)}` : '/connections',
+    ),
   getConnection: (id: string) =>
     request<ConnectionConfig>(`/connections/${id}`),
   createConnection: (input: ConnectionInputDTO) =>
@@ -193,7 +207,14 @@ export const api = {
 
   /* ----- automation hooks ----- */
 
-  listHooks: () => request<Hook[]>('/hooks'),
+  listHooks: (workspaceId?: string) =>
+    request<Hook[]>(
+      workspaceId ? `/hooks?workspaceId=${encodeURIComponent(workspaceId)}` : '/hooks',
+    ),
+  listHookStatuses: (workspaceId: string) =>
+    request<{ hookId: string; active: boolean; lastStatus: string }[]>(
+      `/hooks/statuses?workspaceId=${encodeURIComponent(workspaceId)}`,
+    ),
   getHook: (id: string) => request<Hook>(`/hooks/${id}`),
   createHook: (input: HookInputDTO) =>
     request<Hook>('/hooks', { method: 'POST', ...jsonBody(input) }),

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -1,21 +1,20 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   BrowseParams,
   ConnectionInputDTO,
   HookInputDTO,
   HookRun,
+  WorkspaceInputDTO,
 } from '@data-bridge/core';
 import { api } from './api';
+import { useStudio } from './store';
 
 export const queryKeys = {
   drivers: ['drivers'] as const,
+  workspaces: ['workspaces'] as const,
   connections: ['connections'] as const,
   connection: (id: string) => ['connections', id] as const,
   databases: (id: string) => ['connections', id, 'databases'] as const,
@@ -39,19 +38,63 @@ export function useDrivers() {
   });
 }
 
-export function useConnections() {
+/* ----- workspaces ----- */
+
+export function useWorkspaces() {
   return useQuery({
-    queryKey: queryKeys.connections,
-    queryFn: () => api.listConnections(),
+    queryKey: queryKeys.workspaces,
+    queryFn: () => api.listWorkspaces(),
+  });
+}
+
+export function useCreateWorkspace() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: WorkspaceInputDTO) => api.createWorkspace(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.workspaces }),
+  });
+}
+
+export function useUpdateWorkspace() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: WorkspaceInputDTO }) =>
+      api.updateWorkspace(id, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.workspaces }),
+  });
+}
+
+export function useDeleteWorkspace() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.deleteWorkspace(id),
+    onSuccess: () => {
+      // a workspace delete cascades to its connections + hooks
+      qc.invalidateQueries({ queryKey: queryKeys.workspaces });
+      qc.invalidateQueries({ queryKey: queryKeys.connections });
+      qc.invalidateQueries({ queryKey: queryKeys.hooks });
+    },
+  });
+}
+
+/** connections in the active workspace (the key carries the id so it refetches) */
+export function useConnections() {
+  const workspaceId = useStudio((s) => s.activeWorkspaceId);
+  return useQuery({
+    queryKey: [...queryKeys.connections, workspaceId],
+    queryFn: () => api.listConnections(workspaceId ?? undefined),
+    enabled: !!workspaceId,
   });
 }
 
 export function useCreateConnection() {
   const qc = useQueryClient();
+  const workspaceId = useStudio((s) => s.activeWorkspaceId);
   return useMutation({
-    mutationFn: (input: ConnectionInputDTO) => api.createConnection(input),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.connections }),
+    // stamp the active workspace so new connections land where the user is
+    mutationFn: (input: ConnectionInputDTO) =>
+      api.createConnection({ ...input, workspaceId: input.workspaceId ?? workspaceId ?? undefined }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.connections }),
   });
 }
 
@@ -68,8 +111,7 @@ export function useDeleteConnection() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.deleteConnection(id),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.connections }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.connections }),
   });
 }
 
@@ -96,7 +138,9 @@ export function useBrowse(
 ) {
   return useQuery({
     queryKey:
-      id && params ? queryKeys.browse(id, database, params) : ['browse', 'none'],
+      id && params
+        ? queryKeys.browse(id, database, params)
+        : ['browse', 'none'],
     queryFn: () => api.browse(id as string, params as BrowseParams, database),
     enabled: !!id && !!params,
     placeholderData: (prev) => prev,
@@ -105,17 +149,34 @@ export function useBrowse(
 
 /* ----- automation hooks ----- */
 
+/** bridges (hooks) in the active workspace */
 export function useHooks() {
+  const workspaceId = useStudio((s) => s.activeWorkspaceId);
   return useQuery({
-    queryKey: queryKeys.hooks,
-    queryFn: () => api.listHooks(),
+    queryKey: [...queryKeys.hooks, workspaceId],
+    queryFn: () => api.listHooks(workspaceId ?? undefined),
+    enabled: !!workspaceId,
+  });
+}
+
+/** latest run status per bridge — polled so the map colors stay live */
+export function useHookStatuses() {
+  const workspaceId = useStudio((s) => s.activeWorkspaceId);
+  return useQuery({
+    queryKey: ['hookStatuses', workspaceId],
+    queryFn: () => api.listHookStatuses(workspaceId as string),
+    enabled: !!workspaceId,
+    refetchInterval: 3000,
   });
 }
 
 export function useCreateHook() {
   const qc = useQueryClient();
+  const workspaceId = useStudio((s) => s.activeWorkspaceId);
   return useMutation({
-    mutationFn: (input: HookInputDTO) => api.createHook(input),
+    // stamp the active workspace so a new bridge belongs to the current one
+    mutationFn: (input: HookInputDTO) =>
+      api.createHook({ ...input, workspaceId: input.workspaceId ?? workspaceId ?? undefined }),
     onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hooks }),
   });
 }
@@ -141,10 +202,17 @@ export function useStartHookRun(hookId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (
-      opts: { resumeRunId?: string; runId?: string; retryFailedOf?: string } = {},
+      opts: {
+        resumeRunId?: string;
+        runId?: string;
+        retryFailedOf?: string;
+      } = {},
     ) => api.startHookRun(hookId, opts),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+    // also refresh statuses so the map node/edge updates instantly, not on the poll
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) });
+      qc.invalidateQueries({ queryKey: ['hookStatuses'] });
+    },
   });
 }
 
@@ -152,7 +220,10 @@ export function useStartWatch(hookId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.startWatch(hookId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) });
+      qc.invalidateQueries({ queryKey: ['hookStatuses'] });
+    },
   });
 }
 
@@ -160,7 +231,10 @@ export function useStopWatch(hookId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.stopWatch(hookId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) });
+      qc.invalidateQueries({ queryKey: ['hookStatuses'] });
+    },
   });
 }
 
@@ -170,7 +244,10 @@ export function useRetryFailed(hookId: string) {
     mutationFn: (runId: string) => api.retryFailedDeliveries(hookId, runId),
     onSuccess: (_d, runId) => {
       qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) });
-      qc.invalidateQueries({ queryKey: queryKeys.hookDeliveries(hookId, runId) });
+      qc.invalidateQueries({
+        queryKey: queryKeys.hookDeliveries(hookId, runId),
+      });
+      qc.invalidateQueries({ queryKey: ['hookStatuses'] });
     },
   });
 }
@@ -179,8 +256,10 @@ export function useCancelHookRun(hookId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (runId: string) => api.cancelHookRun(hookId, runId),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) });
+      qc.invalidateQueries({ queryKey: ['hookStatuses'] });
+    },
   });
 }
 
@@ -204,7 +283,11 @@ export function useHookDeliveries(
   hookId: string | null,
   runId: string | null,
   live: boolean,
-  opts: { status?: 'success' | 'failed' | 'skipped'; from?: number; to?: number } = {},
+  opts: {
+    status?: 'success' | 'failed' | 'skipped';
+    from?: number;
+    to?: number;
+  } = {},
 ) {
   const qc = useQueryClient();
   const prevLiveRef = useRef(live);
@@ -232,7 +315,9 @@ export function useHookDeliveries(
   useEffect(() => {
     if (prevLiveRef.current && !live && hookId && runId) {
       void refetch();
-      void qc.invalidateQueries({ queryKey: queryKeys.hookDeliveries(hookId, runId) });
+      void qc.invalidateQueries({
+        queryKey: queryKeys.hookDeliveries(hookId, runId),
+      });
     }
     prevLiveRef.current = live;
   }, [live, hookId, runId, refetch, qc]);
@@ -246,7 +331,9 @@ export function useSkipDeliveries(hookId: string, runId: string) {
     mutationFn: (sequences: number[]) =>
       api.skipHookRun(hookId, runId, sequences),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: queryKeys.hookDeliveries(hookId, runId) });
+      qc.invalidateQueries({
+        queryKey: queryKeys.hookDeliveries(hookId, runId),
+      });
       qc.invalidateQueries({ queryKey: queryKeys.hookRuns(hookId) });
     },
   });

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -5,9 +5,6 @@ import type { RelationKind } from '@data-bridge/core';
 
 export type StudioTab = 'data' | 'query' | 'structure' | 'diagram';
 
-/** sidebar grouping: live "Hooks" (watch trigger) vs on-demand "Jobs" (replay) */
-export type AutomationTab = 'hooks' | 'jobs';
-
 export interface SelectedRelation {
   schema?: string;
   table: string;
@@ -37,6 +34,9 @@ function freshTabs(): { tabs: QueryTab[]; activeId: string } {
 }
 
 interface StudioState {
+  /** the workspace currently in view; everything is scoped to it */
+  activeWorkspaceId: string | null;
+
   activeConnectionId: string | null;
   activeDatabase?: string;
   selected: SelectedRelation | null;
@@ -45,8 +45,7 @@ interface StudioState {
   /** connection editor dialog state */
   dialog: { open: boolean; editingId: string | null };
 
-  /** hooks surface: which sidebar group is active + the selected hook */
-  automationTab: AutomationTab;
+  /** the bridge (hook) currently open in the main panel */
   selectedHookId: string | null;
   /** hook editor dialog: open + which hook (null = new) + optional prefill */
   hookEditor: {
@@ -61,12 +60,12 @@ interface StudioState {
   queryTabs: QueryTab[];
   activeQueryTabId: string;
 
+  setActiveWorkspace: (id: string | null) => void;
   setActiveConnection: (id: string | null) => void;
   setActiveDatabase: (db?: string) => void;
   selectRelation: (rel: SelectedRelation) => void;
   setTab: (tab: StudioTab) => void;
 
-  setAutomationTab: (tab: AutomationTab) => void;
   selectHook: (id: string | null) => void;
   openHookEditor: (opts?: {
     editingId?: string | null;
@@ -90,21 +89,20 @@ interface StudioState {
 const initial = freshTabs();
 
 export const useStudio = create<StudioState>((set) => ({
+  activeWorkspaceId: null,
   activeConnectionId: null,
   activeDatabase: undefined,
   selected: null,
   tab: 'data',
   dialog: { open: false, editingId: null },
-  automationTab: 'hooks',
   selectedHookId: null,
   hookEditor: { open: false, editingId: null, seed: null },
   dataSourcesOpen: false,
   queryTabs: initial.tabs,
   activeQueryTabId: initial.activeId,
 
-  // selecting a hook and browsing a table are mutually exclusive. the main
-  // view shows the table preview when one is picked, else the hooks workspace
-  setAutomationTab: (tab) => set({ automationTab: tab }),
+  // selecting a bridge and browsing a table are mutually exclusive. the main
+  // view shows the table preview when one is picked, else the workspace map
   selectHook: (id) => set({ selectedHookId: id, selected: null }),
   openHookEditor: (opts) =>
     set({
@@ -118,6 +116,10 @@ export const useStudio = create<StudioState>((set) => ({
     set({ hookEditor: { open: false, editingId: null, seed: null } }),
   openDataSources: () => set({ dataSourcesOpen: true }),
   closeDataSources: () => set({ dataSourcesOpen: false }),
+
+  // switching workspace drops the selected bridge (it lives in another one)
+  setActiveWorkspace: (id) =>
+    set({ activeWorkspaceId: id, selectedHookId: null, selected: null }),
 
   setActiveConnection: (id) => {
     const f = freshTabs();

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -61,6 +61,8 @@ export interface AdapterCapabilities {
 export interface ConnectionConfig {
   id: string;
   name: string;
+  /** the workspace this connection belongs to */
+  workspaceId: string;
   engine: DatabaseEngine;
   /** optional accent color for the UI (hex) */
   color?: string;
@@ -80,11 +82,14 @@ export interface ConnectionConfig {
   updatedAt: string;
 }
 
-/** a connection without the assigned id / timestamps (creation payload) */
+/**
+ * a connection without the assigned id / timestamps (creation payload).
+ * workspaceId is optional here — the server falls back to the default workspace.
+ */
 export type ConnectionInput = Omit<
   ConnectionConfig,
-  'id' | 'createdAt' | 'updatedAt'
->;
+  'id' | 'createdAt' | 'updatedAt' | 'workspaceId'
+> & { workspaceId?: string };
 
 /* -------------------------------------------------------------------------- */
 /* schema introspection                                                       */

--- a/packages/core/src/hooks/hook-config.ts
+++ b/packages/core/src/hooks/hook-config.ts
@@ -135,6 +135,8 @@ export const hookTriggerSchema = z.discriminatedUnion('kind', [
 
 export const hookInputSchema = z.object({
   name: z.string().min(1, 'Name is required').max(120),
+  // which workspace this bridge lives in; server defaults it when omitted
+  workspaceId: z.string().optional(),
   source: hookSourceSchema,
   destination: hookDestinationSchema,
   transform: hookTransformSchema,
@@ -219,6 +221,8 @@ export type DeliveryStatus = 'success' | 'failed' | 'skipped';
 export interface Hook {
   id: string;
   name: string;
+  /** the workspace this bridge belongs to */
+  workspaceId: string;
   source: HookSource;
   destination: HookDestination;
   transform: HookTransformConfig;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from './adapters/types';
 export * from './errors';
 export * from './validation';
 export * from './hooks';
+export * from './workspace';
 
 // type-only re-exports of the driver metadata (no driver implementations are
 // pulled in, so this stays safe for the browser bundle)

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -12,6 +12,8 @@ export const engineSchema = z.enum([
 
 export const connectionInputSchema = z.object({
   name: z.string().min(1, 'Name is required').max(120),
+  // which workspace this connection lives in; server defaults it when omitted
+  workspaceId: z.string().optional(),
   engine: engineSchema,
   color: z.string().optional(),
   host: z.string().optional(),

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -1,0 +1,25 @@
+/**
+ * workspaces are the top-level container, an ecosystem that owns connections and
+ * bridges (hooks). everything a user creates lives inside one. there's always a
+ * default workspace so the concept stays invisible until you want a second one.
+ */
+import { z } from 'zod';
+
+/** the always-present default workspace every install starts with */
+export const DEFAULT_WORKSPACE_ID = '00000000-0000-0000-0000-000000000001';
+
+export const workspaceInputSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(120),
+  color: z.string().optional(),
+});
+
+export type WorkspaceInputDTO = z.infer<typeof workspaceInputSchema>;
+
+/** a workspace as returned by the API */
+export interface Workspace {
+  id: string;
+  name: string;
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Introduce a Workspace as the top-level container that owns connections and bridges, and present hooks/jobs as "bridges" — a single sync from a database to an endpoint that runs either an on-demand job (replay) or a live hook (watch/CDC).

Backend
- New Workspace model + module (CRUD); a default workspace is seeded by the migration and re-ensured on boot, and is protected from deletion.
- Add workspaceId to Connection and Hook (FK, cascade); the migration backfills existing rows to the default workspace.
- List endpoints scope by ?workspaceId; creates stamp the workspace.
- Deleting a workspace stops its live bridges first, then cascades.
- New GET /hooks/statuses?workspaceId returns the latest run status per bridge in one query (drives the map colors).

Frontend
- Workspace switcher in the sidebar (switch / create / delete), auto-selecting the default; connections and bridges are scoped to the active workspace.
- One unified "Bridges" list (no more Live/On-demand tabs); each row shows its real run state — Live, Failed, Idle, On-demand, or Off.
- Builder gains a "What runs in this bridge" Job/Hook selector.
- New React Flow workspace map: databases → bridges → endpoints, with edges and nodes colored by live status. Click a bridge to open it.
- Status updates instantly on start/stop via query invalidation, with a light background poll for autonomous changes.

<!-- Thanks for the contribution! Keep PRs focused on one change. -->

## Summary

<!-- What does this PR do, and why? -->

## Changes

<!-- Bullet the notable changes. -->

-

## Testing

<!-- How did you verify this? Commands, manual steps, screenshots. -->

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes

## Notes for reviewers

<!-- Anything tricky, follow-ups, or decisions you want a second opinion on. -->
