### PR TITLE
Rename project from Data Bridge to Syncle

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ What you thought should happen instead.
 3.
 
 **Environment**
-- Data Bridge version / commit:
+- Syncle version / commit:
 - Database engine + version (the one you connected to):
 - OS:
 - Node / pnpm version:

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ next-env.d.ts
 .env*.local
 
 # local application data — metadata store + encryption key (never commit)
-.data-bridge/
+.syncle/
 .relay/
 apps/api/prisma/*.db
 apps/api/prisma/*.db-journal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ reaches 1.0.
 
 ### Changed
 
-- Renamed the project to **Data Bridge**.
+- Renamed the project to **Syncle**.
 - The internal metadata store now runs on **PostgreSQL** instead of SQLite.
 - The live delivery monitor fetches one final time when a run finishes, so the
   last cells settle correctly; added a LIVE indicator and auto-follow paging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,19 @@
-# Contributing to Data Bridge
+# Contributing to Syncle
 
 Thanks for taking the time to contribute! This guide covers everything you need
 to get a change merged.
 
 ## Getting set up
 
-Data Bridge is a pnpm monorepo (`web → api → core`). You'll need:
+Syncle is a pnpm monorepo (`web → api → core`). You'll need:
 
 - **Node.js ≥ 22** (the MySQL binlog reader requires it)
 - **pnpm ≥ 10**
 - **Docker** (for the bundled Postgres + Redis)
 
 ```bash
-git clone https://github.com/ozmanghani/data-bridge.git
-cd data-bridge
+git clone https://github.com/ozmanghani/syncle.git
+cd syncle
 pnpm install
 docker compose up -d          # postgres (metadata) + redis (queue)
 pnpm dev                      # API + web in watch mode
@@ -25,9 +25,9 @@ The web app comes up on `http://localhost:3002`, the API on
 ## Project layout
 
 ```
-packages/core   @data-bridge/core — pure domain logic, adapters, schemas (no framework)
-apps/api        @data-bridge/api  — NestJS backend, Prisma, BullMQ, CDC providers
-apps/web        @data-bridge/web  — Next.js frontend
+packages/core   @syncle/core — pure domain logic, adapters, schemas (no framework)
+apps/api        @syncle/api  — NestJS backend, Prisma, BullMQ, CDC providers
+apps/web        @syncle/web  — Next.js frontend
 ```
 
 The dependency direction is one-way: `core` never imports from `api`/`web`, and

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="apps/web/public/logo-white.png">
-  <img alt="Data Bridge" src="apps/web/public/logo-dark.png" width="400">
+  <img alt="Syncle" src="apps/web/public/logo-dark.png" width="400">
 </picture>
 
 ### Keep any databases in sync — live, across engines.
 
 Connect your databases, draw a **bridge** from a source to one or more
-destinations, and Data Bridge keeps them in sync: the moment a row changes in the
+destinations, and Syncle keeps them in sync: the moment a row changes in the
 source, it's written to every destination you linked. Any engine to any engine —
 **PostgreSQL · MySQL/MariaDB · SQLite · MongoDB · Redis** — plus HTTP endpoints
 when you need them.
@@ -38,7 +38,7 @@ What makes the database-to-database sync trustworthy:
   you choose, so replays, retries, and redeliveries never double-write. Inserts,
   updates, **and deletes** all propagate.
 - **Missing table? Auto-create it.** If the destination table/collection doesn't
-  exist, Data Bridge creates it from the source's shape (with cross-engine type
+  exist, Syncle creates it from the source's shape (with cross-engine type
   translation). Or **map and rename columns** yourself — "write this column into
   that column over there."
 - **Live, polled, or one-shot** — you pick how it fires (see triggers below).
@@ -97,7 +97,7 @@ builds the workspace, runs the database migrations, then launches both the API
 and the web app.
 
 ```
-  Data Bridge · ready
+  Syncle · ready
 
     Web  http://localhost:3002   ← open this
     API  http://localhost:4002/api
@@ -113,7 +113,7 @@ Working on the code? `pnpm dev` is the same thing in watch mode.
 > Fix: use Node 22+ (`nvm use`), get pnpm via `corepack enable` instead of your
 > system package manager, then `pnpm install` again.
 
-> The two services back different things. **Postgres** holds Data Bridge's own
+> The two services back different things. **Postgres** holds Syncle's own
 > metadata (saved connections, hooks, runs, deliveries) through Prisma.
 > **Redis** backs the BullMQ queue that runs hooks durably. Connecting
 > databases, browsing data, and building/previewing hooks all work without
@@ -140,7 +140,7 @@ Working on the code? `pnpm dev` is the same thing in watch mode.
 
 ## Source data, when you need it
 
-Data Bridge ships a full database workbench (the "Data sources" surface) — handy
+Syncle ships a full database workbench (the "Data sources" surface) — handy
 for shaping a source and for inspecting what landed in a destination:
 
 - Browse any table — paginated, sortable, multi-condition filters, inline edit,
@@ -160,21 +160,21 @@ pre-seeded with that table as the source.
 A pnpm monorepo with a one-way dependency flow (`web → api → core`):
 
 ```
-data-bridge/
+syncle/
 ├─ packages/
-│  └─ core/            @data-bridge/core — framework-agnostic domain (pure TS)
+│  └─ core/            @syncle/core — framework-agnostic domain (pure TS)
 │     ├─ adapters/       DatabaseAdapter interface + one file per engine
 │     │                  (raw drivers: pg, mysql2, better-sqlite3, mongodb, ioredis)
 │     └─ hooks/          column mapping + cross-engine table translation,
 │                        payload transform, shared bridge schemas (Zod)
 ├─ apps/
-│  ├─ api/             @data-bridge/api — NestJS backend
+│  ├─ api/             @syncle/api — NestJS backend
 │  │  ├─ hooks/          bridge store · run processor · CDC providers ·
 │  │  │                  sink router → database sink + HTTP delivery
 │  │  ├─ connections/    Prisma-backed store · live adapter pool · controllers
 │  │  ├─ common/         crypto · Zod validation · exception filter
 │  │  └─ prisma/         metadata-store schema + migrations
-│  └─ web/             @data-bridge/web — Next.js 15 frontend (shadcn/ui, TanStack)
+│  └─ web/             @syncle/web — Next.js 15 frontend (shadcn/ui, TanStack)
 └─ docker-compose.yml  Postgres (metadata) + Redis (run queue)
 ```
 
@@ -204,7 +204,7 @@ engine's CDC is a single file.
 
 **Two data layers, two right tools.** The databases you connect _to_ have
 unknown, runtime-discovered schemas, so the adapters use raw drivers with fully
-parameterized queries (an ORM can't introspect arbitrary schemas). Data Bridge's
+parameterized queries (an ORM can't introspect arbitrary schemas). Syncle's
 _own_ store has a fixed schema we control, so it uses Prisma with migrations.
 
 > Adding an engine = implement `DatabaseAdapter` and register it. The connection
@@ -224,12 +224,12 @@ Env files are created automatically on first run from the committed
 | `NEXT_PUBLIC_API_URL`         | web   | Base URL of the API                          |
 | `DATABASE_URL`                | api   | Postgres datasource for the metadata store   |
 | `REDIS_URL`                   | api   | Redis backing the bridge-run queue           |
-| `DATABRIDGE_MASTER_KEY`       | api   | base64 32-byte key for secret encryption     |
-| `DATABRIDGE_HOOK_CONCURRENCY` | api   | How many bridge runs may execute in parallel |
+| `SYNCLE_MASTER_KEY`       | api   | base64 32-byte key for secret encryption     |
+| `SYNCLE_HOOK_CONCURRENCY` | api   | How many bridge runs may execute in parallel |
 | `WEB_ORIGIN`                  | api   | CORS origin (defaults to any in dev)         |
 
-If `DATABRIDGE_MASTER_KEY` is unset, a random key is generated under
-`apps/api/.data-bridge/` on first run — set it explicitly in production.
+If `SYNCLE_MASTER_KEY` is unset, a random key is generated under
+`apps/api/.syncle/` on first run — set it explicitly in production.
 
 ## CDC prerequisites
 
@@ -242,7 +242,7 @@ for you and spells out what's missing.
 | PostgreSQL | logical replication    | `wal_level=logical`, a role with REPLICATION (slot/publication auto-made)                                   |
 | MySQL      | binary log             | `log_bin=ON`, `binlog_format=ROW`, `binlog_row_image=FULL`, REPLICATION grants                              |
 | MongoDB    | change streams         | a replica set (a single-node one is fine for dev); pre-images auto-enabled so deletes propagate by your key |
-| Redis      | keyspace notifications | `notify-keyspace-events` (Data Bridge enables it when it can)                                               |
+| Redis      | keyspace notifications | `notify-keyspace-events` (Syncle enables it when it can)                                               |
 | SQLite     | —                      | not supported; use a watch hook instead                                                                     |
 
 > Redis CDC is real-time only and non-durable — events that happen while Data
@@ -275,7 +275,7 @@ React Flow · Zod · Vitest.
 - All user values are passed as bound parameters; identifiers are dialect-quoted.
 - Hook payloads are built by structured token substitution — no string injection,
   no code execution.
-- Data Bridge runs locally with no auth layer. Add authentication, and restrict
+- Syncle runs locally with no auth layer. Add authentication, and restrict
   which destinations (database connections / endpoint URLs) a bridge may write
   to, before exposing it to an untrusted network.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Data Bridge is pre-1.0 and moves fast; security fixes land on `main` and the
+Syncle is pre-1.0 and moves fast; security fixes land on `main` and the
 latest release only.
 
 | Version | Supported |
@@ -26,7 +26,7 @@ you'd rather stay anonymous.
 
 ## Scope notes
 
-Data Bridge is built to run on a trusted network. A few things are deliberately
+Syncle is built to run on a trusted network. A few things are deliberately
 out of scope unless you've deployed it differently:
 
 - **No built-in auth layer.** The app assumes you put it behind your own

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,5 +1,5 @@
 # ─────────────────────────────────────────────────────────────
-#  Data Bridge API configuration
+#  Syncle API configuration
 #  Copy to ".env" (pnpm bootstrap does this automatically).
 # ─────────────────────────────────────────────────────────────
 
@@ -12,7 +12,7 @@ PORT=4002
 # WEB_ORIGIN=http://localhost:3002
 
 # ── Metadata store ───────────────────────────────────────────
-# Data Bridge's OWN PostgreSQL database (saved connections, hooks, runs) — NOT a
+# Syncle's OWN PostgreSQL database (saved connections, hooks, runs) — NOT a
 # database you connect to. Start one with `docker compose up -d postgres` from
 # the repo root; the credentials below match docker-compose.yml. Point this at
 # any Postgres (managed, RDS, etc.) by changing the URL.
@@ -21,10 +21,10 @@ DATABASE_URL="postgresql://username:password@localhost:5432/db-name?schema=publi
 # ── Security ─────────────────────────────────────────────────
 # Base64 32-byte key. Encrypts stored connection credentials (AES-256-GCM) AND
 # signs login session cookies. Leave blank for local dev — a key is generated
-# under apps/api/.data-bridge/. For production, set this and keep it secret
+# under apps/api/.syncle/. For production, set this and keep it secret
 # (changing it later invalidates stored secrets and logs everyone out):
 #   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
-DATABRIDGE_MASTER_KEY=
+SYNCLE_MASTER_KEY=
 
 # The API is guarded by a single admin account created on first launch via the
 # web app's setup screen — there is no signup. Set NODE_ENV=production to mark
@@ -34,11 +34,11 @@ DATABRIDGE_MASTER_KEY=
 
 # ── Limits / tuning ──────────────────────────────────────────
 # Hard cap on rows returned by a single ad-hoc query.
-DATABRIDGE_MAX_QUERY_ROWS=5000
+SYNCLE_MAX_QUERY_ROWS=5000
 # Idle milliseconds before a pooled database connection is closed.
-DATABRIDGE_POOL_IDLE_MS=300000
-# Where the encryption key + local state live (default: apps/api/.data-bridge).
-# DATABRIDGE_DATA_DIR=.data-bridge
+SYNCLE_POOL_IDLE_MS=300000
+# Where the encryption key + local state live (default: apps/api/.syncle).
+# SYNCLE_DATA_DIR=.syncle
 
 # ── Automation hooks (job queue) ─────────────────────────────
 # Redis backing the BullMQ queue that runs automation hooks. Start one with
@@ -46,4 +46,4 @@ DATABRIDGE_POOL_IDLE_MS=300000
 # payload preview work without Redis — only *running* a hook needs it.
 REDIS_URL=redis://localhost:6379
 # How many hook runs may execute concurrently.
-DATABRIDGE_HOOK_CONCURRENCY=5
+SYNCLE_HOOK_CONCURRENCY=5

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@data-bridge/api",
+  "name": "@syncle/api",
   "version": "0.1.0",
   "private": true,
-  "description": "Data Bridge backend — NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
+  "description": "Syncle backend — NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
   "scripts": {
     "build": "prisma generate && nest build",
     "dev": "prisma generate && prisma migrate deploy && nest start --watch",
@@ -21,7 +21,7 @@
     "@nestjs/platform-express": "^10.4.7",
     "@powersync/mysql-zongji": "^0.6.0",
     "@prisma/client": "^5.22.0",
-    "@data-bridge/core": "workspace:*",
+    "@syncle/core": "workspace:*",
     "bullmq": "^5.34.0",
     "dotenv": "^16.4.5",
     "ioredis": "^5.4.1",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,8 +1,8 @@
-// Prisma schema for Data Bridge's OWN metadata store (saved connections, hooks, runs).
+// Prisma schema for Syncle's OWN metadata store (saved connections, hooks, runs).
 //
 // NOTE: This models only the application's internal database. The databases
 // users connect TO are accessed through the raw driver adapters in
-// @data-bridge/core — an ORM cannot introspect arbitrary, unknown schemas.
+// @syncle/core — an ORM cannot introspect arbitrary, unknown schemas.
 
 generator client {
   provider = "prisma-client-js"

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -17,7 +17,7 @@ import {
   type LoginDTO,
   type SetupDTO,
   UnauthorizedError,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import type { AppUser } from '@prisma/client';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { AuthService } from './auth.service';

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import type { Request } from 'express';
-import { UnauthorizedError } from '@data-bridge/core';
+import { UnauthorizedError } from '@syncle/core';
 import { AuthService } from './auth.service';
 import { IS_PUBLIC } from './public.decorator';
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -19,7 +19,7 @@ import {
   ConflictError,
   UnauthorizedError,
   type AuthUser,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import type { AppUser } from '@prisma/client';
 import { CryptoService } from '../common/crypto.service';
 import { PrismaService } from '../common/prisma.service';

--- a/apps/api/src/common/app-exception.filter.ts
+++ b/apps/api/src/common/app-exception.filter.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import type { Response } from 'express';
-import { AppError } from '@data-bridge/core';
+import { AppError } from '@syncle/core';
 
 /**
  * maps domain {@link AppError}s (and any uncaught error) to a consistent JSON
@@ -15,7 +15,7 @@ import { AppError } from '@data-bridge/core';
  */
 @Catch()
 export class AppExceptionFilter implements ExceptionFilter {
-  private readonly logger = new Logger('Data Bridge');
+  private readonly logger = new Logger('Syncle');
 
   catch(exception: unknown, host: ArgumentsHost): void {
     const res = host.switchToHttp().getResponse<Response>();

--- a/apps/api/src/common/crypto.service.ts
+++ b/apps/api/src/common/crypto.service.ts
@@ -1,7 +1,7 @@
 /**
  * credential encryption at rest (AES-256-GCM).
  *
- * key precedence: DATABRIDGE_MASTER_KEY (base64, 32 bytes) when set, otherwise a
+ * key precedence: SYNCLE_MASTER_KEY (base64, 32 bytes) when set, otherwise a
  * random key generated once and persisted to the data dir with 0600 perms.
  * ciphertext format is "iv:tag:data", all base64
  */
@@ -30,7 +30,7 @@ export class CryptoService {
       const key = Buffer.from(runtimeConfig.masterKey, 'base64');
       if (key.length !== 32) {
         throw new Error(
-          'DATABRIDGE_MASTER_KEY must be a base64-encoded 32-byte value',
+          'SYNCLE_MASTER_KEY must be a base64-encoded 32-byte value',
         );
       }
       this.key = key;
@@ -49,8 +49,8 @@ export class CryptoService {
     // fine for local dev, but the key then lives beside the data it protects —
     // a backup of the data dir carries both. production must set the env key
     new Logger('Crypto').warn(
-      `DATABRIDGE_MASTER_KEY is not set — generated a key at ${runtimeConfig.keyFile}. ` +
-        'Set DATABRIDGE_MASTER_KEY in production.',
+      `SYNCLE_MASTER_KEY is not set — generated a key at ${runtimeConfig.keyFile}. ` +
+        'Set SYNCLE_MASTER_KEY in production.',
     );
     writeFileSync(runtimeConfig.keyFile, key.toString('base64'), {
       mode: 0o600,

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -3,9 +3,9 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 function resolveDataDir(): string {
-  const dir = process.env.DATABRIDGE_DATA_DIR
-    ? resolve(process.env.DATABRIDGE_DATA_DIR)
-    : resolve(process.cwd(), '.data-bridge');
+  const dir = process.env.SYNCLE_DATA_DIR
+    ? resolve(process.env.SYNCLE_DATA_DIR)
+    : resolve(process.cwd(), '.syncle');
   // 0o700: the dir holds the master key, keep it out of reach of other users
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   return dir;
@@ -15,11 +15,11 @@ const dataDir = resolveDataDir();
 
 export const runtimeConfig = {
   dataDir,
-  storeFile: resolve(dataDir, 'data-bridge.db'),
+  storeFile: resolve(dataDir, 'syncle.db'),
   keyFile: resolve(dataDir, 'master.key'),
-  masterKey: process.env.DATABRIDGE_MASTER_KEY ?? null,
-  maxQueryRows: Number(process.env.DATABRIDGE_MAX_QUERY_ROWS ?? 5000),
-  poolIdleMs: Number(process.env.DATABRIDGE_POOL_IDLE_MS ?? 300_000),
+  masterKey: process.env.SYNCLE_MASTER_KEY ?? null,
+  maxQueryRows: Number(process.env.SYNCLE_MAX_QUERY_ROWS ?? 5000),
+  poolIdleMs: Number(process.env.SYNCLE_POOL_IDLE_MS ?? 300_000),
   port: Number(process.env.PORT ?? 4000),
   // never fall back to reflecting arbitrary origins: with credentialed CORS
   // that would let any web page the operator visits call this API
@@ -29,7 +29,7 @@ export const runtimeConfig = {
   /** Redis URL backing the BullMQ hook-run queue */
   redisUrl: process.env.REDIS_URL ?? 'redis://localhost:6379',
   /** worker concurrency: how many hook runs may run in parallel */
-  hookConcurrency: Number(process.env.DATABRIDGE_HOOK_CONCURRENCY ?? 5),
+  hookConcurrency: Number(process.env.SYNCLE_HOOK_CONCURRENCY ?? 5),
 } as const;
 
 /**

--- a/apps/api/src/common/zod-validation.pipe.ts
+++ b/apps/api/src/common/zod-validation.pipe.ts
@@ -3,7 +3,7 @@ import type { ZodSchema } from 'zod';
 
 /**
  * validates and narrows a request payload with a Zod schema, reusing the same
- * schemas shared with the web client (`@data-bridge/core`). usage:
+ * schemas shared with the web client (`@syncle/core`). usage:
  *   `@Body(new ZodValidationPipe(schema)) body: Dto`
  */
 export class ZodValidationPipe<T> implements PipeTransform<unknown, T> {

--- a/apps/api/src/connections/adapter-pool.service.ts
+++ b/apps/api/src/connections/adapter-pool.service.ts
@@ -4,8 +4,8 @@
  * evicted after a period of inactivity
  */
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
-import { createAdapter } from '@data-bridge/core/adapters';
-import type { ConnectionConfig, DatabaseAdapter } from '@data-bridge/core';
+import { createAdapter } from '@syncle/core/adapters';
+import type { ConnectionConfig, DatabaseAdapter } from '@syncle/core';
 import { SettingsStoreService } from '../settings/settings-store.service';
 import { ConnectionStoreService } from './connection-store.service';
 

--- a/apps/api/src/connections/connection-store.service.ts
+++ b/apps/api/src/connections/connection-store.service.ts
@@ -11,7 +11,7 @@ import {
   type ConnectionInput,
   DEFAULT_WORKSPACE_ID,
   NotFoundError,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { CryptoService } from '../common/crypto.service';
 import { PrismaService } from '../common/prisma.service';
 

--- a/apps/api/src/connections/connections.controller.ts
+++ b/apps/api/src/connections/connections.controller.ts
@@ -24,7 +24,7 @@ import {
   restoreSchema,
   updateRowSchema,
   type ConnectionInputDTO,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import type { z } from 'zod';
 import { PrismaService } from '../common/prisma.service';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';

--- a/apps/api/src/drivers/drivers.controller.ts
+++ b/apps/api/src/drivers/drivers.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { listDrivers, toDriverInfo, type DriverInfo } from '@data-bridge/core/adapters';
+import { listDrivers, toDriverInfo, type DriverInfo } from '@syncle/core/adapters';
 
 @Controller('drivers')
 export class DriversController {

--- a/apps/api/src/hooks/cdc/cdc-provider.ts
+++ b/apps/api/src/hooks/cdc/cdc-provider.ts
@@ -19,7 +19,7 @@ import type {
   CdcReadinessDTO,
   ConnectionConfig,
   DatabaseEngine,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import type { ResolvedHook } from '../hooks.types';
 
 /** one decoded change, normalized across every engine */

--- a/apps/api/src/hooks/cdc/providers/mongodb-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/mongodb-cdc.provider.ts
@@ -22,7 +22,7 @@ import type {
   CdcReadinessDTO,
   ConnectionConfig,
   DatabaseEngine,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import type { ResolvedHook } from '../../hooks.types';
 import { backoffMs, delay, type CdcChange, type CdcProvider, type CdcStreamContext, type CdcStreamHandle } from '../cdc-provider';
 

--- a/apps/api/src/hooks/cdc/providers/mysql-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/mysql-cdc.provider.ts
@@ -1,6 +1,6 @@
 /**
  * MySQL CDC via the binary log (row-based replication), read with
- * `@powersync/mysql-zongji`. Data Bridge registers as a replication client and
+ * `@powersync/mysql-zongji`. Syncle registers as a replication client and
  * decodes Write/Update/Delete row events in real time. durable and resumable:
  * the cursor is the binlog `"file:position"`, so a restart resumes exactly
  * where it left off.
@@ -18,7 +18,7 @@ import type {
   CdcReadinessDTO,
   ConnectionConfig,
   DatabaseEngine,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { AdapterPoolService } from '../../../connections/adapter-pool.service';
 import type { ResolvedHook } from '../../hooks.types';
 import {

--- a/apps/api/src/hooks/cdc/providers/postgres-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/postgres-cdc.provider.ts
@@ -17,7 +17,7 @@ import type {
   CdcReadinessDTO,
   ConnectionConfig,
   DatabaseEngine,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { LogicalReplicationService, PgoutputPlugin } from 'pg-logical-replication';
 import { AdapterPoolService } from '../../../connections/adapter-pool.service';
 import type { ResolvedHook } from '../../hooks.types';
@@ -103,10 +103,10 @@ export class PostgresCdcProvider implements CdcProvider {
   /* ----- provisioning ----- */
 
   private pubName(hookId: string): string {
-    return `databridge_pub_${hookId.replace(/-/g, '')}`;
+    return `syncle_pub_${hookId.replace(/-/g, '')}`;
   }
   private slotName(hookId: string): string {
-    return `databridge_slot_${hookId.replace(/-/g, '')}`;
+    return `syncle_slot_${hookId.replace(/-/g, '')}`;
   }
   private quoteIdent(id: string): string {
     return `"${id.replace(/"/g, '""')}"`;

--- a/apps/api/src/hooks/cdc/providers/redis-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/redis-cdc.provider.ts
@@ -3,7 +3,7 @@
  *
  * IMPORTANT, this is real-time but NON-DURABLE by nature:
  *  - keyspace notifications are fire-and-forget pub/sub with no backlog. any
- *    event published while Data Bridge is disconnected (restart, network blip)
+ *    event published while Syncle is disconnected (restart, network blip)
  *    is gone for good, there's no resume cursor.
  *  - the event carries only the KEY, not the value, so we do a best-effort
  *    follow-up read to fill the row (the key may already be gone for deletes).
@@ -21,7 +21,7 @@ import type {
   CdcReadinessDTO,
   ConnectionConfig,
   DatabaseEngine,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import type { ResolvedHook } from '../../hooks.types';
 import type {
   CdcChange,
@@ -102,11 +102,11 @@ export class RedisCdcProvider implements CdcProvider {
       });
       if (!ok) {
         instructions.push(
-          'Enable keyspace notifications:  CONFIG SET notify-keyspace-events EA  (or set `notify-keyspace-events EA` in redis.conf). Data Bridge will attempt this automatically on start; managed Redis may require enabling it in the provider console.',
+          'Enable keyspace notifications:  CONFIG SET notify-keyspace-events EA  (or set `notify-keyspace-events EA` in redis.conf). Syncle will attempt this automatically on start; managed Redis may require enabling it in the provider console.',
         );
       }
       instructions.push(
-        'Note: Redis change capture is real-time only. Events that occur while Data Bridge is offline cannot be recovered, and the changed value is fetched after the fact (best-effort).',
+        'Note: Redis change capture is real-time only. Events that occur while Syncle is offline cannot be recovered, and the changed value is fetched after the fact (best-effort).',
       );
       return { engine: 'redis', supported: true, ready: ok, checks, instructions };
     } catch (err) {

--- a/apps/api/src/hooks/cdc/providers/sqlite-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/sqlite-cdc.provider.ts
@@ -2,14 +2,14 @@
  * SQLite has no event-based CDC for external writers.
  *
  * `sqlite3_update_hook` only fires for writes made through the *same in-process
- * connection handle*. Data Bridge opens a database file that a *different*
+ * connection handle*. Syncle opens a database file that a *different*
  * process writes to, so it can never see those writes via the hook, and there's
  * no public WAL-tailing API that yields logical row changes. so we report
  * `supported: false` and steer the user to the polling (watch) trigger, which
  * works fine for SQLite.
  */
 import { Injectable } from '@nestjs/common';
-import type { CdcReadiness, DatabaseEngine } from '@data-bridge/core';
+import type { CdcReadiness, DatabaseEngine } from '@syncle/core';
 import type { CdcProvider, CdcStreamContext, CdcStreamHandle } from '../cdc-provider';
 
 @Injectable()

--- a/apps/api/src/hooks/database-sink.service.ts
+++ b/apps/api/src/hooks/database-sink.service.ts
@@ -34,7 +34,7 @@ import {
   type CdcOperation,
   type DatabaseTarget,
   type TargetColumnShape,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { ConnectionStoreService } from '../connections/connection-store.service';
 import type { DeliveryOutcome } from './hooks.types';

--- a/apps/api/src/hooks/delivery.service.ts
+++ b/apps/api/src/hooks/delivery.service.ts
@@ -7,7 +7,7 @@
  * truncated response snippet is kept.
  */
 import { Injectable, Logger } from '@nestjs/common';
-import type { HookDeliveryConfig, HttpDestination } from '@data-bridge/core';
+import type { HookDeliveryConfig, HttpDestination } from '@syncle/core';
 import type { DeliveryOutcome } from './hooks.types';
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);

--- a/apps/api/src/hooks/hook-cdc.service.ts
+++ b/apps/api/src/hooks/hook-cdc.service.ts
@@ -28,7 +28,7 @@ import {
   type ConnectionConfig,
   type DatabaseEngine,
   type HookRun,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { randomUUID } from 'node:crypto';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { ConnectionStoreService } from '../connections/connection-store.service';

--- a/apps/api/src/hooks/hook-run.processor.ts
+++ b/apps/api/src/hooks/hook-run.processor.ts
@@ -20,7 +20,7 @@ import {
   BadRequestError,
   type BrowseParams,
   type SortSpec,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import type { Job } from 'bullmq';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { runtimeConfig } from '../common/runtime-config';

--- a/apps/api/src/hooks/hook-run.service.ts
+++ b/apps/api/src/hooks/hook-run.service.ts
@@ -19,7 +19,7 @@ import {
   type HookRun,
   type HookRunStatus,
   NotFoundError,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { Queue } from 'bullmq';
 import type {
   HookDelivery as DeliveryRow,

--- a/apps/api/src/hooks/hook-sink.service.ts
+++ b/apps/api/src/hooks/hook-sink.service.ts
@@ -13,7 +13,7 @@ import {
   renderBatch,
   renderRow,
   type CdcOperation,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { DeliveryService } from './delivery.service';
 import { DatabaseSinkService } from './database-sink.service';
 import type { DeliveryOutcome, ResolvedHook } from './hooks.types';

--- a/apps/api/src/hooks/hook-store.service.ts
+++ b/apps/api/src/hooks/hook-store.service.ts
@@ -13,7 +13,7 @@ import {
   type HookInputDTO,
   DEFAULT_WORKSPACE_ID,
   NotFoundError,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { CryptoService } from '../common/crypto.service';
 import { PrismaService } from '../common/prisma.service';
 import type { ResolvedHook } from './hooks.types';

--- a/apps/api/src/hooks/hook-watch.service.ts
+++ b/apps/api/src/hooks/hook-watch.service.ts
@@ -5,7 +5,7 @@
  * `pollIntervalMs`. schedulers persist in Redis, so listening survives restarts;
  * `onModuleInit` re-registers any that should still be active.
  *
- * the change-detection itself is the pure engine in `@data-bridge/core`
+ * the change-detection itself is the pure engine in `@syncle/core`
  * (`watchQuery` / `advanceCursor`); this service is the I/O around it: fetch a
  * page, deliver the new rows, persist the advanced cursor.
  */
@@ -24,7 +24,7 @@ import {
   watchStrategySchema,
   type HookRun,
   type WatchCursor,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { Queue } from 'bullmq';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { PrismaService } from '../common/prisma.service';

--- a/apps/api/src/hooks/hooks.controller.ts
+++ b/apps/api/src/hooks/hooks.controller.ts
@@ -28,7 +28,7 @@ import {
   renderRow,
   skipSchema,
   startRunSchema,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { DatabaseSinkService } from './database-sink.service';

--- a/apps/api/src/hooks/hooks.types.ts
+++ b/apps/api/src/hooks/hooks.types.ts
@@ -9,7 +9,7 @@ import type {
   HookSource,
   HookTransformConfig,
   HookTrigger,
-} from '@data-bridge/core';
+} from '@syncle/core';
 
 /** a hook with its auth secret decrypted, server-internal use only */
 export interface ResolvedHook {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -46,7 +46,7 @@ async function bootstrap(): Promise<void> {
   // plain console.log so it always shows regardless of the nest log level
   const webPort = process.env.WEB_PORT ?? '3002';
   console.log(
-    `\n  Data Bridge · ready\n\n` +
+    `\n  Syncle · ready\n\n` +
       `    Web  http://localhost:${webPort}   ← open this\n` +
       `    API  http://localhost:${runtimeConfig.port}/api\n`,
   );

--- a/apps/api/src/settings/settings-store.service.ts
+++ b/apps/api/src/settings/settings-store.service.ts
@@ -9,7 +9,7 @@ import {
   appSettingsSchema,
   type AppSettings,
   type AppSettingsDTO,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { PrismaService } from '../common/prisma.service';
 import { runtimeConfig } from '../common/runtime-config';
 

--- a/apps/api/src/settings/settings.controller.ts
+++ b/apps/api/src/settings/settings.controller.ts
@@ -3,7 +3,7 @@ import {
   appSettingsSchema,
   type AppSettings,
   type AppSettingsDTO,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { SettingsStoreService } from './settings-store.service';
 

--- a/apps/api/src/workspaces/workspace-store.service.ts
+++ b/apps/api/src/workspaces/workspace-store.service.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_WORKSPACE_ID,
   BadRequestError,
   NotFoundError,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { PrismaService } from '../common/prisma.service';
 
 @Injectable()

--- a/apps/api/src/workspaces/workspaces.controller.ts
+++ b/apps/api/src/workspaces/workspaces.controller.ts
@@ -11,7 +11,7 @@ import {
   type Workspace,
   type WorkspaceInputDTO,
   workspaceInputSchema,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { HookStoreService } from '../hooks/hook-store.service';
 import { HookWatchService } from '../hooks/hook-watch.service';

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,9 +1,9 @@
 # ─────────────────────────────────────────────────────────────
-#  Data Bridge Web configuration
+#  Syncle Web configuration
 #  Copy to ".env.local" (the run scripts do this automatically).
 # ─────────────────────────────────────────────────────────────
 
-# Base URL of the Data Bridge API. Must match PORT in apps/api/.env.
+# Base URL of the Syncle API. Must match PORT in apps/api/.env.
 NEXT_PUBLIC_API_URL=http://localhost:4002/api
 
 # Port the web app runs on.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -7,8 +7,8 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const nextConfig = {
   reactStrictMode: true,
   // The web app is a pure frontend; all data access goes through the NestJS
-  // API. `@data-bridge/core` is consumed for shared types and Zod schemas only.
-  transpilePackages: ['@data-bridge/core'],
+  // API. `@syncle/core` is consumed for shared types and Zod schemas only.
+  transpilePackages: ['@syncle/core'],
   // Pin the monorepo root so Next doesn't pick up a stray lockfile elsewhere.
   outputFileTracingRoot: root,
   // Hide the floating Next.js dev indicator badge.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@data-bridge/web",
+  "name": "@syncle/web",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -23,7 +23,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@data-bridge/core": "workspace:*",
+    "@syncle/core": "workspace:*",
     "@tanstack/react-query": "^5.59.16",
     "@tanstack/react-table": "^8.20.5",
     "@xyflow/react": "^12.3.5",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'Data Bridge — Sync any databases, live',
+  title: 'Syncle — Sync any databases, live',
   description:
     'Keep any databases in sync across engines — PostgreSQL, MySQL, SQLite, MongoDB, Redis — in real time with CDC, polling, or one-shot replay. HTTP endpoints supported too.',
 };

--- a/apps/web/src/components/auth/login-screen.tsx
+++ b/apps/web/src/components/auth/login-screen.tsx
@@ -47,7 +47,7 @@ export function LoginScreen() {
         <CardHeader className="items-center text-center">
           <Image
             src="/logo-dark.png"
-            alt="Data Bridge"
+            alt="Syncle"
             width={747}
             height={412}
             priority
@@ -55,7 +55,7 @@ export function LoginScreen() {
           />
           <Image
             src="/logo-white.png"
-            alt="Data Bridge"
+            alt="Syncle"
             width={747}
             height={412}
             priority
@@ -63,7 +63,7 @@ export function LoginScreen() {
           />
           <CardTitle>Sign in</CardTitle>
           <CardDescription>
-            Enter your credentials to access Data Bridge.
+            Enter your credentials to access Syncle.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/web/src/components/auth/setup-screen.tsx
+++ b/apps/web/src/components/auth/setup-screen.tsx
@@ -56,7 +56,7 @@ export function SetupScreen() {
         <CardHeader className="items-center text-center">
           <Image
             src="/logo-dark.png"
-            alt="Data Bridge"
+            alt="Syncle"
             width={747}
             height={412}
             priority
@@ -64,7 +64,7 @@ export function SetupScreen() {
           />
           <Image
             src="/logo-white.png"
-            alt="Data Bridge"
+            alt="Syncle"
             width={747}
             height={412}
             priority
@@ -73,7 +73,7 @@ export function SetupScreen() {
           <CardTitle>Create the admin account</CardTitle>
           <CardDescription>
             This is the first run. The account you create here is the single
-            operator that protects every Data Bridge endpoint.
+            operator that protects every Syncle endpoint.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/web/src/components/automations/automations-view.tsx
+++ b/apps/web/src/components/automations/automations-view.tsx
@@ -12,7 +12,7 @@ import {
   useStartWatch,
   useStopWatch,
 } from '@/lib/queries';
-import { destinationLabel, type EndpointInfo } from '@data-bridge/core';
+import { destinationLabel, type EndpointInfo } from '@syncle/core';
 import { useStudio } from '@/lib/store';
 import { cn } from '@/lib/utils';
 import { useConfirm } from '@/components/confirm';

--- a/apps/web/src/components/automations/delivery-log.tsx
+++ b/apps/web/src/components/automations/delivery-log.tsx
@@ -15,7 +15,7 @@ import type {
   DeliveryStatus,
   EndpointInfo,
   HookDelivery,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { ApiError } from '@/lib/api';
 import { useHookDeliveries, useSkipDeliveries } from '@/lib/queries';
 import { cn } from '@/lib/utils';

--- a/apps/web/src/components/automations/hook-builder.tsx
+++ b/apps/web/src/components/automations/hook-builder.tsx
@@ -21,7 +21,7 @@ import {
   type HookInputDTO,
   type SortSpec,
   type TableSchema,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import {
   useBrowse,
@@ -173,7 +173,7 @@ export function HookBuilder() {
   const [cdcOps, setCdcOps] = useState<Set<'insert' | 'update' | 'delete'>>(
     new Set(['insert', 'update', 'delete']),
   );
-  const [readiness, setReadiness] = useState<import('@data-bridge/core').CdcReadiness | null>(null);
+  const [readiness, setReadiness] = useState<import('@syncle/core').CdcReadiness | null>(null);
   const [checkingCdc, setCheckingCdc] = useState(false);
 
   // ----- payload / destination / delivery -----
@@ -300,7 +300,7 @@ export function HookBuilder() {
     setEnabled(true);
   }
 
-  function loadHook(h: import('@data-bridge/core').Hook) {
+  function loadHook(h: import('@syncle/core').Hook) {
     setName(h.name);
     setConnectionId(h.source.connectionId);
     setDatabase(h.source.database ?? '');

--- a/apps/web/src/components/automations/hook-list.tsx
+++ b/apps/web/src/components/automations/hook-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Plus, Radio, Zap, Network, Workflow, AlertTriangle } from 'lucide-react';
-import { destinationLabel, type Hook } from '@data-bridge/core';
+import { destinationLabel, type Hook } from '@syncle/core';
 import { useHooks, useHookStatuses } from '@/lib/queries';
 import { useStudio } from '@/lib/store';
 import { cn } from '@/lib/utils';

--- a/apps/web/src/components/automations/run-detail.tsx
+++ b/apps/web/src/components/automations/run-detail.tsx
@@ -2,7 +2,7 @@
 
 import { Ban, Loader2, Play, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
-import type { EndpointInfo, HookRun, HookRunStatus } from '@data-bridge/core';
+import type { EndpointInfo, HookRun, HookRunStatus } from '@syncle/core';
 import { ApiError } from '@/lib/api';
 import {
   useCancelHookRun,

--- a/apps/web/src/components/automations/workspace-map.tsx
+++ b/apps/web/src/components/automations/workspace-map.tsx
@@ -13,7 +13,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { Database, Globe, Loader2, Radio, Zap, Plus, Network } from 'lucide-react';
-import type { ConnectionConfig, Hook } from '@data-bridge/core';
+import type { ConnectionConfig, Hook } from '@syncle/core';
 import { useConnections, useHooks, useHookStatuses } from '@/lib/queries';
 import { useStudio } from '@/lib/store';
 import { cn } from '@/lib/utils';

--- a/apps/web/src/components/connections/connection-dialog.tsx
+++ b/apps/web/src/components/connections/connection-dialog.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Loader2, PlugZap } from 'lucide-react';
 import { toast } from 'sonner';
-import type { ConnectionInputDTO, DatabaseEngine } from '@data-bridge/core';
+import type { ConnectionInputDTO, DatabaseEngine } from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import {
   useCreateConnection,

--- a/apps/web/src/components/data/data-grid.tsx
+++ b/apps/web/src/components/data/data-grid.tsx
@@ -20,7 +20,7 @@ import type {
   FilterOperator,
   FilterSpec,
   SortSpec,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import { exportRows } from '@/lib/export';
 import { useBrowse, useConnections, useDrivers } from '@/lib/queries';

--- a/apps/web/src/components/data/row-editor-dialog.tsx
+++ b/apps/web/src/components/data/row-editor-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import type { QueryColumn } from '@data-bridge/core';
+import type { QueryColumn } from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import {
   Dialog,

--- a/apps/web/src/components/diagram/er-diagram.tsx
+++ b/apps/web/src/components/diagram/er-diagram.tsx
@@ -13,7 +13,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { KeyRound, Link2 } from 'lucide-react';
-import type { DatabaseSchema, TableSchema } from '@data-bridge/core';
+import type { DatabaseSchema, TableSchema } from '@syncle/core';
 import { useSchema } from '@/lib/queries';
 import { useStudio } from '@/lib/store';
 

--- a/apps/web/src/components/query/query-editor.tsx
+++ b/apps/web/src/components/query/query-editor.tsx
@@ -6,7 +6,7 @@ import { useTheme } from 'next-themes';
 import { Loader2, Play, Plus, Sparkles, X } from 'lucide-react';
 import { format } from 'sql-formatter';
 import { toast } from 'sonner';
-import type { QueryLanguage, QueryResult } from '@data-bridge/core';
+import type { QueryLanguage, QueryResult } from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import { useConnections, useDrivers, useSchema } from '@/lib/queries';
 import { useStudio } from '@/lib/store';

--- a/apps/web/src/components/query/result-table.tsx
+++ b/apps/web/src/components/query/result-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Download } from 'lucide-react';
-import type { QueryResult } from '@data-bridge/core';
+import type { QueryResult } from '@syncle/core';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {

--- a/apps/web/src/components/schema/create-table-dialog.tsx
+++ b/apps/web/src/components/schema/create-table-dialog.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Loader2, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
-import type { ColumnDefinition, DatabaseEngine } from '@data-bridge/core';
+import type { ColumnDefinition, DatabaseEngine } from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import {
   Dialog,

--- a/apps/web/src/components/schema/schema-tree.tsx
+++ b/apps/web/src/components/schema/schema-tree.tsx
@@ -23,7 +23,7 @@ import {
   Webhook,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import type { BackupFormat, RelationKind, TableSchema } from '@data-bridge/core';
+import type { BackupFormat, RelationKind, TableSchema } from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import { downloadText } from '@/lib/export';
 import {

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -7,7 +7,7 @@ import type {
   AppSettings,
   AppSettingsDTO,
   AuthUser,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { ApiError } from '@/lib/api';
 import {
   useAuthStatus,
@@ -32,7 +32,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 type CdcOp = 'insert' | 'update' | 'delete';
 const CDC_OPS: CdcOp[] = ['insert', 'update', 'delete'];
 
-/** ranges mirror appSettingsSchema in @data-bridge/core */
+/** ranges mirror appSettingsSchema in @syncle/core */
 const RANGES = {
   defaultPollIntervalMs: { min: 1000, max: 3_600_000 },
   defaultMaxPerPoll: { min: 1, max: 5000 },

--- a/apps/web/src/components/studio.tsx
+++ b/apps/web/src/components/studio.tsx
@@ -72,7 +72,7 @@ export function Studio() {
                 {/* dark artwork in light mode, white artwork in dark mode */}
                 <Image
                   src="/logo-dark.png"
-                  alt="Data Bridge"
+                  alt="Syncle"
                   width={747}
                   height={412}
                   priority
@@ -80,7 +80,7 @@ export function Studio() {
                 />
                 <Image
                   src="/logo-white.png"
-                  alt="Data Bridge"
+                  alt="Syncle"
                   width={747}
                   height={412}
                   priority

--- a/apps/web/src/components/workspace/workspace-switcher.tsx
+++ b/apps/web/src/components/workspace/workspace-switcher.tsx
@@ -10,7 +10,7 @@ import {
   useDeleteWorkspace,
 } from '@/lib/queries';
 import { readPersistedWorkspaceId, useStudio } from '@/lib/store';
-import { DEFAULT_WORKSPACE_ID } from '@data-bridge/core';
+import { DEFAULT_WORKSPACE_ID } from '@syncle/core';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,5 @@
 /**
- * typed client for the Data Bridge NestJS API. unwraps the `{ data }` envelope,
+ * typed client for the Syncle NestJS API. unwraps the `{ data }` envelope,
  * throws a structured {@link ApiError} on `{ error }` responses
  */
 import type {
@@ -31,7 +31,7 @@ import type {
   UpdateRowParams,
   Workspace,
   WorkspaceInputDTO,
-} from '@data-bridge/core';
+} from '@syncle/core';
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000/api';
@@ -63,7 +63,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     });
   } catch (err) {
     throw new ApiError(
-      `Cannot reach the Data Bridge API at ${BASE_URL}. Is it running?`,
+      `Cannot reach the Syncle API at ${BASE_URL}. Is it running?`,
       'NETWORK',
       0,
       (err as Error).message,

--- a/apps/web/src/lib/engines.ts
+++ b/apps/web/src/lib/engines.ts
@@ -1,4 +1,4 @@
-import type { DatabaseEngine } from '@data-bridge/core';
+import type { DatabaseEngine } from '@syncle/core';
 
 interface EngineMeta {
   label: string;

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -17,7 +17,7 @@ import type {
   LoginDTO,
   SetupDTO,
   WorkspaceInputDTO,
-} from '@data-bridge/core';
+} from '@syncle/core';
 import { api } from './api';
 import { useStudio } from './store';
 

--- a/apps/web/src/lib/sql.ts
+++ b/apps/web/src/lib/sql.ts
@@ -1,4 +1,4 @@
-import type { DatabaseEngine } from '@data-bridge/core';
+import type { DatabaseEngine } from '@syncle/core';
 
 /** quote an identifier for the given engine's dialect */
 export function quoteIdent(engine: DatabaseEngine, id: string): string {

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
-import type { RelationKind } from '@data-bridge/core';
+import type { RelationKind } from '@syncle/core';
 
 export type StudioTab = 'data' | 'query' | 'structure' | 'diagram';
 
@@ -91,7 +91,7 @@ interface StudioState {
 const initial = freshTabs();
 
 /** localStorage key for the last active workspace (survives refreshes) */
-const WORKSPACE_STORAGE_KEY = 'data-bridge.activeWorkspaceId';
+const WORKSPACE_STORAGE_KEY = 'syncle.activeWorkspaceId';
 
 export function readPersistedWorkspaceId(): string | null {
   if (typeof window === 'undefined') return null;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-# Local infrastructure for Data Bridge.
+# Local infrastructure for Syncle.
 #
 #   docker compose up -d           # start postgres + redis
 #
-# - postgres backs Data Bridge's OWN metadata store (saved connections, hooks, runs,
+# - postgres backs Syncle's OWN metadata store (saved connections, hooks, runs,
 #   deliveries) via Prisma — see apps/api/.env DATABASE_URL.
 # - redis backs the BullMQ queue that executes hook runs durably (jobs survive an
 #   API restart and auto-resume). The database studio, hook CRUD and payload
@@ -10,32 +10,32 @@
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: data-bridge-postgres
+    container_name: syncle-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: Admin_Osman
-      POSTGRES_DB: databridge
+      POSTGRES_DB: syncle
     ports:
       # Host 5433 avoids clashing with any local/other Postgres on 5432.
       - '5433:5432'
     volumes:
-      - data-bridge-postgres-data:/var/lib/postgresql/data
+      - syncle-postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres -d databridge']
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d syncle']
       interval: 5s
       timeout: 3s
       retries: 5
 
   redis:
     image: redis:7-alpine
-    container_name: data-bridge-redis
+    container_name: syncle-redis
     restart: unless-stopped
     ports:
       - '6379:6379'
     command: ['redis-server', '--save', '60', '1', '--appendonly', 'yes']
     volumes:
-      - data-bridge-redis-data:/data
+      - syncle-redis-data:/data
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -43,5 +43,5 @@ services:
       retries: 5
 
 volumes:
-  data-bridge-postgres-data:
-  data-bridge-redis-data:
+  syncle-postgres-data:
+  syncle-redis-data:

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "data-bridge",
+  "name": "syncle",
   "version": "0.1.0",
   "private": true,
-  "description": "Data Bridge — keep any databases in sync, live and across engines (PostgreSQL, MySQL, SQLite, MongoDB, Redis), with HTTP endpoints as an extra destination.",
+  "description": "Syncle — keep any databases in sync, live and across engines (PostgreSQL, MySQL, SQLite, MongoDB, Redis), with HTTP endpoints as an extra destination.",
   "author": "Osman Ahmadzai",
   "license": "MIT",
-  "homepage": "https://github.com/ozmanghani/data-bridge#readme",
+  "homepage": "https://github.com/ozmanghani/syncle#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ozmanghani/data-bridge.git"
+    "url": "git+https://github.com/ozmanghani/syncle.git"
   },
   "bugs": {
-    "url": "https://github.com/ozmanghani/data-bridge/issues"
+    "url": "https://github.com/ozmanghani/syncle/issues"
   },
   "engines": {
     "node": ">=22"
@@ -27,15 +27,15 @@
     ]
   },
   "scripts": {
-    "dev": "node scripts/setup-env.mjs && pnpm --filter @data-bridge/core build && concurrently -n api,web -c magenta,cyan \"pnpm --filter @data-bridge/api dev\" \"pnpm --filter @data-bridge/web dev\"",
-    "dev:api": "pnpm --filter @data-bridge/api dev",
-    "dev:web": "pnpm --filter @data-bridge/web dev",
-    "start": "node scripts/setup-env.mjs && pnpm build && concurrently -n api,web -c magenta,cyan \"pnpm --filter @data-bridge/api start\" \"pnpm --filter @data-bridge/web start\"",
-    "build": "pnpm --filter @data-bridge/core build && pnpm --filter @data-bridge/api build && pnpm --filter @data-bridge/web build",
-    "build:core": "pnpm --filter @data-bridge/core build",
-    "migrate": "pnpm --filter @data-bridge/api migrate:deploy",
-    "migrate:dev": "pnpm --filter @data-bridge/api migrate:dev",
-    "db:studio": "pnpm --filter @data-bridge/api exec prisma studio",
+    "dev": "node scripts/setup-env.mjs && pnpm --filter @syncle/core build && concurrently -n api,web -c magenta,cyan \"pnpm --filter @syncle/api dev\" \"pnpm --filter @syncle/web dev\"",
+    "dev:api": "pnpm --filter @syncle/api dev",
+    "dev:web": "pnpm --filter @syncle/web dev",
+    "start": "node scripts/setup-env.mjs && pnpm build && concurrently -n api,web -c magenta,cyan \"pnpm --filter @syncle/api start\" \"pnpm --filter @syncle/web start\"",
+    "build": "pnpm --filter @syncle/core build && pnpm --filter @syncle/api build && pnpm --filter @syncle/web build",
+    "build:core": "pnpm --filter @syncle/core build",
+    "migrate": "pnpm --filter @syncle/api migrate:deploy",
+    "migrate:dev": "pnpm --filter @syncle/api migrate:dev",
+    "db:studio": "pnpm --filter @syncle/api exec prisma studio",
     "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@data-bridge/core",
+  "name": "@syncle/core",
   "version": "0.1.0",
   "private": true,
   "description": "Framework-agnostic database domain: adapters, types, validation.",

--- a/packages/core/src/adapters/nosql/mongodb-adapter.ts
+++ b/packages/core/src/adapters/nosql/mongodb-adapter.ts
@@ -362,7 +362,7 @@ export class MongodbAdapter implements DatabaseAdapter {
     }
 
     const doc: BackupDocument = {
-      dataBridge: 'backup',
+      syncle: 'backup',
       version: 1,
       engine: this.engine,
       database: db.databaseName,
@@ -405,8 +405,8 @@ export class MongodbAdapter implements DatabaseAdapter {
     } catch {
       throw new BadRequestError('Backup file is not valid JSON');
     }
-    if (doc.dataBridge !== 'backup' || !Array.isArray(doc.tables)) {
-      throw new BadRequestError('Not a Data Bridge backup file');
+    if (doc.syncle !== 'backup' || !Array.isArray(doc.tables)) {
+      throw new BadRequestError('Not a Syncle backup file');
     }
     const db = await this.getDb();
     let rows = 0;

--- a/packages/core/src/adapters/nosql/redis-adapter.ts
+++ b/packages/core/src/adapters/nosql/redis-adapter.ts
@@ -373,7 +373,7 @@ export class RedisAdapter implements DatabaseAdapter {
       );
     }
     const doc: BackupDocument = {
-      dataBridge: 'backup',
+      syncle: 'backup',
       version: 1,
       engine: this.engine,
       database: `db${this.config.options?.db ?? this.config.database ?? 0}`,
@@ -400,8 +400,8 @@ export class RedisAdapter implements DatabaseAdapter {
     } catch {
       throw new BadRequestError('Backup file is not valid JSON');
     }
-    if (doc.dataBridge !== 'backup' || !Array.isArray(doc.tables)) {
-      throw new BadRequestError('Not a Data Bridge backup file');
+    if (doc.syncle !== 'backup' || !Array.isArray(doc.tables)) {
+      throw new BadRequestError('Not a Syncle backup file');
     }
     const client = this.getClient();
     if (client.status !== 'ready') await client.connect().catch(() => {});

--- a/packages/core/src/adapters/sql/base-sql-adapter.ts
+++ b/packages/core/src/adapters/sql/base-sql-adapter.ts
@@ -644,7 +644,7 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
 
     if (opts.format === 'json') {
       const doc: BackupDocument = {
-        dataBridge: 'backup',
+        syncle: 'backup',
         version: 1,
         engine: this.engine,
         database,
@@ -669,7 +669,7 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
 
     // SQL dump: DDL + INSERT statements
     const out: string[] = [
-      `-- Data Bridge SQL backup`,
+      `-- Syncle SQL backup`,
       `-- engine: ${this.engine}`,
       `-- database: ${database}`,
       ``,
@@ -750,8 +750,8 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
     } catch {
       throw new BadRequestError('Backup file is not valid JSON');
     }
-    if (doc.dataBridge !== 'backup' || !Array.isArray(doc.tables)) {
-      throw new BadRequestError('Not a Data Bridge backup file');
+    if (doc.syncle !== 'backup' || !Array.isArray(doc.tables)) {
+      throw new BadRequestError('Not a Syncle backup file');
     }
 
     let rows = 0;
@@ -890,7 +890,7 @@ function normalizeForInsert(value: unknown): unknown {
 /**
  * split a `.sql` script into individual statements, respecting single-quoted
  * strings (with `''` escapes) and `--` / block comments. good enough for
- * Data Bridge-generated dumps and typical hand-written scripts
+ * Syncle-generated dumps and typical hand-written scripts
  */
 function splitSqlStatements(sql: string): string[] {
   const out: string[] = [];

--- a/packages/core/src/adapters/sql/sqlite-adapter.test.ts
+++ b/packages/core/src/adapters/sql/sqlite-adapter.test.ts
@@ -24,7 +24,7 @@ describe('SqliteAdapter', () => {
   let file: string;
 
   beforeEach(async () => {
-    file = join(tmpdir(), `data-bridge-test-${Date.now()}-${Math.random()}.db`);
+    file = join(tmpdir(), `syncle-test-${Date.now()}-${Math.random()}.db`);
     adapter = new SqliteAdapter(makeConfig(file));
     await adapter.connect();
     await adapter.query(

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -1,7 +1,7 @@
 /**
  * core adapter contract.
  *
- * every database engine Data Bridge supports (relational, document, key-value,
+ * every database engine Syncle supports (relational, document, key-value,
  * or anything added later) implements {@link DatabaseAdapter}. the rest of the
  * app (API routes, UI) depends ONLY on these types, never on a concrete driver.
  * so adding a new engine means: implement this interface and register it, that's it.
@@ -309,7 +309,7 @@ export interface BackupOptions {
 
 /** the portable JSON backup shape (also embedded inside `json` dumps) */
 export interface BackupDocument {
-  dataBridge: 'backup';
+  syncle: 'backup';
   version: 1;
   engine: DatabaseEngine;
   database: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * web-safe entry point: types, error classes, and validation schemas only.
  * importing this never pulls in a native database driver, so it's safe for the
  * browser bundle. server code that needs to open connections imports from
- * `@data-bridge/core/adapters` instead.
+ * `@syncle/core/adapters` instead.
  */
 export * from './adapters/types';
 export * from './errors';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
 
   apps/api:
     dependencies:
-      '@data-bridge/core':
+      '@syncle/core':
         specifier: workspace:*
         version: link:../../packages/core
       '@nestjs/bullmq':
@@ -96,7 +96,7 @@ importers:
 
   apps/web:
     dependencies:
-      '@data-bridge/core':
+      '@syncle/core':
         specifier: workspace:*
         version: link:../../packages/core
       '@monaco-editor/react':


### PR DESCRIPTION
Rename every occurrence of the project name across code, config, and docs: display strings, @syncle/* package names, SYNCLE_* env vars, the .syncle data dir, the backup-document marker field, the Postgres database name, and replication slot/publication names.

<!-- Thanks for the contribution! Keep PRs focused on one change. -->

## Summary

<!-- What does this PR do, and why? -->

## Changes

<!-- Bullet the notable changes. -->

-

## Testing

<!-- How did you verify this? Commands, manual steps, screenshots. -->

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes

## Notes for reviewers

<!-- Anything tricky, follow-ups, or decisions you want a second opinion on. -->
