### PR TITLE
Harden the API layer against crashes, leaks, and unsafe defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # no `version:` here — the version is pinned by "packageManager" in
+      # package.json; specifying both makes action-setup fail on a mismatch
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -6,8 +6,9 @@
 # Port the API listens on. Must match NEXT_PUBLIC_API_URL in the web app.
 PORT=4002
 
-# Browser origin allowed by CORS. Defaults to reflecting any origin in dev;
-# set an explicit URL in production, e.g. https://relay.example.com
+# Browser origin(s) allowed by CORS (comma-separated for more than one).
+# Defaults to the local web app (http://localhost:<WEB_PORT or 3002>); set an
+# explicit URL when the web app is served elsewhere, e.g. https://bridge.example.com
 # WEB_ORIGIN=http://localhost:3002
 
 # ── Metadata store ───────────────────────────────────────────
@@ -29,8 +30,8 @@ DATABRIDGE_MASTER_KEY=
 DATABRIDGE_MAX_QUERY_ROWS=5000
 # Idle milliseconds before a pooled database connection is closed.
 DATABRIDGE_POOL_IDLE_MS=300000
-# Where the encryption key + local state live (default: apps/api/.relay).
-# DATABRIDGE_DATA_DIR=.relay
+# Where the encryption key + local state live (default: apps/api/.data-bridge).
+# DATABRIDGE_DATA_DIR=.data-bridge
 
 # ── Automation hooks (job queue) ─────────────────────────────
 # Redis backing the BullMQ queue that runs automation hooks. Start one with

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "dev": "prisma generate && prisma migrate deploy && nest start --watch",
     "start": "prisma generate && prisma migrate deploy && node dist/main.js",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "prisma:generate": "prisma generate",
     "migrate:dev": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",

--- a/apps/api/src/common/crypto.service.ts
+++ b/apps/api/src/common/crypto.service.ts
@@ -7,7 +7,7 @@
  */
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
 import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { runtimeConfig } from './runtime-config';
 
 const ALGO = 'aes-256-gcm';
@@ -40,6 +40,12 @@ export class CryptoService {
     }
 
     const key = randomBytes(32);
+    // fine for local dev, but the key then lives beside the data it protects —
+    // a backup of the data dir carries both. production must set the env key
+    new Logger('Crypto').warn(
+      `DATABRIDGE_MASTER_KEY is not set — generated a key at ${runtimeConfig.keyFile}. ` +
+        'Set DATABRIDGE_MASTER_KEY in production.',
+    );
     writeFileSync(runtimeConfig.keyFile, key.toString('base64'), {
       mode: 0o600,
     });

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -6,7 +6,8 @@ function resolveDataDir(): string {
   const dir = process.env.DATABRIDGE_DATA_DIR
     ? resolve(process.env.DATABRIDGE_DATA_DIR)
     : resolve(process.cwd(), '.data-bridge');
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // 0o700: the dir holds the master key, keep it out of reach of other users
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   return dir;
 }
 
@@ -20,7 +21,11 @@ export const runtimeConfig = {
   maxQueryRows: Number(process.env.DATABRIDGE_MAX_QUERY_ROWS ?? 5000),
   poolIdleMs: Number(process.env.DATABRIDGE_POOL_IDLE_MS ?? 300_000),
   port: Number(process.env.PORT ?? 4000),
-  webOrigin: process.env.WEB_ORIGIN ?? true,
+  // never fall back to reflecting arbitrary origins: with credentialed CORS
+  // that would let any web page the operator visits call this API
+  webOrigin: process.env.WEB_ORIGIN
+    ? process.env.WEB_ORIGIN.split(',').map((o) => o.trim())
+    : `http://localhost:${process.env.WEB_PORT ?? '3002'}`,
   /** Redis URL backing the BullMQ hook-run queue */
   redisUrl: process.env.REDIS_URL ?? 'redis://localhost:6379',
   /** worker concurrency: how many hook runs may run in parallel */

--- a/apps/api/src/connections/adapter-pool.service.ts
+++ b/apps/api/src/connections/adapter-pool.service.ts
@@ -18,6 +18,8 @@ interface PoolEntry {
 @Injectable()
 export class AdapterPoolService implements OnModuleDestroy {
   private readonly entries = new Map<string, PoolEntry>();
+  /** in-flight opens, so concurrent requests share one connect instead of leaking */
+  private readonly pending = new Map<string, Promise<DatabaseAdapter>>();
   private readonly sweepTimer: NodeJS.Timeout;
 
   constructor(private readonly store: ConnectionStoreService) {
@@ -65,12 +67,29 @@ export class AdapterPoolService implements OnModuleDestroy {
       existing.lastUsedAt = Date.now();
       return existing.adapter;
     }
-    if (existing) {
-      await existing.adapter.close().catch(() => {});
-      this.entries.delete(key);
-    }
 
-    const adapter = createAdapter({ ...config, database: effectiveDb });
+    // join an in-flight open instead of racing it: two concurrent misses would
+    // otherwise both connect and the loser's adapter would leak unreferenced
+    const inFlight = this.pending.get(key);
+    if (inFlight) return inFlight;
+
+    const open = this.open(key, { ...config, database: effectiveDb }).finally(
+      () => this.pending.delete(key),
+    );
+    this.pending.set(key, open);
+    return open;
+  }
+
+  private async open(
+    key: string,
+    config: ConnectionConfig,
+  ): Promise<DatabaseAdapter> {
+    const stale = this.entries.get(key);
+    if (stale) {
+      this.entries.delete(key);
+      await stale.adapter.close().catch(() => {});
+    }
+    const adapter = createAdapter(config);
     await adapter.connect();
     this.entries.set(key, {
       adapter,
@@ -108,11 +127,19 @@ export class AdapterPoolService implements OnModuleDestroy {
    * after the connection is edited or deleted
    */
   async evict(id: string): Promise<void> {
-    for (const [key, entry] of this.entries) {
-      if (key === id || key.startsWith(`${id}::`)) {
-        await entry.adapter.close().catch(() => {});
-        this.entries.delete(key);
-      }
-    }
+    const prefix = `${id}::`;
+    // settle in-flight opens first so their adapters can't escape the evict
+    const opening = [...this.pending.entries()]
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([, p]) => p.catch(() => {}));
+    await Promise.all(opening);
+
+    const targets = [...this.entries.entries()].filter(([key]) =>
+      key.startsWith(prefix),
+    );
+    for (const [key] of targets) this.entries.delete(key);
+    await Promise.all(
+      targets.map(([, entry]) => entry.adapter.close().catch(() => {})),
+    );
   }
 }

--- a/apps/api/src/connections/connection-store.service.ts
+++ b/apps/api/src/connections/connection-store.service.ts
@@ -1,11 +1,11 @@
 /**
- * persistent store for saved connections, backed by Prisma (SQLite).
+ * persistent store for saved connections, backed by Prisma (PostgreSQL).
  * secrets (password, connection string) are encrypted at rest. callers get a
  * redacted view unless they explicitly resolve the full config
  */
 import { randomUUID } from 'node:crypto';
-import { Injectable } from '@nestjs/common';
-import type { Connection as ConnectionRow } from '@prisma/client';
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma, type Connection as ConnectionRow } from '@prisma/client';
 import {
   type ConnectionConfig,
   type ConnectionInput,
@@ -19,10 +19,22 @@ const REDACTED = '********';
 
 @Injectable()
 export class ConnectionStoreService {
+  private readonly logger = new Logger('ConnectionStore');
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly crypto: CryptoService,
   ) {}
+
+  /** corrupt options must not make the whole connection un-listable */
+  private parseOptions(id: string, json: string): Record<string, unknown> | undefined {
+    try {
+      return JSON.parse(json) as Record<string, unknown>;
+    } catch {
+      this.logger.warn(`Connection ${id} has unparseable optionsJson — ignoring it`);
+      return undefined;
+    }
+  }
 
   private toConfig(row: ConnectionRow, includeSecrets: boolean): ConnectionConfig {
     return {
@@ -49,7 +61,7 @@ export class ConnectionStoreService {
             ? REDACTED
             : undefined,
       options: row.optionsJson
-        ? (JSON.parse(row.optionsJson) as Record<string, unknown>)
+        ? this.parseOptions(row.id, row.optionsJson)
         : undefined,
       createdAt: row.createdAt.toISOString(),
       updatedAt: row.updatedAt.toISOString(),
@@ -119,27 +131,45 @@ export class ConnectionStoreService {
           ? this.crypto.encrypt(input.connectionString)
           : null;
 
-    const row = await this.prisma.connection.update({
-      where: { id },
-      data: {
-        name: input.name,
-        engine: input.engine,
-        color: input.color ?? null,
-        host: input.host ?? null,
-        port: input.port ?? null,
-        user: input.user ?? null,
-        passwordEnc,
-        database: input.database ?? null,
-        ssl: input.ssl ?? false,
-        connectionStringEnc,
-        optionsJson: input.options ? JSON.stringify(input.options) : null,
-      },
-    });
-    return this.toConfig(row, false);
+    try {
+      const row = await this.prisma.connection.update({
+        where: { id },
+        data: {
+          name: input.name,
+          engine: input.engine,
+          color: input.color ?? null,
+          host: input.host ?? null,
+          port: input.port ?? null,
+          user: input.user ?? null,
+          passwordEnc,
+          database: input.database ?? null,
+          ssl: input.ssl ?? false,
+          connectionStringEnc,
+          optionsJson: input.options ? JSON.stringify(input.options) : null,
+        },
+      });
+      return this.toConfig(row, false);
+    } catch (err) {
+      throw this.mapMissing(err, id);
+    }
   }
 
   async remove(id: string): Promise<void> {
-    await this.getRow(id); // 404s if missing
-    await this.prisma.connection.delete({ where: { id } });
+    try {
+      await this.prisma.connection.delete({ where: { id } });
+    } catch (err) {
+      throw this.mapMissing(err, id);
+    }
+  }
+
+  /** a concurrent delete between read and write should 404, not 500 */
+  private mapMissing(err: unknown, id: string): unknown {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2025'
+    ) {
+      return new NotFoundError(`Connection "${id}" not found`);
+    }
+    return err;
   }
 }

--- a/apps/api/src/connections/connections.controller.ts
+++ b/apps/api/src/connections/connections.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import {
   type ConnectionConfig,
+  ConflictError,
   backupSchema,
   browseSchema,
   connectionInputSchema,
@@ -25,6 +26,7 @@ import {
   type ConnectionInputDTO,
 } from '@data-bridge/core';
 import type { z } from 'zod';
+import { PrismaService } from '../common/prisma.service';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { AdapterPoolService } from './adapter-pool.service';
 import { ConnectionStoreService } from './connection-store.service';
@@ -45,6 +47,7 @@ export class ConnectionsController {
   constructor(
     private readonly store: ConnectionStoreService,
     private readonly pool: AdapterPoolService,
+    private readonly prisma: PrismaService,
   ) {}
 
   /* ----- CRUD ----- */
@@ -97,6 +100,27 @@ export class ConnectionsController {
 
   @Delete(':id')
   async remove(@Param('id') id: string): Promise<{ id: string }> {
+    await this.store.get(id); // 404s if missing
+    // Hook.connectionId has no FK, so enforce the reference here: deleting a
+    // connection out from under its bridges would leave zombie listeners and
+    // runs that can only fail. destinations embed connection ids in their
+    // JSON, so a contains-check on the uuid covers that side too
+    const [asSource, asDest] = await Promise.all([
+      this.prisma.hook.findMany({
+        where: { connectionId: id },
+        select: { id: true },
+      }),
+      this.prisma.hook.findMany({
+        where: { destinationJson: { contains: id } },
+        select: { id: true },
+      }),
+    ]);
+    const inUse = new Set([...asSource, ...asDest].map((h) => h.id)).size;
+    if (inUse > 0) {
+      throw new ConflictError(
+        `This connection is used by ${inUse} bridge${inUse === 1 ? '' : 's'}. Delete or repoint ${inUse === 1 ? 'it' : 'them'} first.`,
+      );
+    }
     await this.pool.evict(id);
     await this.store.remove(id);
     return { id };

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,18 +1,38 @@
 import 'reflect-metadata';
 import 'dotenv/config';
+import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { AppExceptionFilter } from './common/app-exception.filter';
 import { TransformInterceptor } from './common/transform.interceptor';
 import { runtimeConfig } from './common/runtime-config';
 
+const logger = new Logger('Bootstrap');
+
+// last-resort handlers: a stray rejection (e.g. a driver emitting an error on
+// an idle pooled connection) must never take the server down silently
+process.on('unhandledRejection', (reason) => {
+  const msg = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+  logger.error(`Unhandled promise rejection: ${msg}`);
+});
+process.on('uncaughtException', (err) => {
+  logger.error(`Uncaught exception: ${err.stack ?? err.message}`);
+  // state may be corrupt after an uncaught throw; exit and let the supervisor restart
+  process.exit(1);
+});
+
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     // quiet the verbose route-mapping/bootstrap logs so the combined
     // `pnpm dev` output stays readable. errors and warnings still show
     logger: ['error', 'warn'],
+    // registered manually below so the JSON limit is explicit: backup/restore
+    // payloads carry whole dumps and would 413 on the 100kb express default
+    bodyParser: false,
   });
 
+  app.useBodyParser('json', { limit: '50mb' });
   app.setGlobalPrefix('api');
   app.enableCors({ origin: runtimeConfig.webOrigin, credentials: true });
   app.useGlobalFilters(new AppExceptionFilter());
@@ -32,4 +52,13 @@ async function bootstrap(): Promise<void> {
   );
 }
 
-void bootstrap();
+bootstrap().catch((err: NodeJS.ErrnoException) => {
+  if (err.code === 'EADDRINUSE') {
+    logger.error(
+      `Port ${runtimeConfig.port} is already in use. Stop the other process or set PORT.`,
+    );
+  } else {
+    logger.error(`Failed to start: ${err.stack ?? err.message}`);
+  }
+  process.exit(1);
+});

--- a/apps/api/src/workspaces/workspace-store.service.ts
+++ b/apps/api/src/workspaces/workspace-store.service.ts
@@ -5,7 +5,7 @@
  */
 import { randomUUID } from 'node:crypto';
 import { Injectable, type OnModuleInit, Logger } from '@nestjs/common';
-import type { Workspace as WorkspaceRow } from '@prisma/client';
+import { Prisma, type Workspace as WorkspaceRow } from '@prisma/client';
 import {
   type Workspace,
   type WorkspaceInputDTO,
@@ -70,12 +70,15 @@ export class WorkspaceStoreService implements OnModuleInit {
   }
 
   async update(id: string, input: WorkspaceInputDTO): Promise<Workspace> {
-    await this.get(id); // 404 if missing
-    const row = await this.prisma.workspace.update({
-      where: { id },
-      data: { name: input.name, color: input.color ?? null },
-    });
-    return this.toWorkspace(row);
+    try {
+      const row = await this.prisma.workspace.update({
+        where: { id },
+        data: { name: input.name, color: input.color ?? null },
+      });
+      return this.toWorkspace(row);
+    } catch (err) {
+      throw this.mapMissing(err, id);
+    }
   }
 
   // deleting cascades to the workspace's connections and hooks (and their runs).
@@ -84,7 +87,21 @@ export class WorkspaceStoreService implements OnModuleInit {
     if (id === DEFAULT_WORKSPACE_ID) {
       throw new BadRequestError('The default workspace cannot be deleted.');
     }
-    await this.get(id);
-    await this.prisma.workspace.delete({ where: { id } });
+    try {
+      await this.prisma.workspace.delete({ where: { id } });
+    } catch (err) {
+      throw this.mapMissing(err, id);
+    }
+  }
+
+  /** a concurrent delete between read and write should 404, not 500 */
+  private mapMissing(err: unknown, id: string): unknown {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2025'
+    ) {
+      return new NotFoundError(`Workspace "${id}" not found`);
+    }
+    return err;
   }
 }


### PR DESCRIPTION
- CORS no longer reflects arbitrary origins with credentials; it defaults to the local web app origin and accepts a comma-separated WEB_ORIGIN list
- add last-resort unhandledRejection/uncaughtException handlers and guard bootstrap with a clear EADDRINUSE message
- register the JSON body parser explicitly with a 50mb limit so backup and restore payloads no longer 413 on the 100kb express default
- adapter pool: memoize in-flight opens so concurrent cache misses share one connect instead of leaking the loser; evict now settles pending opens and closes adapters in parallel
- block deleting a connection while bridges still reference it (source or destination) with a clear 409 instead of leaving zombie listeners
- connection/workspace stores: map P2025 races to 404s, survive corrupt optionsJson instead of 500ing on every list, warn loudly when falling back to a generated master key, create the data dir 0700
- fix stale .relay/SQLite docs and make the api test script pass with no test files so pnpm test / CI stays green

<!-- Thanks for the contribution! Keep PRs focused on one change. -->

## Summary

<!-- What does this PR do, and why? -->

## Changes

<!-- Bullet the notable changes. -->

-

## Testing

<!-- How did you verify this? Commands, manual steps, screenshots. -->

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes

## Notes for reviewers

<!-- Anything tricky, follow-ups, or decisions you want a second opinion on. -->
