### PR TITLE
Watch trigger correctness: ordering, livelock, lookback, filters, mid-page cancel

### DIFF
--- a/apps/api/src/hooks/hook-watch.service.ts
+++ b/apps/api/src/hooks/hook-watch.service.ts
@@ -32,8 +32,11 @@ import { sleep } from './delivery.service';
 import { HookSinkService } from './hook-sink.service';
 import { HookRunService } from './hook-run.service';
 import { HookStoreService } from './hook-store.service';
+import { RunRegistryService } from './run-registry.service';
 import type { ResolvedHook } from './hooks.types';
 import { HOOK_WATCH_QUEUE, type HookWatchJob } from './hooks.types';
+
+type TableSource = Extract<ResolvedHook['source'], { kind: 'table' }>;
 
 @Injectable()
 export class HookWatchService implements OnModuleInit {
@@ -48,6 +51,15 @@ export class HookWatchService implements OnModuleInit {
   private static readonly FAST_MS = 1000;
   /** stay fast for this many empty polls after activity before backing off */
   private static readonly COOLDOWN_POLLS = 4;
+  /**
+   * scan budget per poll cycle: how many pages one poll may fetch while digging
+   * through fully-deduped pages (rows sharing one boundary timestamp, or a
+   * snapshot table larger than a page). without this, a boundary denser than
+   * `maxPerPoll` would refetch the identical first page forever and livelock.
+   */
+  private static readonly SCAN_PAGES_PER_POLL = 50;
+  /** resolved primary key per hook (probed once per table identity) */
+  private readonly pkCache = new Map<string, { sig: string; pk: string[] }>();
 
   constructor(
     private readonly prisma: PrismaService,
@@ -55,6 +67,7 @@ export class HookWatchService implements OnModuleInit {
     private readonly pool: AdapterPoolService,
     private readonly sink: HookSinkService,
     private readonly runs: HookRunService,
+    private readonly registry: RunRegistryService,
     @InjectQueue(HOOK_WATCH_QUEUE) private readonly queue: Queue<HookWatchJob>,
   ) {}
 
@@ -124,7 +137,22 @@ export class HookWatchService implements OnModuleInit {
     if (hook.trigger.kind !== 'watch') return false;
     try {
       const cursor = JSON.parse(cursorJson) as WatchCursor;
-      return cursor.strategy === watchStrategySchema.parse(hook.trigger.strategy).strategy;
+      const strategy = watchStrategySchema.parse(hook.trigger.strategy);
+      if (cursor.strategy !== strategy.strategy) return false;
+      // a cursor value only means something against the column it was read
+      // from — editing the watch column must rebuild the cursor, not apply the
+      // stale value to the new column (which would silently skip rows). legacy
+      // cursors persisted without `column` are accepted and gain it on the
+      // next advance.
+      if (
+        cursor.strategy !== 'snapshot' &&
+        'column' in strategy &&
+        cursor.column != null &&
+        cursor.column !== strategy.column
+      ) {
+        return false;
+      }
+      return true;
     } catch {
       return false;
     }
@@ -137,6 +165,9 @@ export class HookWatchService implements OnModuleInit {
       orderBy: { startedAt: 'desc' },
     });
     if (!run) return null;
+    // abort any in-flight poll so Stop takes effect mid-page, not after the
+    // whole page has been delivered
+    this.registry.abort(run.id);
     await this.runs.finalize(run.id, 'paused');
     return this.runs.getRun(hookId, run.id);
   }
@@ -184,69 +215,137 @@ export class HookWatchService implements OnModuleInit {
       await this.unschedule(hookId);
       return;
     }
-    const { filters, sort } = watchQuery(strategy, cursor);
     const src = hook.source;
+    const userFilters = src.filters ?? [];
+    // the primary key drives deterministic ordering (timestamp tiebreakers,
+    // snapshot scan order) — resolve it BEFORE building the query, not from
+    // the page that the query returned
+    const pk = await this.resolvePk(hookId, src);
     const limit =
       strategy.strategy === 'snapshot'
         ? Math.min(strategy.maxTracked, 1000)
         : hook.trigger.maxPerPoll;
+    const pageLimit = Math.min(limit, 1000);
 
-    const page = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
-      a.browse({
-        schema: src.schema,
-        table: src.table,
-        filters: filters.length ? filters : undefined,
-        sort: sort.length ? sort : undefined,
-        limit: Math.min(limit, 1000),
-        offset: 0,
-      }),
-    );
-    const pk = page.primaryKey;
-    const { newRows, cursor: next } = advanceCursor(strategy, cursor, page.rows, pk);
+    // registry-backed abort so Stop cancels an in-flight poll mid-page
+    const controller = this.registry.register(run.id);
+    const signal = controller.signal;
+    try {
+      let seq = run.cursorOffset;
+      let delivered = 0;
+      let offset = 0;
+      let pages = 0;
+      // one poll normally fetches a single page. two situations dig deeper:
+      // a fully-deduped full page (rows sharing one boundary timestamp, or a
+      // snapshot table larger than a page) pages on at the same cursor so the
+      // watch can't livelock, and an advanced cursor with a full page re-reads
+      // from the window top to drain a burst — both under one scan budget.
+      while (delivered < limit && pages < HookWatchService.SCAN_PAGES_PER_POLL) {
+        if (signal.aborted) return;
+        const { filters, sort } = watchQuery(strategy, cursor, pk);
+        const allFilters = [...userFilters, ...filters];
+        const page = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
+          a.browse({
+            schema: src.schema,
+            table: src.table,
+            filters: allFilters.length ? allFilters : undefined,
+            sort: sort.length ? sort : undefined,
+            limit: pageLimit,
+            offset,
+          }),
+        );
+        pages++;
+        const effPk = pk.length ? pk : page.primaryKey;
+        const { newRows, cursor: next } = advanceCursor(strategy, cursor, page.rows, effPk);
 
-    const signal = new AbortController().signal;
-    let seq = run.cursorOffset;
-    for (const row of newRows) {
-      const now = new Date().toISOString();
-      const idem =
-        hook.destination.kind === 'http' && hook.destination.idempotency
-          ? `${run.id}:${seq}`
-          : undefined;
-      const { outcome } = await this.sink.deliver(
-        hook,
-        [row],
-        { table: src.table, now, startIndex: seq },
-        signal,
-        idem,
-      );
-      await this.runs.recordDelivery(
-        run.id,
-        {
-          sequence: seq,
-          rowIndex: seq,
-          rowCount: 1,
-          rowKeys: pk.length ? pk.map((c) => row[c]) : null,
-        },
-        outcome,
-      );
-      seq++;
-      // checkpoint the sequence immediately: a crash mid-batch must never reuse
-      // a sequence (the upsert would overwrite a delivered row with new data).
-      // the cursorJson itself only advances after the whole page (below), so a
-      // crash re-fetches the same rows but delivers them under fresh sequences
-      await this.prisma.hookRun.update({
-        where: { id: run.id },
-        data: { cursorOffset: seq },
-      });
-      if (hook.delivery.minDelayMs) await sleep(hook.delivery.minDelayMs);
+        for (const row of newRows) {
+          if (signal.aborted) return;
+          const now = new Date().toISOString();
+          // idempotency keys on stable row identity, NOT the mutable sequence:
+          // a crash that re-fetches this page redelivers under the same key so
+          // the receiver can dedupe. the tracked timestamp salts the key so a
+          // genuine later update of the same row still delivers fresh.
+          const idem =
+            hook.destination.kind === 'http' && hook.destination.idempotency
+              ? strategy.strategy === 'timestamp'
+                ? `${run.id}:${rowKey(row, effPk)}:${String(row[strategy.column] ?? '')}`
+                : `${run.id}:${rowKey(row, effPk)}`
+              : undefined;
+          const { outcome } = await this.sink.deliver(
+            hook,
+            [row],
+            { table: src.table, now, startIndex: seq },
+            signal,
+            idem,
+          );
+          await this.runs.recordDelivery(
+            run.id,
+            {
+              sequence: seq,
+              rowIndex: seq,
+              rowCount: 1,
+              rowKeys: effPk.length ? effPk.map((c) => row[c]) : null,
+            },
+            outcome,
+          );
+          seq++;
+          // checkpoint the sequence immediately: a crash mid-page must never
+          // reuse a sequence (the upsert would overwrite a delivered row)
+          await this.prisma.hookRun.update({
+            where: { id: run.id },
+            data: { cursorOffset: seq },
+          });
+          if (hook.delivery.minDelayMs) await sleep(hook.delivery.minDelayMs, signal);
+        }
+        if (signal.aborted) return;
+
+        const advanced = JSON.stringify(next) !== JSON.stringify(cursor);
+        cursor = next;
+        delivered += newRows.length;
+        await this.prisma.hookRun.update({
+          where: { id: run.id },
+          data: { cursorJson: JSON.stringify(cursor), cursorOffset: seq },
+        });
+
+        const full = page.rows.length >= pageLimit;
+        if (!full) break; // drained everything matching the filter window
+        if (newRows.length === 0 && !advanced) {
+          // dense boundary: every row of a full page was already delivered and
+          // the cursor can't move yet — dig into the next page of the window
+          if (offset === 0) {
+            this.logger.warn(
+              `Watch ${hookId}: paging within a dense boundary (${pageLimit}+ rows share the cursor position)`,
+            );
+          }
+          offset += page.rows.length;
+          continue;
+        }
+        // the cursor advanced and the page was full: more rows may be waiting —
+        // restart from the top of the (new) window
+        offset = 0;
+      }
+      if (pages >= HookWatchService.SCAN_PAGES_PER_POLL) {
+        this.logger.warn(
+          `Watch ${hookId}: scan budget exhausted (${pages} pages in one poll) — will continue next poll`,
+        );
+      }
+
+      await this.adapt(hookId, hook.trigger.pollIntervalMs, delivered > 0);
+    } finally {
+      this.registry.release(run.id);
     }
+  }
 
-    await this.prisma.hookRun.update({
-      where: { id: run.id },
-      data: { cursorJson: JSON.stringify(next), cursorOffset: seq },
-    });
-
-    await this.adapt(hookId, hook.trigger.pollIntervalMs, newRows.length > 0);
+  /** resolve (and cache) the source table's primary key for stable ordering */
+  private async resolvePk(hookId: string, src: TableSource): Promise<string[]> {
+    const sig = `${src.connectionId}:${src.database ?? ''}:${src.schema ?? ''}:${src.table}`;
+    const hit = this.pkCache.get(hookId);
+    if (hit && hit.sig === sig) return hit.pk;
+    const probe = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
+      a.browse({ schema: src.schema, table: src.table, limit: 1, offset: 0 }),
+    );
+    this.pkCache.set(hookId, { sig, pk: probe.primaryKey });
+    return probe.primaryKey;
   }
 
   /**
@@ -281,18 +380,30 @@ export class HookWatchService implements OnModuleInit {
     const src = hook.source;
     const cid = src.connectionId;
     const db = src.database;
+    // seeds must look at the same row universe the polls will: apply the
+    // hook's own source filters to every seeding query
+    const userFilters = src.filters ?? [];
+    const withUser = (extra: typeof userFilters) => {
+      const all = [...userFilters, ...extra];
+      return all.length ? all : undefined;
+    };
 
     if (strategy.strategy === 'increment') {
       const page = await this.pool.withAdapter(cid, db, (a) =>
         a.browse({
           schema: src.schema,
           table: src.table,
+          filters: withUser([]),
           sort: [{ column: strategy.column, direction: 'desc' }],
           limit: 1,
           offset: 0,
         }),
       );
-      return { strategy: 'increment', value: page.rows[0]?.[strategy.column] ?? null };
+      return {
+        strategy: 'increment',
+        value: page.rows[0]?.[strategy.column] ?? null,
+        column: strategy.column,
+      };
     }
 
     if (strategy.strategy === 'timestamp') {
@@ -300,6 +411,7 @@ export class HookWatchService implements OnModuleInit {
         a.browse({
           schema: src.schema,
           table: src.table,
+          filters: withUser([]),
           sort: [{ column: strategy.column, direction: 'desc' }],
           limit: 1,
           offset: 0,
@@ -307,34 +419,55 @@ export class HookWatchService implements OnModuleInit {
       );
       const maxTs = top.rows[0]?.[strategy.column];
       if (maxTs == null) return emptyCursor(strategy);
-      // remember every row already at the max timestamp so they aren't re-sent
-      const at = await this.pool.withAdapter(cid, db, (a) =>
-        a.browse({
-          schema: src.schema,
-          table: src.table,
-          filters: [{ column: strategy.column, operator: 'gte', value: maxTs }],
-          sort: [{ column: strategy.column, direction: 'asc' }],
-          limit: 1000,
-          offset: 0,
-        }),
-      );
+      // remember every row already at the max timestamp so it isn't re-sent —
+      // paged, because a bulk-loaded table can hold far more than one page of
+      // rows at a single timestamp
+      const boundaryKeys: string[] = [];
+      for (let offset = 0; offset < 20_000; offset += 1000) {
+        const at = await this.pool.withAdapter(cid, db, (a) =>
+          a.browse({
+            schema: src.schema,
+            table: src.table,
+            filters: withUser([
+              { column: strategy.column, operator: 'gte', value: maxTs },
+            ]),
+            sort: [{ column: strategy.column, direction: 'asc' }],
+            limit: 1000,
+            offset,
+          }),
+        );
+        boundaryKeys.push(...at.rows.map((r) => rowKey(r, at.primaryKey)));
+        if (at.rows.length < 1000) break;
+      }
       return {
         strategy: 'timestamp',
         ts: maxTs instanceof Date ? maxTs.toISOString() : maxTs,
-        boundaryKeys: at.rows.map((r) => rowKey(r, at.primaryKey)),
+        boundaryKeys,
+        column: strategy.column,
       };
     }
 
-    // snapshot: seed the seen-set with current primary keys (bounded)
-    const page = await this.pool.withAdapter(cid, db, (a) =>
-      a.browse({
-        schema: src.schema,
-        table: src.table,
-        limit: Math.min(strategy.maxTracked, 1000),
-        offset: 0,
-      }),
-    );
-    return { strategy: 'snapshot', seen: page.rows.map((r) => rowKey(r, page.primaryKey)) };
+    // snapshot: seed the seen-set with current primary keys (bounded), scanned
+    // in pk order so the seed and the polls walk the table the same way
+    const pk = await this.resolvePk(hook.id, src);
+    const seen: string[] = [];
+    for (let offset = 0; offset < strategy.maxTracked; offset += 1000) {
+      const page = await this.pool.withAdapter(cid, db, (a) =>
+        a.browse({
+          schema: src.schema,
+          table: src.table,
+          filters: withUser([]),
+          sort: pk.length
+            ? pk.map((c) => ({ column: c, direction: 'asc' as const }))
+            : undefined,
+          limit: Math.min(strategy.maxTracked - offset, 1000),
+          offset,
+        }),
+      );
+      seen.push(...page.rows.map((r) => rowKey(r, pk.length ? pk : page.primaryKey)));
+      if (page.rows.length < 1000) break;
+    }
+    return { strategy: 'snapshot', seen };
   }
 
   /* ----- scheduler plumbing ----- */
@@ -354,6 +487,7 @@ export class HookWatchService implements OnModuleInit {
   private async unschedule(hookId: string): Promise<void> {
     this.emptyStreak.delete(hookId);
     this.scheduledEvery.delete(hookId);
+    this.pkCache.delete(hookId);
     await this.queue.removeJobScheduler(this.schedulerId(hookId)).catch(() => false);
   }
 

--- a/apps/api/src/hooks/hook-watch.service.ts
+++ b/apps/api/src/hooks/hook-watch.service.ts
@@ -9,7 +9,7 @@
  * (`watchQuery` / `advanceCursor`); this service is the I/O around it: fetch a
  * page, deliver the new rows, persist the advanced cursor.
  */
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import {
@@ -24,6 +24,7 @@ import {
   watchStrategySchema,
   type HookRun,
   type WatchCursor,
+  type WatchStrategyConfig,
 } from '@syncle/core';
 import { Queue } from 'bullmq';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
@@ -263,13 +264,10 @@ export class HookWatchService implements OnModuleInit {
           const now = new Date().toISOString();
           // idempotency keys on stable row identity, NOT the mutable sequence:
           // a crash that re-fetches this page redelivers under the same key so
-          // the receiver can dedupe. the tracked timestamp salts the key so a
-          // genuine later update of the same row still delivers fresh.
+          // the receiver can dedupe
           const idem =
             hook.destination.kind === 'http' && hook.destination.idempotency
-              ? strategy.strategy === 'timestamp'
-                ? `${run.id}:${rowKey(row, effPk)}:${String(row[strategy.column] ?? '')}`
-                : `${run.id}:${rowKey(row, effPk)}`
+              ? this.idempotencyKey(run.id, strategy, row, effPk)
               : undefined;
           const { outcome } = await this.sink.deliver(
             hook,
@@ -334,6 +332,27 @@ export class HookWatchService implements OnModuleInit {
     } finally {
       this.registry.release(run.id);
     }
+  }
+
+  /**
+   * idempotency key from stable row identity, salted with the tracked
+   * timestamp so a genuine later update of the same row still delivers fresh.
+   * hashed: raw pk values can carry characters that don't belong in an HTTP
+   * header (and composite keys can be arbitrarily long).
+   */
+  private idempotencyKey(
+    runId: string,
+    strategy: WatchStrategyConfig,
+    row: Record<string, unknown>,
+    pk: string[],
+  ): string {
+    const tracked = strategy.strategy === 'timestamp' ? row[strategy.column] : null;
+    const salt = tracked instanceof Date ? tracked.toISOString() : String(tracked ?? '');
+    const identity = createHash('sha256')
+      .update(`${rowKey(row, pk)} ${salt}`)
+      .digest('hex')
+      .slice(0, 32);
+    return `${runId}:${identity}`;
   }
 
   /** resolve (and cache) the source table's primary key for stable ordering */
@@ -421,7 +440,12 @@ export class HookWatchService implements OnModuleInit {
       if (maxTs == null) return emptyCursor(strategy);
       // remember every row already at the max timestamp so it isn't re-sent —
       // paged, because a bulk-loaded table can hold far more than one page of
-      // rows at a single timestamp
+      // rows at a single timestamp. pk tiebreakers keep the offset paging
+      // stable (rows sharing the timestamp would otherwise shuffle per page)
+      const pk = await this.resolvePk(hook.id, src);
+      const tiebreakers = pk
+        .filter((c) => c !== strategy.column)
+        .map((c) => ({ column: c, direction: 'asc' as const }));
       const boundaryKeys: string[] = [];
       for (let offset = 0; offset < 20_000; offset += 1000) {
         const at = await this.pool.withAdapter(cid, db, (a) =>
@@ -431,12 +455,12 @@ export class HookWatchService implements OnModuleInit {
             filters: withUser([
               { column: strategy.column, operator: 'gte', value: maxTs },
             ]),
-            sort: [{ column: strategy.column, direction: 'asc' }],
+            sort: [{ column: strategy.column, direction: 'asc' }, ...tiebreakers],
             limit: 1000,
             offset,
           }),
         );
-        boundaryKeys.push(...at.rows.map((r) => rowKey(r, at.primaryKey)));
+        boundaryKeys.push(...at.rows.map((r) => rowKey(r, pk.length ? pk : at.primaryKey)));
         if (at.rows.length < 1000) break;
       }
       return {

--- a/apps/web/src/components/automations/hook-builder.tsx
+++ b/apps/web/src/components/automations/hook-builder.tsx
@@ -595,7 +595,9 @@ export function HookBuilder() {
                 strategy:
                   watchStrategy === 'snapshot'
                     ? { strategy: 'snapshot', maxTracked: 50000 }
-                    : { strategy: watchStrategy, column: watchColumn },
+                    : watchStrategy === 'timestamp'
+                      ? { strategy: 'timestamp', column: watchColumn, lookbackMs: 3000 }
+                      : { strategy: 'increment', column: watchColumn },
                 pollIntervalMs: Math.max(1000, Math.round(pollSeconds * 1000)),
                 startFrom: watchStartFrom,
                 maxPerPoll: 500,

--- a/packages/core/src/hooks/hook-config.ts
+++ b/packages/core/src/hooks/hook-config.ts
@@ -149,7 +149,16 @@ export const watchStrategySchema = z.discriminatedUnion('strategy', [
   // track a strictly-increasing column (auto-increment id / sequence)
   z.object({ strategy: z.literal('increment'), column: z.string().min(1) }),
   // track a created_at / updated_at column
-  z.object({ strategy: z.literal('timestamp'), column: z.string().min(1) }),
+  z.object({
+    strategy: z.literal('timestamp'),
+    column: z.string().min(1),
+    /**
+     * re-scan this many ms behind the cursor each poll so late-committing
+     * transactions aren't lost (overlap rows are deduped by the cursor's
+     * boundary keys). 0 disables the window.
+     */
+    lookbackMs: z.coerce.number().int().min(0).max(600_000).default(3000),
+  }),
   // diff the set of seen primary keys (for UUID / non-monotonic keys)
   z.object({
     strategy: z.literal('snapshot'),

--- a/packages/core/src/hooks/watch.test.ts
+++ b/packages/core/src/hooks/watch.test.ts
@@ -250,6 +250,71 @@ describe('timestamp lookback window', () => {
     expect(second.newRows.map((r) => r.id)).toEqual([4]);
   });
 
+  it('never moves the cursor backwards through already-seen window rows', () => {
+    // a page can consist purely of window rows BEHIND the cursor (e.g. a burst
+    // denser than one page): the cursor must hold its ground and keep its keys
+    const t9 = '2026-01-01T00:00:09.000Z';
+    const t10 = '2026-01-01T00:00:10.000Z';
+    const first = advanceCursor(
+      TSL,
+      emptyCursor(TSL),
+      [
+        { id: 1, updated_at: t9 },
+        { id: 2, updated_at: t10 },
+      ],
+      ['id'],
+    );
+    const replay = advanceCursor(TSL, first.cursor, [{ id: 1, updated_at: t9 }], ['id']);
+    expect(replay.newRows).toEqual([]);
+    expect(replay.cursor).toMatchObject({ ts: t10 });
+    // ...and the full-window re-fetch afterwards still re-emits nothing
+    const refetch = advanceCursor(
+      TSL,
+      replay.cursor,
+      [
+        { id: 1, updated_at: t9 },
+        { id: 2, updated_at: t10 },
+      ],
+      ['id'],
+    );
+    expect(refetch.newRows).toEqual([]);
+  });
+
+  it('keeps window keys a truncated page did not re-fetch', () => {
+    // poll 1 emitted ids 1+2; poll 2's page held only the newest row (the rest
+    // was cut off by the page limit). the keys for 1+2 are still inside the
+    // window and must survive the advance, or the next overlap re-fetch would
+    // re-deliver both rows
+    const first = advanceCursor(
+      TSL,
+      emptyCursor(TSL),
+      [
+        { id: 1, updated_at: '2026-01-01T00:00:06.000Z' },
+        { id: 2, updated_at: '2026-01-01T00:00:09.000Z' },
+      ],
+      ['id'],
+    );
+    const second = advanceCursor(
+      TSL,
+      first.cursor,
+      [{ id: 3, updated_at: '2026-01-01T00:00:10.000Z' }],
+      ['id'],
+    );
+    expect(second.newRows.map((r) => r.id)).toEqual([3]);
+
+    const third = advanceCursor(
+      TSL,
+      second.cursor,
+      [
+        { id: 1, updated_at: '2026-01-01T00:00:06.000Z' },
+        { id: 2, updated_at: '2026-01-01T00:00:09.000Z' },
+        { id: 3, updated_at: '2026-01-01T00:00:10.000Z' },
+      ],
+      ['id'],
+    );
+    expect(third.newRows).toEqual([]);
+  });
+
   it('without lookback only exact-boundary rows are keyed (legacy behavior)', () => {
     const rows = [
       { id: 1, updated_at: '2026-01-01T00:00:06.000Z' },

--- a/packages/core/src/hooks/watch.test.ts
+++ b/packages/core/src/hooks/watch.test.ts
@@ -207,3 +207,89 @@ describe('rowKey', () => {
     expect(rowKey({ id: 1 }, ['id'])).not.toBe(rowKey({ id: 2 }, ['id']));
   });
 });
+
+describe('timestamp lookback window', () => {
+  const TSL: TimestampStrategy = {
+    strategy: 'timestamp',
+    column: 'updated_at',
+    lookbackMs: 5000,
+  };
+
+  it('queries a window behind the cursor instead of the exact boundary', () => {
+    const cursor = {
+      strategy: 'timestamp' as const,
+      ts: '2026-01-01T00:00:10.000Z',
+      boundaryKeys: [],
+    };
+    const q = watchQuery(TSL, cursor, ['id']);
+    expect(q.filters).toEqual([
+      { column: 'updated_at', operator: 'gte', value: '2026-01-01T00:00:05.000Z' },
+    ]);
+    // numeric cursors stay numeric
+    const qn = watchQuery(TSL, { ...cursor, ts: 10_000 }, ['id']);
+    expect(qn.filters[0]!.value).toBe(5000);
+  });
+
+  it('keys every row inside the window so the overlap re-fetch dedupes', () => {
+    const rows = [
+      { id: 1, updated_at: '2026-01-01T00:00:06.000Z' },
+      { id: 2, updated_at: '2026-01-01T00:00:09.000Z' },
+      { id: 3, updated_at: '2026-01-01T00:00:10.000Z' },
+    ];
+    const first = advanceCursor(TSL, emptyCursor(TSL), rows, ['id']);
+    expect(first.newRows).toHaveLength(3);
+    // all three rows fall within 5s of the max — all are remembered
+    expect(
+      (first.cursor as { boundaryKeys: string[] }).boundaryKeys,
+    ).toHaveLength(3);
+
+    // the next poll re-fetches the window; nothing re-emits, and a genuinely
+    // late-committing row that appeared inside the window IS emitted
+    const late = { id: 4, updated_at: '2026-01-01T00:00:07.000Z' };
+    const second = advanceCursor(TSL, first.cursor, [...rows, late], ['id']);
+    expect(second.newRows.map((r) => r.id)).toEqual([4]);
+  });
+
+  it('without lookback only exact-boundary rows are keyed (legacy behavior)', () => {
+    const rows = [
+      { id: 1, updated_at: '2026-01-01T00:00:06.000Z' },
+      { id: 2, updated_at: '2026-01-01T00:00:10.000Z' },
+    ];
+    const r = advanceCursor(TS, emptyCursor(TS), rows, ['id']);
+    expect((r.cursor as { boundaryKeys: string[] }).boundaryKeys).toHaveLength(1);
+  });
+});
+
+describe('cursor column stamping', () => {
+  it('cursors carry the column they were read from', () => {
+    expect(emptyCursor(INC)).toMatchObject({ column: 'id' });
+    expect(emptyCursor(TS)).toMatchObject({ column: 'updated_at' });
+    const adv = advanceCursor(INC, emptyCursor(INC), [{ id: 7 }], ['id']);
+    expect(adv.cursor).toMatchObject({ column: 'id' });
+    const advTs = advanceCursor(
+      TS,
+      emptyCursor(TS),
+      [{ id: 1, updated_at: 100 }],
+      ['id'],
+    );
+    expect(advTs.cursor).toMatchObject({ column: 'updated_at' });
+  });
+});
+
+describe('watchQuery determinism', () => {
+  it('timestamp polls tiebreak on the primary key', () => {
+    const q = watchQuery(TS, emptyCursor(TS), ['id']);
+    expect(q.sort).toEqual([
+      { column: 'updated_at', direction: 'asc' },
+      { column: 'id', direction: 'asc' },
+    ]);
+  });
+
+  it('snapshot scans order by the primary key', () => {
+    const q = watchQuery(SNAP, emptyCursor(SNAP), ['a', 'b']);
+    expect(q.sort).toEqual([
+      { column: 'a', direction: 'asc' },
+      { column: 'b', direction: 'asc' },
+    ]);
+  });
+});

--- a/packages/core/src/hooks/watch.ts
+++ b/packages/core/src/hooks/watch.ts
@@ -236,33 +236,39 @@ export function advanceCursor(
     if (maxTs == null) {
       return { newRows, cursor };
     }
+    // the lookback window can hand back a page consisting purely of older,
+    // already-emitted rows — the cursor must never move backwards through them
+    const nextTs =
+      cursor.ts != null && !tsGreater(maxTs, cursor.ts) ? cursor.ts : maxTs;
     // remember all rows at the boundary timestamp — and, with a lookback
     // window, every row inside the window behind it — so the next `>=` poll
     // can dedupe the re-fetched overlap
     const lookback = strategy.lookbackMs ?? 0;
-    const nMax = tsNorm(maxTs);
+    const nNext = tsNorm(nextTs);
     const inWindow = (v: unknown): boolean => {
       if (v == null) return false;
-      if (tsEquals(v, maxTs)) return true;
+      if (tsEquals(v, nextTs)) return true;
       if (lookback <= 0) return false;
       const n = tsNorm(v);
       return (
-        typeof n === 'number' && typeof nMax === 'number' && nMax - n <= lookback
+        typeof n === 'number' && typeof nNext === 'number' && nNext - n <= lookback
       );
     };
     const boundaryKeys = rows
       .filter((r) => inWindow(r[strategy.column]))
       .map((r) => rowKey(r, pk));
-    // when the boundary timestamp didn't move, this poll only saw a subset of
-    // the rows at that instant — union with the keys already remembered so
-    // rows emitted by earlier polls at the same ts aren't re-delivered
-    const stalled = cursor.ts != null && tsEquals(maxTs, cursor.ts);
+    // keys remembered by earlier polls stay live for as long as their rows can
+    // still be re-fetched, i.e. until the cursor moves a full window past them.
+    // this poll may only have seen a subset of those rows (same-ts paging, a
+    // truncated page), so union — replacing would shed keys for overlap rows
+    // this page didn't contain and re-deliver them next poll
+    const carry = cursor.ts != null && inWindow(cursor.ts);
     return {
       newRows,
       cursor: {
         strategy: 'timestamp',
-        ts: serializeTs(maxTs),
-        boundaryKeys: stalled
+        ts: serializeTs(nextTs),
+        boundaryKeys: carry
           ? [...new Set([...cursor.boundaryKeys, ...boundaryKeys])]
           : boundaryKeys,
         column: strategy.column,

--- a/packages/core/src/hooks/watch.ts
+++ b/packages/core/src/hooks/watch.ts
@@ -30,6 +30,13 @@ export interface IncrementStrategy {
 export interface TimestampStrategy {
   strategy: 'timestamp';
   column: string;
+  /**
+   * re-scan this many ms behind the cursor each poll. covers transactions that
+   * set their timestamp early but commit late (their rows would otherwise land
+   * behind an already-advanced cursor and never be seen). the window's rows are
+   * deduped via `boundaryKeys`, so the overlap re-fetch never re-emits.
+   */
+  lookbackMs?: number;
 }
 export interface SnapshotStrategy {
   strategy: 'snapshot';
@@ -44,12 +51,19 @@ export type WatchStrategy =
 export interface IncrementCursor {
   strategy: 'increment';
   value: unknown;
+  /** the column this cursor value belongs to (guards against editing the strategy) */
+  column?: string;
 }
 export interface TimestampCursor {
   strategy: 'timestamp';
   ts: unknown;
-  /** row keys already emitted at exactly `ts` (dedupe on the `>=` re-fetch) */
+  /**
+   * row keys already emitted at `ts` — and, when a lookback window is
+   * configured, within the window behind it (dedupe on the `>=` re-fetch)
+   */
   boundaryKeys: string[];
+  /** the column this cursor value belongs to (guards against editing the strategy) */
+  column?: string;
 }
 export interface SnapshotCursor {
   strategy: 'snapshot';
@@ -101,6 +115,18 @@ function serializeTs(v: unknown): unknown {
   return v instanceof Date ? v.toISOString() : v;
 }
 
+/**
+ * `ts` shifted `ms` into the past, in a form comparable against the column
+ * (ISO string stays ISO, epoch number stays a number). values that don't
+ * normalize to a number are returned unchanged — no lookback is possible.
+ */
+function tsMinus(ts: unknown, ms: number): unknown {
+  const n = tsNorm(ts);
+  if (typeof n !== 'number') return ts;
+  if (typeof ts === 'number') return n - ms;
+  return new Date(n - ms).toISOString();
+}
+
 /* -------------------------------------------------------------------------- */
 /* engine                                                                     */
 /* -------------------------------------------------------------------------- */
@@ -109,9 +135,9 @@ function serializeTs(v: unknown): unknown {
 export function emptyCursor(strategy: WatchStrategy): WatchCursor {
   switch (strategy.strategy) {
     case 'increment':
-      return { strategy: 'increment', value: null };
+      return { strategy: 'increment', value: null, column: strategy.column };
     case 'timestamp':
-      return { strategy: 'timestamp', ts: null, boundaryKeys: [] };
+      return { strategy: 'timestamp', ts: null, boundaryKeys: [], column: strategy.column };
     case 'snapshot':
       return { strategy: 'snapshot', seen: [] };
   }
@@ -143,10 +169,16 @@ export function watchQuery(
     const tiebreakers: SortSpec[] = pk
       .filter((c) => c !== strategy.column)
       .map((c) => ({ column: c, direction: 'asc' }));
+    // re-scan the lookback window behind the cursor so late-committing
+    // transactions (timestamp set early, commit after the cursor moved past
+    // it) are still picked up; boundaryKeys dedupes the overlap
+    const lookback = strategy.lookbackMs ?? 0;
+    const bound =
+      cursor.ts != null && lookback > 0 ? tsMinus(cursor.ts, lookback) : cursor.ts;
     return {
       filters:
         cursor.ts != null
-          ? [{ column: strategy.column, operator: 'gte', value: cursor.ts }]
+          ? [{ column: strategy.column, operator: 'gte', value: bound }]
           : [],
       sort: [{ column: strategy.column, direction: 'asc' }, ...tiebreakers],
     };
@@ -182,7 +214,7 @@ export function advanceCursor(
     }
     return {
       newRows: rows,
-      cursor: { strategy: 'increment', value },
+      cursor: { strategy: 'increment', value, column: strategy.column },
     };
   }
 
@@ -204,10 +236,22 @@ export function advanceCursor(
     if (maxTs == null) {
       return { newRows, cursor };
     }
-    // remember all rows at the boundary timestamp so the next `>=` poll can
-    // dedupe them
+    // remember all rows at the boundary timestamp — and, with a lookback
+    // window, every row inside the window behind it — so the next `>=` poll
+    // can dedupe the re-fetched overlap
+    const lookback = strategy.lookbackMs ?? 0;
+    const nMax = tsNorm(maxTs);
+    const inWindow = (v: unknown): boolean => {
+      if (v == null) return false;
+      if (tsEquals(v, maxTs)) return true;
+      if (lookback <= 0) return false;
+      const n = tsNorm(v);
+      return (
+        typeof n === 'number' && typeof nMax === 'number' && nMax - n <= lookback
+      );
+    };
     const boundaryKeys = rows
-      .filter((r) => tsEquals(r[strategy.column], maxTs))
+      .filter((r) => inWindow(r[strategy.column]))
       .map((r) => rowKey(r, pk));
     // when the boundary timestamp didn't move, this poll only saw a subset of
     // the rows at that instant — union with the keys already remembered so
@@ -221,6 +265,7 @@ export function advanceCursor(
         boundaryKeys: stalled
           ? [...new Set([...cursor.boundaryKeys, ...boundaryKeys])]
           : boundaryKeys,
+        column: strategy.column,
       },
     };
   }


### PR DESCRIPTION
Fixes the confirmed correctness bugs in the watch (polling) trigger:

- **Primary-key ordering**: the poll resolves the source table's primary key *before* building the query, so timestamp tiebreak sorts and snapshot scan order actually apply. Previously `watchQuery` was called with an empty pk — unordered LIMIT scans can return a different subset per poll and silently miss rows.
- **Dense-boundary livelock**: when more rows share one timestamp than `maxPerPoll`, every poll refetched the same fully-deduped page forever. Polls now page deeper within the boundary under a scan budget (50 pages/poll) and log when they do.
- **Lookback window**: the timestamp strategy re-scans a configurable window (default 3s) behind the cursor so late-committing transactions are captured; boundary keys cover the window so the overlap never re-emits.
- **Source filters**: a filtered bridge applied its filters under replay but synced the whole table under watch. Filters now merge into every poll and every cursor seed.
- **Stale cursor on column edit**: cursors record their column; changing the watch column rebuilds the cursor instead of silently skipping rows.
- **Stable idempotency keys**: `runId:rowKey` (timestamp-salted) instead of the mutable sequence — crash-replayed pages dedupe at the receiver.
- **Stop works mid-page**: polls register with the run registry; delivery delays are interruptible.

Also: timestamp/snapshot cursor seeds paginate past 1,000 rows (bulk-loaded tables used to duplicate on the first poll).

Tests: new core cases for the lookback window, window dedupe, cursor column stamping, and query determinism. `pnpm typecheck` and the full suite pass.