### PR TITLE
Repair the fresh-clone quickstart and clean up dev tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Syncle is a pnpm monorepo (`web → api → core`). You'll need:
 
 ```bash
 git clone https://github.com/osmanahmadxai/SYNCLE.git
-cd syncle
+cd SYNCLE
 pnpm install
 docker compose up -d          # postgres (metadata) + redis (queue)
 pnpm dev                      # API + web in watch mode
@@ -45,6 +45,9 @@ pnpm build         # core → api → web
 
 If you change `packages/core`, rebuild it (`pnpm build:core`) before the API
 will pick up the new types — `core` is consumed from its compiled `dist/`.
+
+Testing an HTTP destination by hand? `pnpm dev:receiver` starts a tiny echo
+server on `http://localhost:4990` that logs every request it receives.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -374,9 +374,14 @@ React Flow · Zod · Vitest.
 - All user values are passed as bound parameters; identifiers are dialect-quoted.
 - Hook payloads are built by structured token substitution — no string injection,
   no code execution.
-- Syncle runs locally with no auth layer. Add authentication, and restrict
-  which destinations (database connections / endpoint URLs) a bridge may write
-  to, before exposing it to an untrusted network.
+- Every API route sits behind a single-operator auth layer: the first run
+  creates the admin account, after which a scrypt-hashed password and an
+  httpOnly session cookie guard the app. Changing the password invalidates
+  existing sessions.
+- Syncle is still designed for local / trusted-network use. Before exposing it
+  further, complete first-run setup before the port is reachable, put it behind
+  TLS, and restrict which destinations (database connections / endpoint URLs)
+  a bridge may write to.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ Env files are created automatically on first run from the committed
 | `WEB_ORIGIN`                  | api   | CORS origin (defaults to any in dev)         |
 
 If `SYNCLE_MASTER_KEY` is unset, a random key is generated under
-`apps/api/.syncle/` on first run — set it explicitly in production.
+`apps/api/.syncle/` on first run — set it explicitly in production
+(generate one with `openssl rand -base64 32`).
 
 ## CDC prerequisites
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -14,9 +14,10 @@ PORT=4002
 # ── Metadata store ───────────────────────────────────────────
 # Syncle's OWN PostgreSQL database (saved connections, hooks, runs) — NOT a
 # database you connect to. Start one with `docker compose up -d postgres` from
-# the repo root; the credentials below match docker-compose.yml. Point this at
-# any Postgres (managed, RDS, etc.) by changing the URL.
-DATABASE_URL="postgresql://username:password@localhost:5432/db-name?schema=public"
+# the repo root; the credentials below match docker-compose.yml (host port 5433
+# so it never clashes with a local Postgres on 5432). Point this at any
+# Postgres (managed, RDS, etc.) by changing the URL.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5433/syncle?schema=public"
 
 # ── Security ─────────────────────────────────────────────────
 # Base64 32-byte key. Encrypts stored connection credentials (AES-256-GCM) AND

--- a/apps/api/src/hooks/hook-store.service.ts
+++ b/apps/api/src/hooks/hook-store.service.ts
@@ -1,5 +1,5 @@
 /**
- * persistent store for automation hooks (Prisma / SQLite). nested config is kept
+ * persistent store for automation hooks (Prisma / PostgreSQL). nested config is kept
  * as JSON strings; the destination's auth secret is the only sensitive field and
  * is encrypted at rest in `auth_enc`, same as how `ConnectionStoreService`
  * handles passwords. callers get a redacted view unless they explicitly resolve.

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -54,8 +54,15 @@ services:
       WEB_ORIGIN: http://localhost:3002
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/syncle?schema=public
       REDIS_URL: redis://redis:6379
-      # Persist the generated master key + local state in a named volume so
-      # stored credentials and sessions survive restarts.
+      # ⚠ SET THIS. Encrypts stored connection credentials and signs session
+      # cookies. Generate one with `openssl rand -base64 32` and export it
+      # before `docker compose up`. Left empty, the API auto-generates a key
+      # inside the data volume — i.e. stored right next to the data it
+      # protects, and lost with it if the volume is removed.
+      SYNCLE_MASTER_KEY: ${SYNCLE_MASTER_KEY:-}
+      # Persist local state (and the auto-generated key, if you skipped setting
+      # one) in a named volume so stored credentials and sessions survive
+      # restarts.
       SYNCLE_DATA_DIR: /app/apps/api/.syncle
     volumes:
       - syncle-api-data:/app/apps/api/.syncle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,12 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: Admin_Osman
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: syncle
     ports:
       # Host 5433 avoids clashing with any local/other Postgres on 5432.
-      - '5433:5432'
+      # Bound to loopback so the metadata store is never exposed on the LAN.
+      - '127.0.0.1:5433:5432'
     volumes:
       - syncle-postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -32,7 +33,8 @@ services:
     container_name: syncle-redis
     restart: unless-stopped
     ports:
-      - '6379:6379'
+      # Loopback-only, same reasoning as postgres above.
+      - '127.0.0.1:6379:6379'
     command: ['redis-server', '--save', '60', '1', '--appendonly', 'yes']
     volumes:
       - syncle-redis-data:/data

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dev": "node scripts/setup-env.mjs && pnpm --filter @syncle/core build && concurrently -n api,web -c magenta,cyan \"pnpm --filter @syncle/api dev\" \"pnpm --filter @syncle/web dev\"",
     "dev:api": "pnpm --filter @syncle/api dev",
     "dev:web": "pnpm --filter @syncle/web dev",
+    "dev:receiver": "node scripts/dev-receiver.js",
     "start": "node scripts/setup-env.mjs && pnpm build && concurrently -n api,web -c magenta,cyan \"pnpm --filter @syncle/api start\" \"pnpm --filter @syncle/web start\"",
     "build": "pnpm --filter @syncle/core build && pnpm --filter @syncle/api build && pnpm --filter @syncle/web build",
     "build:core": "pnpm --filter @syncle/core build",

--- a/scripts/dev-receiver.js
+++ b/scripts/dev-receiver.js
@@ -1,6 +1,6 @@
 const http = require('http');
 
-const PORT = 4000;
+const PORT = 4990;
 
 const server = http.createServer((req, res) => {
   let body = '';

--- a/scripts/setup-env.mjs
+++ b/scripts/setup-env.mjs
@@ -1,6 +1,6 @@
 // makes sure local env files exist by copying from the committed examples.
-// idempotent, never overwrites files that already exist. runs automatically on
-// `pnpm install` (root postinstall) and before `pnpm dev` / `pnpm start`
+// idempotent, never overwrites files that already exist. runs automatically
+// before `pnpm dev` / `pnpm start` (it is NOT wired to `pnpm install`)
 import { copyFileSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
Fixes the broken first-run experience and several dev-tooling loose ends:

- **`.env.example` now actually matches `docker-compose.yml`** — fresh clones connect to the bundled Postgres on the first `pnpm dev` instead of failing at `prisma migrate` (generic `postgres/postgres` credentials, host port 5433, db `syncle`).
- Dev compose binds Postgres/Redis to **loopback only** and drops the personal password.
- `docker-compose.app.yml` surfaces **`SYNCLE_MASTER_KEY`** with generation guidance instead of silently auto-generating a key stored next to the data it protects.
- CONTRIBUTING quickstart uses `cd SYNCLE` (the lowercase form fails on case-sensitive filesystems) and documents the HTTP echo receiver.
- `receiver.js` moves to `scripts/dev-receiver.js` on port 4990 with a `pnpm dev:receiver` script.
- `setup-env.mjs` header no longer claims a postinstall hook that doesn't exist; `hook-store` header says PostgreSQL, not SQLite.
- README's Security section describes the real single-operator auth layer instead of claiming there is none.