### PR TITLE
Security hardening: setup token, rate limiting, SSRF guard, key hygiene

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,16 +24,32 @@ You'll get an acknowledgement within a few days. Once a fix is ready I'll
 coordinate disclosure timing with you and credit you in the release notes unless
 you'd rather stay anonymous.
 
-## Scope notes
+## Security model
 
-Syncle is built to run on a trusted network. A few things are deliberately
-out of scope unless you've deployed it differently:
+Syncle is built to run on a trusted network, but it does ship its own
+protections:
 
-- **No built-in auth layer.** The app assumes you put it behind your own
-  authentication / network controls before exposing it.
-- **Outbound webhook URLs are user-controlled.** Restrict destinations at your
-  network edge if you run this somewhere multi-tenant.
+- **Single-operator auth on every route.** First run creates the one admin
+  account (guarded by a one-time setup token printed to the server console),
+  after which a scrypt-hashed password and a signed httpOnly session cookie
+  protect the whole API. Password changes invalidate all outstanding sessions,
+  and the login/setup endpoints rate-limit repeated failures.
+- **Secrets encrypted at rest.** Connection credentials and hook auth secrets
+  are AES-256-GCM encrypted under `SYNCLE_MASTER_KEY` (session cookies are
+  signed with an HKDF-derived sub-key, so encryption and signing stay
+  independent). Set the key explicitly in production.
+- **Outbound destination guard.** Hook deliveries never follow redirects and
+  always refuse cloud metadata endpoints (169.254.169.254 and friends). On a
+  network-exposed deployment, set `SYNCLE_BLOCK_PRIVATE_DESTINATIONS=true` to
+  also refuse loopback/private/link-local destinations — it is off by default
+  because posting to localhost services is a primary local use case.
+- **SQLite path jail.** Set `SYNCLE_SQLITE_DIR` to restrict which files SQLite
+  connections may open/create on the server.
 
-Things that *are* in scope and that I care about: credential handling (secrets
-are encrypted at rest with AES-256-GCM), SQL/command injection through the
-adapters, and payload-template injection.
+Still your job when exposing Syncle beyond localhost: TLS termination,
+completing first-run setup before the port is reachable, and network-level
+control over who can reach the API at all.
+
+Things that are always in scope and that I care about: credential handling,
+SQL/command injection through the adapters, payload-template injection, auth
+bypasses, and SSRF that dodges the destination guard.

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -46,9 +46,15 @@ export class AuthController {
   @Post('setup')
   async setup(
     @Body(new ZodValidationPipe(setupSchema)) dto: SetupDTO,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ): Promise<AuthUser> {
-    const user = await this.auth.setup(dto.username, dto.password);
+    const user = await this.auth.setup(
+      dto.username,
+      dto.password,
+      dto.setupToken,
+      req.ip ?? '',
+    );
     await this.auth.issueSession(res, user);
     return this.auth.toAuthUser(user);
   }
@@ -57,9 +63,10 @@ export class AuthController {
   @Post('login')
   async login(
     @Body(new ZodValidationPipe(loginSchema)) dto: LoginDTO,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ): Promise<AuthUser> {
-    const user = await this.auth.login(dto.username, dto.password);
+    const user = await this.auth.login(dto.username, dto.password, req.ip ?? '');
     await this.auth.issueSession(res, user);
     return this.auth.toAuthUser(user);
   }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -12,14 +12,16 @@ import {
   timingSafeEqual,
 } from 'node:crypto';
 import { promisify } from 'node:util';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import {
+  AppError,
   BadRequestError,
   ConflictError,
   UnauthorizedError,
   type AuthUser,
 } from '@syncle/core';
+import { AttemptLimiter } from '../common/attempt-limiter';
 import type { AppUser } from '@prisma/client';
 import { CryptoService } from '../common/crypto.service';
 import { PrismaService } from '../common/prisma.service';
@@ -42,8 +44,14 @@ interface SessionPayload {
 }
 
 @Injectable()
-export class AuthService {
+export class AuthService implements OnModuleInit {
   private readonly logger = new Logger('Auth');
+  /** one-time first-run token; null once an account exists */
+  private setupToken: string | null = null;
+  /** per-ip:username lockout against online password guessing */
+  private readonly loginLimiter = new AttemptLimiter();
+  /** per-ip lockout against setup-token guessing */
+  private readonly setupLimiter = new AttemptLimiter(5, 60_000);
 
   constructor(
     private readonly prisma: PrismaService,
@@ -53,25 +61,63 @@ export class AuthService {
 
   /* ----- account lifecycle ----- */
 
+  /**
+   * first-run guard: whoever reaches an un-set-up instance first would own it
+   * (trust-on-first-use). mint a one-time token at boot and print it to the
+   * server console — setup then requires something only the operator has.
+   */
+  async onModuleInit(): Promise<void> {
+    try {
+      if (await this.hasAccount()) return;
+    } catch (err) {
+      // DB not up yet — the token is minted lazily on the first setup attempt
+      this.logger.warn(`Skipped setup-token mint: ${(err as Error).message}`);
+      return;
+    }
+    this.logger.log(this.setupBanner(this.mintSetupToken()));
+  }
+
   async hasAccount(): Promise<boolean> {
     return (await this.prisma.appUser.count()) > 0;
   }
 
   /** create the one admin account; refuses if an account already exists */
-  async setup(username: string, password: string): Promise<AppUser> {
+  async setup(
+    username: string,
+    password: string,
+    setupToken: string,
+    ip: string,
+  ): Promise<AppUser> {
     if (await this.hasAccount()) {
       throw new ConflictError('An account already exists. Sign in instead.');
     }
-    return this.prisma.appUser.create({
+    this.assertNotLocked(this.setupLimiter, `setup:${ip}`);
+    if (this.setupToken == null) {
+      // boot couldn't reach the DB (or the token was consumed by a failed
+      // race) — mint now so the console always shows a usable token
+      this.logger.log(this.setupBanner(this.mintSetupToken()));
+    }
+    if (!tokensEqual(setupToken, this.setupToken!)) {
+      this.setupLimiter.fail(`setup:${ip}`);
+      throw new UnauthorizedError(
+        'Invalid setup token. It is printed in the server logs at startup.',
+      );
+    }
+    const user = await this.prisma.appUser.create({
       data: {
         id: randomUUID(),
         username,
         passwordHash: await this.hashPassword(password),
       },
     });
+    this.setupToken = null;
+    this.setupLimiter.succeed(`setup:${ip}`);
+    return user;
   }
 
-  async login(username: string, password: string): Promise<AppUser> {
+  async login(username: string, password: string, ip: string): Promise<AppUser> {
+    const key = `${ip}:${username}`;
+    this.assertNotLocked(this.loginLimiter, key);
     const user = await this.prisma.appUser.findUnique({ where: { username } });
     // verify against a decoy hash even when the user is missing, so a wrong
     // username and a wrong password take the same time (no user enumeration)
@@ -80,9 +126,37 @@ export class AuthService {
       user?.passwordHash ?? DECOY_HASH,
     );
     if (!user || !ok) {
+      this.loginLimiter.fail(key);
       throw new UnauthorizedError('Incorrect username or password.');
     }
+    this.loginLimiter.succeed(key);
     return user;
+  }
+
+  private assertNotLocked(limiter: AttemptLimiter, key: string): void {
+    const waitMs = limiter.retryAfterMs(key);
+    if (waitMs > 0) {
+      throw new AppError(
+        'RATE_LIMITED',
+        `Too many attempts. Try again in ${Math.ceil(waitMs / 1000)}s.`,
+        429,
+      );
+    }
+  }
+
+  private mintSetupToken(): string {
+    this.setupToken = randomBytes(9).toString('base64url');
+    return this.setupToken;
+  }
+
+  private setupBanner(token: string): string {
+    return [
+      '',
+      '  ┌──────────────────────────────────────────────────┐',
+      '  │  First-run setup token (enter it in the web UI)  │',
+      `  │      ${token.padEnd(44)}│`,
+      '  └──────────────────────────────────────────────────┘',
+    ].join('\n');
   }
 
   async changePassword(
@@ -188,6 +262,14 @@ export class AuthService {
 
 function nowMs(): number {
   return new Date().getTime();
+}
+
+/** constant-time string compare (padded so length mismatches don't throw) */
+function tokensEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
 }
 
 /** parse a single cookie value out of the raw Cookie header (no cookie-parser dep) */

--- a/apps/api/src/common/attempt-limiter.test.ts
+++ b/apps/api/src/common/attempt-limiter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { AttemptLimiter } from './attempt-limiter';
+
+describe('AttemptLimiter', () => {
+  it('locks after the failure threshold and backs off exponentially', () => {
+    const l = new AttemptLimiter(3, 1000, 8000);
+    const t0 = 1_000_000;
+    expect(l.retryAfterMs('k', t0)).toBe(0);
+    l.fail('k', t0);
+    l.fail('k', t0);
+    expect(l.retryAfterMs('k', t0)).toBe(0); // below threshold
+    l.fail('k', t0);
+    expect(l.retryAfterMs('k', t0)).toBe(1000); // 3rd failure locks
+    l.fail('k', t0);
+    expect(l.retryAfterMs('k', t0)).toBe(2000); // doubles
+    l.fail('k', t0);
+    l.fail('k', t0);
+    l.fail('k', t0);
+    expect(l.retryAfterMs('k', t0)).toBe(8000); // capped
+  });
+
+  it('unlocks when the cooldown elapses and clears on success', () => {
+    const l = new AttemptLimiter(1, 1000, 8000);
+    const t0 = 5_000;
+    l.fail('k', t0);
+    expect(l.retryAfterMs('k', t0 + 999)).toBe(1);
+    expect(l.retryAfterMs('k', t0 + 1000)).toBe(0);
+    l.succeed('k');
+    l.fail('other', t0);
+    expect(l.retryAfterMs('k', t0)).toBe(0); // keys are independent
+  });
+});

--- a/apps/api/src/common/attempt-limiter.ts
+++ b/apps/api/src/common/attempt-limiter.ts
@@ -1,0 +1,44 @@
+/**
+ * tiny in-memory attempt limiter for the auth endpoints. sliding lockout:
+ * after `maxFailures` consecutive failures for a key, further attempts are
+ * rejected for a cooldown that doubles with each subsequent failure (capped).
+ * success clears the key. single-process by design — the API runs as one
+ * process, and durable rate limiting would be overkill for a single-operator
+ * tool; the point is making online guessing impractical, not accounting.
+ */
+export class AttemptLimiter {
+  private readonly entries = new Map<
+    string,
+    { failures: number; lockedUntil: number }
+  >();
+
+  constructor(
+    private readonly maxFailures = 5,
+    private readonly baseLockMs = 30_000,
+    private readonly maxLockMs = 15 * 60_000,
+  ) {}
+
+  /** ms until the key may try again; 0 when it is free to proceed */
+  retryAfterMs(key: string, now = Date.now()): number {
+    const e = this.entries.get(key);
+    if (!e) return 0;
+    return e.lockedUntil > now ? e.lockedUntil - now : 0;
+  }
+
+  /** record a failed attempt; starts/extends the lockout past the threshold */
+  fail(key: string, now = Date.now()): void {
+    const e = this.entries.get(key) ?? { failures: 0, lockedUntil: 0 };
+    e.failures += 1;
+    if (e.failures >= this.maxFailures) {
+      const over = e.failures - this.maxFailures;
+      const lock = Math.min(this.baseLockMs * 2 ** over, this.maxLockMs);
+      e.lockedUntil = now + lock;
+    }
+    this.entries.set(key, e);
+  }
+
+  /** a successful attempt clears the slate for the key */
+  succeed(key: string): void {
+    this.entries.delete(key);
+  }
+}

--- a/apps/api/src/common/crypto.service.test.ts
+++ b/apps/api/src/common/crypto.service.test.ts
@@ -5,10 +5,10 @@ import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 // import fresh with a pinned master key so the test never touches a real data dir
-async function loadService() {
+async function loadService(masterKey = randomBytes(32).toString('base64')) {
   vi.resetModules();
   vi.stubEnv('SYNCLE_DATA_DIR', mkdtempSync(join(tmpdir(), 'syncle-test-')));
-  vi.stubEnv('SYNCLE_MASTER_KEY', randomBytes(32).toString('base64'));
+  vi.stubEnv('SYNCLE_MASTER_KEY', masterKey);
   const { CryptoService } = await import('./crypto.service.js');
   return new CryptoService();
 }
@@ -29,5 +29,18 @@ describe('CryptoService', () => {
     expect(() => svc.decrypt(`${iv}:${shortTag}:${data}`)).toThrow(/Malformed/);
     // the untampered ciphertext still decrypts
     expect(svc.decrypt(`${iv}:${tag}:${data}`)).toBe('payload');
+  });
+
+  it('derives a stable HKDF signing key from the master key', async () => {
+    // the derivation must be deterministic: a session minted before a restart
+    // (fresh service instance, same master key) still verifies after it
+    const key = randomBytes(32).toString('base64');
+    const before = await loadService(key);
+    const token = before.signToken({ uid: 'u1' });
+    const after = await loadService(key);
+    expect(after.verifyToken(token)).toMatchObject({ uid: 'u1' });
+    // ...while a different master key derives a different signing key
+    const other = await loadService();
+    expect(other.verifyToken(token)).toBeNull();
   });
 });

--- a/apps/api/src/common/crypto.service.test.ts
+++ b/apps/api/src/common/crypto.service.test.ts
@@ -1,0 +1,33 @@
+import { randomBytes } from 'node:crypto';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// import fresh with a pinned master key so the test never touches a real data dir
+async function loadService() {
+  vi.resetModules();
+  vi.stubEnv('SYNCLE_DATA_DIR', mkdtempSync(join(tmpdir(), 'syncle-test-')));
+  vi.stubEnv('SYNCLE_MASTER_KEY', randomBytes(32).toString('base64'));
+  const { CryptoService } = await import('./crypto.service.js');
+  return new CryptoService();
+}
+
+describe('CryptoService', () => {
+  it('round-trips encryption and signed tokens', async () => {
+    const svc = await loadService();
+    expect(svc.decrypt(svc.encrypt('s3cret'))).toBe('s3cret');
+    const token = svc.signToken({ uid: 'u1', v: 2 });
+    expect(svc.verifyToken(token)).toMatchObject({ uid: 'u1', v: 2 });
+    expect(svc.verifyToken(token.slice(0, -2) + 'xx')).toBeNull();
+  });
+
+  it('rejects ciphertexts with a truncated auth tag', async () => {
+    const svc = await loadService();
+    const [iv, tag, data] = svc.encrypt('payload').split(':');
+    const shortTag = Buffer.from(tag!, 'base64').subarray(0, 8).toString('base64');
+    expect(() => svc.decrypt(`${iv}:${shortTag}:${data}`)).toThrow(/Malformed/);
+    // the untampered ciphertext still decrypts
+    expect(svc.decrypt(`${iv}:${tag}:${data}`)).toBe('payload');
+  });
+});

--- a/apps/api/src/common/crypto.service.ts
+++ b/apps/api/src/common/crypto.service.ts
@@ -9,6 +9,7 @@ import {
   createCipheriv,
   createDecipheriv,
   createHmac,
+  hkdfSync,
   randomBytes,
   timingSafeEqual,
 } from 'node:crypto';
@@ -18,10 +19,12 @@ import { runtimeConfig } from './runtime-config';
 
 const ALGO = 'aes-256-gcm';
 const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
 
 @Injectable()
 export class CryptoService {
   private key: Buffer | null = null;
+  private sigKey: Buffer | null = null;
 
   private loadKey(): Buffer {
     if (this.key) return this.key;
@@ -78,12 +81,16 @@ export class CryptoService {
   decrypt(payload: string): string {
     const [ivB64, tagB64, dataB64] = payload.split(':');
     if (!ivB64 || !tagB64 || !dataB64) throw new Error('Malformed ciphertext');
+    const tag = Buffer.from(tagB64, 'base64');
+    // GCM accepts tags as short as 4 bytes; a truncated tag collapses forgery
+    // resistance, so only the full 16-byte tag our encrypt() emits is valid
+    if (tag.length !== TAG_LENGTH) throw new Error('Malformed ciphertext');
     const decipher = createDecipheriv(
       ALGO,
       this.loadKey(),
       Buffer.from(ivB64, 'base64'),
     );
-    decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+    decipher.setAuthTag(tag);
     return Buffer.concat([
       decipher.update(Buffer.from(dataB64, 'base64')),
       decipher.final(),
@@ -92,8 +99,10 @@ export class CryptoService {
 
   /**
    * sign an arbitrary JSON-serializable payload into a compact, tamper-evident
-   * token: `base64url(json).base64url(hmac)`. used for the session cookie — the
-   * master key doubles as the HMAC secret, so no extra key to manage.
+   * token: `base64url(json).base64url(hmac)`. used for the session cookie —
+   * signed with a sub-key HKDF-derived from the master key, so the encryption
+   * key and the MAC key stay independent (key-separation hygiene) while the
+   * operator still manages a single secret.
    */
   signToken(payload: Record<string, unknown>): string {
     const body = base64url(Buffer.from(JSON.stringify(payload), 'utf8'));
@@ -127,7 +136,16 @@ export class CryptoService {
   }
 
   private hmac(data: string): string {
-    return base64url(createHmac('sha256', this.loadKey()).update(data).digest());
+    return base64url(createHmac('sha256', this.loadSigKey()).update(data).digest());
+  }
+
+  /** HKDF(master, info='syncle-session-sig') — derived once, never persisted */
+  private loadSigKey(): Buffer {
+    if (this.sigKey) return this.sigKey;
+    this.sigKey = Buffer.from(
+      hkdfSync('sha256', this.loadKey(), Buffer.alloc(0), 'syncle-session-sig', 32),
+    );
+    return this.sigKey;
   }
 }
 

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -30,6 +30,18 @@ export const runtimeConfig = {
   redisUrl: process.env.REDIS_URL ?? 'redis://localhost:6379',
   /** worker concurrency: how many hook runs may run in parallel */
   hookConcurrency: Number(process.env.SYNCLE_HOOK_CONCURRENCY ?? 5),
+  /**
+   * when true, HTTP destinations may not resolve to loopback/private/link-local
+   * addresses (SSRF guard for network-exposed deployments). off by default —
+   * Syncle is local-first and posting to localhost services is a primary use.
+   * cloud metadata endpoints are blocked regardless of this flag.
+   */
+  blockPrivateDestinations:
+    (process.env.SYNCLE_BLOCK_PRIVATE_DESTINATIONS ?? '') === 'true',
+  /** when set, SQLite connections may only open files under this directory */
+  sqliteBaseDir: process.env.SYNCLE_SQLITE_DIR
+    ? resolve(process.env.SYNCLE_SQLITE_DIR)
+    : null,
 } as const;
 
 /**

--- a/apps/api/src/common/url-guard.test.ts
+++ b/apps/api/src/common/url-guard.test.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// runtime-config resolves the environment at import time (and creates the data
+// dir), so each case stubs the env and re-imports the guard fresh
+async function loadGuard(blockPrivate: boolean) {
+  vi.resetModules();
+  vi.stubEnv('SYNCLE_DATA_DIR', mkdtempSync(join(tmpdir(), 'syncle-test-')));
+  vi.stubEnv('SYNCLE_BLOCK_PRIVATE_DESTINATIONS', blockPrivate ? 'true' : '');
+  const mod = await import('./url-guard.js');
+  return mod.assertAllowedDestination;
+}
+
+describe('assertAllowedDestination', () => {
+  beforeEach(() => vi.unstubAllEnvs());
+
+  it('always refuses cloud metadata endpoints', async () => {
+    const guard = await loadGuard(false);
+    await expect(guard('http://169.254.169.254/latest/meta-data/')).rejects.toThrow(
+      /metadata/,
+    );
+    await expect(guard('http://[fd00:ec2::254]/')).rejects.toThrow(/metadata/);
+    await expect(guard('http://100.100.100.200/')).rejects.toThrow(/metadata/);
+  });
+
+  it('allows private/loopback destinations by default (local-first)', async () => {
+    const guard = await loadGuard(false);
+    await expect(guard('http://127.0.0.1:4990/hook')).resolves.toBeUndefined();
+    await expect(guard('http://192.168.1.20/ingest')).resolves.toBeUndefined();
+  });
+
+  it('refuses private ranges when the deployment opts in', async () => {
+    const guard = await loadGuard(true);
+    await expect(guard('http://127.0.0.1:4990/hook')).rejects.toThrow(/private/);
+    await expect(guard('http://10.0.0.5/')).rejects.toThrow(/private/);
+    await expect(guard('http://172.16.0.1/')).rejects.toThrow(/private/);
+    await expect(guard('http://192.168.1.20/')).rejects.toThrow(/private/);
+    await expect(guard('http://[::1]/')).rejects.toThrow(/private/);
+    await expect(guard('http://[fe80::1]/')).rejects.toThrow(/private/);
+    // public addresses stay reachable
+    await expect(guard('http://93.184.216.34/')).resolves.toBeUndefined();
+  });
+
+  it('rejects malformed URLs', async () => {
+    const guard = await loadGuard(false);
+    await expect(guard('not a url')).rejects.toThrow(/valid URL/);
+  });
+});

--- a/apps/api/src/common/url-guard.ts
+++ b/apps/api/src/common/url-guard.ts
@@ -1,0 +1,108 @@
+/**
+ * outbound-destination guard for hook HTTP deliveries (SSRF).
+ *
+ * two tiers:
+ *  - cloud metadata endpoints (169.254.169.254 and friends) are ALWAYS
+ *    blocked — no legitimate bridge posts rows to an instance-metadata API,
+ *    and they are the highest-value SSRF target.
+ *  - loopback / private / link-local ranges are blocked only when
+ *    SYNCLE_BLOCK_PRIVATE_DESTINATIONS=true. Syncle is local-first, and
+ *    posting to a service on localhost is a primary, documented use case —
+ *    the strict tier exists for network-exposed deployments.
+ *
+ * the caller must also disable redirect-following: a public host that 302s to
+ * an internal address would otherwise bypass any pre-flight check.
+ */
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import { BadRequestError } from '@syncle/core';
+import { runtimeConfig } from './runtime-config';
+
+/** instance-metadata addresses, blocked unconditionally */
+const METADATA_ADDRS = new Set([
+  '169.254.169.254', // AWS / GCP / Azure / OpenStack IMDS
+  'fd00:ec2::254', // AWS IMDSv2 over IPv6
+  '100.100.100.200', // Alibaba Cloud
+]);
+
+function isPrivateV4(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
+  const [a, b] = parts as [number, number, number, number];
+  return (
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    a === 0
+  );
+}
+
+function isPrivateV6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  return (
+    lower === '::1' ||
+    lower === '::' ||
+    lower.startsWith('fe80:') || // link-local
+    lower.startsWith('fc') || // ULA fc00::/7
+    lower.startsWith('fd') ||
+    lower.startsWith('::ffff:127.') || // v4-mapped loopback
+    lower.startsWith('::ffff:10.') ||
+    lower.startsWith('::ffff:192.168.') ||
+    lower.startsWith('::ffff:169.254.')
+  );
+}
+
+function normalizeAddr(ip: string): string {
+  // strip a v4-mapped prefix so METADATA_ADDRS matches either notation
+  const lower = ip.toLowerCase();
+  return lower.startsWith('::ffff:') && isIP(lower.slice(7)) === 4
+    ? lower.slice(7)
+    : lower;
+}
+
+/**
+ * throw when `rawUrl` may not be used as a delivery destination. resolves the
+ * hostname so DNS-based dodges (a public name pointing at an internal IP) are
+ * caught at the same tier as literal addresses.
+ */
+export async function assertAllowedDestination(rawUrl: string): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new BadRequestError('Destination is not a valid URL.');
+  }
+  const host = url.hostname.replace(/^\[|\]$/g, ''); // [::1] → ::1
+
+  const addrs: string[] = [];
+  if (isIP(host)) {
+    addrs.push(host);
+  } else {
+    try {
+      const resolved = await lookup(host, { all: true, verbatim: true });
+      addrs.push(...resolved.map((r) => r.address));
+    } catch {
+      // unresolvable hosts fail at fetch time with a clearer network error
+      return;
+    }
+  }
+
+  for (const raw of addrs) {
+    const addr = normalizeAddr(raw);
+    if (METADATA_ADDRS.has(addr)) {
+      throw new BadRequestError(
+        'Destination resolves to a cloud metadata endpoint, which is not allowed.',
+      );
+    }
+    if (
+      runtimeConfig.blockPrivateDestinations &&
+      (isPrivateV4(addr) || isPrivateV6(addr))
+    ) {
+      throw new BadRequestError(
+        `Destination resolves to a private address (${addr}); this deployment only allows public destinations (SYNCLE_BLOCK_PRIVATE_DESTINATIONS).`,
+      );
+    }
+  }
+}

--- a/apps/api/src/connections/adapter-pool.service.ts
+++ b/apps/api/src/connections/adapter-pool.service.ts
@@ -5,6 +5,7 @@
  */
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { createAdapter } from '@syncle/core/adapters';
+import { runtimeConfig } from '../common/runtime-config';
 import type { ConnectionConfig, DatabaseAdapter } from '@syncle/core';
 import { SettingsStoreService } from '../settings/settings-store.service';
 import { ConnectionStoreService } from './connection-store.service';
@@ -92,7 +93,7 @@ export class AdapterPoolService implements OnModuleDestroy {
       this.entries.delete(key);
       await stale.adapter.close().catch(() => {});
     }
-    const adapter = createAdapter(config);
+    const adapter = createAdapter(withServerRestrictions(config));
     await adapter.connect();
     this.entries.set(key, {
       adapter,
@@ -116,7 +117,7 @@ export class AdapterPoolService implements OnModuleDestroy {
 
   /** build a one-off adapter from a raw config (used by "test connection") */
   async test(config: ConnectionConfig): Promise<void> {
-    const adapter = createAdapter(config);
+    const adapter = createAdapter(withServerRestrictions(config));
     try {
       await adapter.connect();
       await adapter.ping();
@@ -145,4 +146,16 @@ export class AdapterPoolService implements OnModuleDestroy {
       targets.map(([, entry]) => entry.adapter.close().catch(() => {})),
     );
   }
+}
+
+/**
+ * server-side config restrictions applied to every adapter, whatever store
+ * the config came from: the SQLite path jail (SYNCLE_SQLITE_DIR) must not be
+ * bypassable by anything a client can persist.
+ */
+function withServerRestrictions<T extends { engine: string }>(config: T): T {
+  if (config.engine === 'sqlite' && runtimeConfig.sqliteBaseDir) {
+    return { ...config, fileBaseDir: runtimeConfig.sqliteBaseDir };
+  }
+  return config;
 }

--- a/apps/api/src/hooks/delivery.service.ts
+++ b/apps/api/src/hooks/delivery.service.ts
@@ -8,6 +8,7 @@
  */
 import { Injectable, Logger } from '@nestjs/common';
 import type { HookDeliveryConfig, HttpDestination } from '@syncle/core';
+import { assertAllowedDestination } from '../common/url-guard';
 import type { DeliveryOutcome } from './hooks.types';
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
@@ -77,12 +78,22 @@ export class DeliveryService {
       const timeout = AbortSignal.timeout(delivery.timeoutMs);
       const signal = AbortSignal.any([runSignal, timeout]);
       try {
+        // SSRF guard: metadata endpoints always, private ranges when the
+        // deployment opts in. redirects are surfaced instead of followed so a
+        // public host can't 302 the delivery to an internal address.
+        await assertAllowedDestination(dest.url);
         const res = await fetch(dest.url, {
           method: dest.method,
           headers,
           body: payload,
           signal,
+          redirect: 'manual',
         });
+        if (res.status >= 300 && res.status < 400) {
+          lastStatus = res.status;
+          lastError = `HTTP ${res.status}: redirects are not followed — point the destination at the final URL`;
+          break;
+        }
         lastStatus = res.status;
         lastResponse = (await readBodyCapped(res)).slice(0, RESPONSE_LIMIT);
 

--- a/apps/web/src/components/auth/setup-screen.tsx
+++ b/apps/web/src/components/auth/setup-screen.tsx
@@ -25,6 +25,7 @@ export function SetupScreen() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
+  const [setupToken, setSetupToken] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   async function handleSubmit() {
@@ -42,9 +43,17 @@ export function SetupScreen() {
       setError(t('passwordsNoMatch'));
       return;
     }
+    if (!setupToken.trim()) {
+      setError(t('tokenMissing'));
+      return;
+    }
     setError(null);
     try {
-      await setup.mutateAsync({ username: username.trim(), password });
+      await setup.mutateAsync({
+        username: username.trim(),
+        password,
+        setupToken: setupToken.trim(),
+      });
     } catch (err) {
       const message =
         err instanceof ApiError ? err.message : tc('somethingWrong');
@@ -116,6 +125,16 @@ export function SetupScreen() {
                 value={confirm}
                 onChange={(e) => setConfirm(e.target.value)}
               />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="setup-token">{t('token')}</Label>
+              <Input
+                id="setup-token"
+                autoComplete="off"
+                value={setupToken}
+                onChange={(e) => setSetupToken(e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs">{t('tokenHint')}</p>
             </div>
             {error && <p className="text-destructive text-sm">{error}</p>}
             <Button type="submit" className="w-full" disabled={setup.isPending}>

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -41,7 +41,10 @@
       "usernameTooShort": "Username must be at least 3 characters.",
       "passwordTooShort": "Password must be at least 8 characters.",
       "passwordsNoMatch": "Passwords do not match.",
-      "couldNotCreate": "Could not create account"
+      "couldNotCreate": "Could not create account",
+      "token": "Setup token",
+      "tokenHint": "Printed in the server logs when Syncle starts — it proves you operate this server.",
+      "tokenMissing": "Enter the setup token from the server logs."
     }
   },
   "userMenu": {

--- a/apps/web/src/messages/zh.json
+++ b/apps/web/src/messages/zh.json
@@ -41,7 +41,10 @@
       "usernameTooShort": "用户名至少 3 个字符。",
       "passwordTooShort": "密码至少 8 个字符。",
       "passwordsNoMatch": "两次输入的密码不一致。",
-      "couldNotCreate": "无法创建账号"
+      "couldNotCreate": "无法创建账号",
+      "token": "初始化令牌",
+      "tokenHint": "Syncle 启动时打印在服务器日志中——用于证明你是这台服务器的运维者。",
+      "tokenMissing": "请输入服务器日志中的初始化令牌。"
     }
   },
   "userMenu": {

--- a/packages/core/src/adapters/sql/sqlite-adapter.test.ts
+++ b/packages/core/src/adapters/sql/sqlite-adapter.test.ts
@@ -1,8 +1,8 @@
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { rmSync } from 'node:fs';
+import { join, sep } from 'node:path';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { BadRequestError } from '../../errors';
+import { BadRequestError, ConnectionError } from '../../errors';
 import type { ConnectionConfig } from '../types';
 import { assertSafeDefaultValue } from './base-sql-adapter';
 import { SqliteAdapter } from './sqlite-adapter';
@@ -315,5 +315,59 @@ describe('assertSafeDefaultValue', () => {
     ]) {
       expect(() => assertSafeDefaultValue(bad)).toThrow(BadRequestError);
     }
+  });
+});
+
+describe('SqliteAdapter fileBaseDir jail', () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'syncle-jail-'));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  function jailed(file: string): SqliteAdapter {
+    return new SqliteAdapter({ ...makeConfig(file), fileBaseDir: base });
+  }
+
+  it('resolves relative paths under the base directory', async () => {
+    const adapter = jailed('data.db');
+    await adapter.connect();
+    await adapter.ping();
+    await adapter.close();
+    expect(existsSync(join(base, 'data.db'))).toBe(true);
+  });
+
+  it('allows absolute paths inside the base directory', async () => {
+    const adapter = jailed(join(base, 'inner.db'));
+    await adapter.connect();
+    await adapter.close();
+    expect(existsSync(join(base, 'inner.db'))).toBe(true);
+  });
+
+  it('rejects ../ traversal out of the base directory', async () => {
+    await expect(jailed('../escape.db').connect()).rejects.toThrow(
+      ConnectionError,
+    );
+    await expect(
+      jailed(join('sub', '..', '..', 'escape.db')).connect(),
+    ).rejects.toThrow(/restricted/);
+  });
+
+  it('rejects absolute paths outside the base directory', async () => {
+    await expect(jailed(join(tmpdir(), 'outside.db')).connect()).rejects.toThrow(
+      /restricted/,
+    );
+    await expect(jailed('/etc/passwd').connect()).rejects.toThrow(/restricted/);
+  });
+
+  it('rejects a sibling directory sharing the base as a name prefix', async () => {
+    // base "/x/jail" must not admit "/x/jail-evil/f.db" (string-prefix pitfall)
+    await expect(jailed(`${base}-evil${sep}f.db`).connect()).rejects.toThrow(
+      /restricted/,
+    );
   });
 });

--- a/packages/core/src/adapters/sql/sqlite-adapter.ts
+++ b/packages/core/src/adapters/sql/sqlite-adapter.ts
@@ -1,4 +1,5 @@
 /** SQLite adapter backed by `better-sqlite3` (synchronous, single file) */
+import { isAbsolute, resolve, sep } from 'node:path';
 import Database from 'better-sqlite3';
 import type {
   AdapterCapabilities,
@@ -59,9 +60,21 @@ export class SqliteAdapter extends BaseSqlAdapter {
 
   private getDb(): Database.Database {
     if (this.db) return this.db;
-    const file = this.config.database ?? this.config.connectionString;
+    let file = this.config.database ?? this.config.connectionString;
     if (!file) {
       throw new ConnectionError('SQLite requires a database file path');
+    }
+    // honor the server-configured jail: resolve relative paths under it and
+    // refuse anything (including ../ traversal) that escapes it
+    if (this.config.fileBaseDir) {
+      const base = resolve(this.config.fileBaseDir);
+      const resolved = isAbsolute(file) ? resolve(file) : resolve(base, file);
+      if (resolved !== base && !resolved.startsWith(base + sep)) {
+        throw new ConnectionError(
+          `SQLite files are restricted to ${base} on this server`,
+        );
+      }
+      file = resolved;
     }
     try {
       this.db = new Database(file, { fileMustExist: false });

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -78,6 +78,11 @@ export interface ConnectionConfig {
   connectionString?: string;
   /** free-form engine-specific options (e.g. Mongo authSource, Redis db index) */
   options?: Record<string, unknown>;
+  /**
+   * server-set restriction (never user input): when present, file-backed
+   * engines (SQLite) may only open paths under this directory
+   */
+  fileBaseDir?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -21,6 +21,8 @@ const passwordSchema = z
 export const setupSchema = z.object({
   username: usernameSchema,
   password: passwordSchema,
+  /** one-time token printed to the server console on first boot (TOFU guard) */
+  setupToken: z.string().min(1, 'Setup token is required').max(64),
 });
 
 export const loginSchema = z.object({

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -9,6 +9,7 @@ export type AppErrorCode =
   | 'FORBIDDEN'
   | 'NOT_FOUND'
   | 'CONFLICT'
+  | 'RATE_LIMITED'
   | 'CONNECTION_FAILED'
   | 'QUERY_FAILED'
   | 'UNSUPPORTED'


### PR DESCRIPTION
Closes the confirmed security findings:

- **First-run takeover (TOFU)**: `/auth/setup` was unauthenticated — whoever reached a fresh deployment first owned it. Setup now requires a one-time token printed to the server console at boot; the web setup screen gains the field (en + zh).
- **Login brute force**: login and setup rate-limit repeated failures with a per-IP/per-account sliding lockout (exponential backoff, capped). New `RATE_LIMITED` error code (HTTP 429).
- **SSRF on HTTP destinations**: deliveries never follow redirects (a public host could 302 to an internal address), always refuse cloud metadata endpoints (`169.254.169.254`, `fd00:ec2::254`, Alibaba), and — when `SYNCLE_BLOCK_PRIVATE_DESTINATIONS=true` — refuse loopback/private/link-local ranges after DNS resolution. Off by default because posting to localhost services is a primary local-first use case.
- **GCM tag truncation**: decryption rejects any auth tag that isn't the full 16 bytes (Node accepts 4-byte tags, collapsing forgery resistance).
- **Key separation**: session cookies are now signed with an HKDF-derived sub-key (`info='syncle-session-sig'`) instead of the raw master key. Existing encrypted credentials still decrypt unchanged; outstanding sessions are invalidated once (one re-login).
- **SQLite path jail**: `SYNCLE_SQLITE_DIR` restricts which files SQLite connections may open/create, applied server-side in the adapter pool so no persisted config can bypass it.
- **SECURITY.md** rewritten to describe the real model (it claimed there was no auth layer).

Tests: 8 new API unit tests (limiter lockout/backoff, guard classification incl. v4-mapped metadata, crypto round-trip + truncated-tag rejection). `pnpm typecheck` and the full suite pass.