### PR TITLE
Coherent release story: 1.0.0 everywhere, tag-based installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,45 @@
 
 All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project aims
-to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it
-reaches 1.0.
+to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-20
+
+First stable release: visual bridges between any supported engines
+(PostgreSQL, MySQL/MariaDB, SQLite, MongoDB, Redis) and HTTP endpoints, fired
+by one-shot replay, cursor polling, or change-data-capture — with idempotent
+multi-target delivery, a live timeline, and the database workbench.
+
 ### Added
 
+- Database-to-database bridges: sync data across engines directly, with HTTP
+  endpoints as an extra destination rather than the only one.
+- Workspaces, with hooks reframed as bridges and a live workspace map.
 - Event-based (CDC) delivery for **MySQL** (binlog), **MongoDB** (change
   streams), and **Redis** (keyspace notifications), alongside the existing
   PostgreSQL logical-replication support. Each engine sits behind a shared
   `CdcProvider` interface.
+- A login system and a settings section.
+- One-command Docker install (`install.sh`) and the `syncle` launcher CLI.
+- Chinese (zh) localization for the web app.
 - The `{{$op}}` payload token, exposing the change operation
   (`insert` / `update` / `delete`) for CDC and watch hooks.
+- README visuals: animated banner, badges, diagrams, and a how-to guide.
 
 ### Changed
 
-- Renamed the project to **Syncle**.
+- Renamed the project to **Syncle** (formerly Data Bridge).
 - The internal metadata store now runs on **PostgreSQL** instead of SQLite.
 - The live delivery monitor fetches one final time when a run finishes, so the
   last cells settle correctly; added a LIVE indicator and auto-follow paging.
 
 ### Fixed
 
+- Crash, data-loss, and injection paths across the API layer, bridge engine,
+  and core adapters; multi-target bridge writes are atomic and backup memory
+  is bounded.
+- Stale-state bugs in the studio, which now updates instantly.
 - Delivery timeline now uses the run's snapshot `batchSize`, keeping cells
   aligned even after a hook is edited mid-run.

--- a/bin/syncle
+++ b/bin/syncle
@@ -64,7 +64,19 @@ case "$cmd" in
   logs)    shift || true; compose logs -f "$@" ;;
   open)    open_url "$WEB_URL" ;;
   update)
-    git -C "$APP_DIR" pull --ff-only
+    git -C "$APP_DIR" fetch --tags --quiet origin
+    if [ "${SYNCLE_CHANNEL:-release}" = "main" ]; then
+      git -C "$APP_DIR" checkout --quiet main
+      git -C "$APP_DIR" pull --ff-only
+    else
+      tag=$(git -C "$APP_DIR" tag --list 'v*' --sort=-v:refname | head -n 1)
+      if [ -n "$tag" ]; then
+        git -C "$APP_DIR" checkout --quiet "$tag"
+      else
+        git -C "$APP_DIR" checkout --quiet main
+        git -C "$APP_DIR" pull --ff-only
+      fi
+    fi
     compose up -d --build
     printf 'Updated. %s\n' "$WEB_URL"
     ;;
@@ -85,8 +97,10 @@ case "$cmd" in
     esac
     ;;
   version|-v|--version)
-    v=$(node -p "require('$APP_DIR/package.json').version" 2>/dev/null || echo unknown)
-    printf 'Syncle %s\n' "$v"
+    # Parsed with sed so `syncle version` works on hosts without Node (the
+    # docker-only install is the normal case).
+    v=$(sed -n 's/^  "version": "\(.*\)",$/\1/p' "$APP_DIR/package.json" 2>/dev/null)
+    printf 'Syncle %s\n' "${v:-unknown}"
     ;;
   help|-h|--help) usage ;;
   *) usage; exit 1 ;;

--- a/install.sh
+++ b/install.sh
@@ -22,14 +22,30 @@ command -v git >/dev/null 2>&1 || die "git is required. Install it and re-run."
 command -v docker >/dev/null 2>&1 || die "Docker is required. Get it at https://docs.docker.com/get-docker/"
 docker compose version >/dev/null 2>&1 || die "Docker Compose v2 is required (bundled with Docker Desktop or the compose plugin)."
 
-# 1) Fetch or update the app.
+# 1) Fetch or update the app. Installs track the latest release tag; set
+#    SYNCLE_CHANNEL=main to ride the development branch instead.
+CHANNEL="${SYNCLE_CHANNEL:-release}"
 if [ -d "$APP_DIR/.git" ]; then
   info "Updating Syncle in $APP_DIR"
-  git -C "$APP_DIR" pull --ff-only
+  git -C "$APP_DIR" fetch --tags --quiet origin
 else
   info "Cloning Syncle into $APP_DIR"
   mkdir -p "$SYNCLE_HOME"
-  git clone --depth 1 "$REPO" "$APP_DIR"
+  git clone "$REPO" "$APP_DIR"
+fi
+if [ "$CHANNEL" = "main" ]; then
+  git -C "$APP_DIR" checkout --quiet main
+  git -C "$APP_DIR" pull --ff-only
+else
+  TAG=$(git -C "$APP_DIR" tag --list 'v*' --sort=-v:refname | head -n 1)
+  if [ -n "$TAG" ]; then
+    info "Using release $TAG (SYNCLE_CHANNEL=main for the development branch)"
+    git -C "$APP_DIR" checkout --quiet "$TAG"
+  else
+    info "No release tags found — using main"
+    git -C "$APP_DIR" checkout --quiet main
+    git -C "$APP_DIR" pull --ff-only
+  fi
 fi
 
 # 2) Install the `syncle` launcher onto PATH.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncle",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Syncle — keep any databases in sync, live and across engines (PostgreSQL, MySQL, SQLite, MongoDB, Redis), with HTTP endpoints as an extra destination.",
   "author": "Osman Ahmadzai",


### PR DESCRIPTION
The repo had three versions at once: git tag `v1.0.0`, `package.json` `0.1.0`, and a CHANGELOG with only *Unreleased* — while the installer tracked `main` HEAD as a rolling release.

- `package.json` version is now **1.0.0**, matching the tag, so `syncle version` reports the truth.
- CHANGELOG gains a real **[1.0.0]** section (written from the git history: the rename to Syncle, db-to-db bridges, workspaces, multi-engine CDC, auth and settings, the one-command installer, localization, README visuals, and the hardening fixes), with a fresh empty *Unreleased* above it.
- `install.sh` now checks out the **latest release tag** by default; `SYNCLE_CHANNEL=main` opts into the development branch. Same for `syncle update`.
- `syncle version` no longer requires Node on the host (the docker-only install is the normal case) — it parses the version with `sed`.
