### PR TITLE
fix(api): retry and database-sink integrity for hook deliveries

### DIFF
--- a/apps/api/prisma/migrations/20260820000000_delivery_retry_integrity/migration.sql
+++ b/apps/api/prisma/migrations/20260820000000_delivery_retry_integrity/migration.sql
@@ -1,0 +1,12 @@
+-- Retry integrity for hook deliveries:
+--  * "op" — the CDC operation behind the delivery, so a resend replays a
+--    delete as a keyed delete instead of resurrecting the deleted row.
+--  * "body_truncated" — the captured request body was cut at the storage cap
+--    and can no longer be replayed faithfully; resends refuse such deliveries.
+--  * "succeeded_targets_json" — database-sink fan-out: target keys that have
+--    already committed, so a retry skips them instead of double-writing.
+
+-- AlterTable
+ALTER TABLE "hook_deliveries" ADD COLUMN "op" TEXT;
+ALTER TABLE "hook_deliveries" ADD COLUMN "body_truncated" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "hook_deliveries" ADD COLUMN "succeeded_targets_json" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -160,6 +160,9 @@ model HookDelivery {
   requestBody     String?  @map("request_body")     // exact JSON body sent (capped)
   responseBody    String?  @map("response_body")     // full response text (capped)
   durationMs      Int?     @map("duration_ms")
+  op              String?  // CDC operation ('insert' | 'update' | 'delete') — a resend must replay a delete as a delete
+  bodyTruncated   Boolean  @default(false) @map("body_truncated") // requestBody was cut at the storage cap; resends refuse it
+  succeededTargetsJson String? @map("succeeded_targets_json") // database sink: target keys already written (skipped on retry)
   createdAt       DateTime @default(now()) @map("created_at")
 
   run HookRun @relation(fields: [runId], references: [id], onDelete: Cascade)

--- a/apps/api/src/hooks/database-sink.service.ts
+++ b/apps/api/src/hooks/database-sink.service.ts
@@ -20,12 +20,12 @@
  * per-row upsert/delete instead, which is equally retry-safe.
  *
  * cross-target retry: the delivery is still reported failed if ANY target
- * fails (the monitor depends on that single-outcome contract). there is no
- * per-target retry checkpoint here, so a full-delivery retry re-runs every
- * target — that is safe because every write path is either transactionally
- * atomic or an idempotent upsert/delete; the only non-idempotent path is
- * `insert` mode, whose batch is now atomic so a retry re-applies the whole
- * batch cleanly rather than duplicating a committed prefix.
+ * fails (the monitor depends on that single-outcome contract), but the outcome
+ * carries the keys of the targets that DID commit ({@link DeliveryOutcome}'s
+ * `succeededTargets`, persisted with the delivery row). a retry passes those
+ * back as `skipTargets` so already-committed targets are skipped, not re-run —
+ * without that checkpoint, `insert` mode would duplicate target A's atomic
+ * batch on every retry that only target B needs.
  */
 import { Injectable, Logger } from '@nestjs/common';
 import {
@@ -67,22 +67,35 @@ export class DatabaseSinkService {
    * write a batch of rows to every target. `op` is the CDC operation when the
    * rows came from a change stream (`delete` removes by key); for replay/watch
    * it's undefined and rows are inserted/upserted per the target's writeMode.
+   * `skipTargets` are target keys that already committed on a previous attempt
+   * (from the persisted delivery); those are skipped, never re-written.
    */
   async deliver(
     hook: ResolvedHook,
     targets: DatabaseTarget[],
     rows: Row[],
     op: CdcOperation | undefined,
+    skipTargets?: ReadonlySet<string>,
   ): Promise<DeliveryOutcome> {
     const started = performance.now();
     const summaries: string[] = [];
+    const succeeded: string[] = [];
     let firstError: string | null = null;
 
     for (const target of targets) {
       const label = targetLabel(target);
+      const key = targetKey(target);
+      // committed on an earlier attempt of this same delivery: skip, but keep
+      // it in the succeeded set so the checkpoint survives another failure
+      if (skipTargets?.has(key)) {
+        succeeded.push(key);
+        summaries.push(`${label}: skipped (already written by a previous attempt)`);
+        continue;
+      }
       try {
         await this.ensureTarget(hook, target, rows[0] ?? {});
         const affected = await this.writeRows(target, rows, op);
+        succeeded.push(key);
         summaries.push(`${label}: ${op === 'delete' ? 'deleted' : 'wrote'} ${affected}`);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -94,9 +107,10 @@ export class DatabaseSinkService {
     // requestBody mirrors what we attempted to write (mapped to the first
     // target's columns), so the monitor can show the exact payload
     const mappedPreview = rows.map((r) => mapRow(r, targets[0]?.mapping ?? []));
-    const requestBody = JSON.stringify(
+    const serialized = JSON.stringify(
       mappedPreview.length === 1 ? mappedPreview[0] : mappedPreview,
-    ).slice(0, SUMMARY_LIMIT);
+    );
+    const requestBody = serialized.slice(0, SUMMARY_LIMIT);
 
     return {
       status: firstError ? 'failed' : 'success',
@@ -106,6 +120,11 @@ export class DatabaseSinkService {
       requestBody,
       responseBody: summaries.join('\n').slice(0, SUMMARY_LIMIT) || null,
       durationMs: Math.round(performance.now() - started),
+      op: op ?? null,
+      // a capped capture can't be replayed faithfully; the resend path refuses it
+      bodyTruncated: serialized.length > SUMMARY_LIMIT,
+      // checkpoint only matters while the delivery is failed; a success clears it
+      succeededTargets: firstError ? succeeded : null,
     };
   }
 
@@ -219,7 +238,7 @@ export class DatabaseSinkService {
     }
 
     const engine = (await this.connections.resolve(target.connectionId)).engine;
-    const columns = this.targetColumns(hook, target, sampleRow);
+    const columns = await this.targetColumns(hook, target, sampleRow);
     if (columns.length === 0) {
       throw new Error('Cannot create target table: no columns to derive');
     }
@@ -242,19 +261,75 @@ export class DatabaseSinkService {
 
   /**
    * the target's columns to create: the mapped target names, typed from the
-   * source schema where known, otherwise inferred from a sample row's values.
+   * source table's REAL column types (schema introspection, cached per hook)
+   * so bridge.ts's normalizeType/engineColumnType translation gets a proper
+   * dataType string — a pg BIGINT/NUMERIC arrives as a string at runtime and
+   * would otherwise decay to TEXT. only when no schema is available (query
+   * source, introspection failure, renamed column) do we fall back to
+   * inferring a column's type from the sample row's runtime value.
    */
-  private targetColumns(
+  private async targetColumns(
     hook: ResolvedHook,
     target: DatabaseTarget,
     sampleRow: Row,
-  ): TargetColumnShape[] {
-    const mapped = mapRow(sampleRow, target.mapping);
-    return Object.entries(mapped).map(([name, value]) => ({
-      name,
-      sourceType: inferType(value),
-      nullable: !target.keyColumns.includes(name),
-    }));
+  ): Promise<TargetColumnShape[]> {
+    const source = await this.resolveSourceCols(hook);
+    const byName = new Map((source ?? []).map((c) => [c.name, c]));
+    const mappedSample = mapRow(sampleRow, target.mapping);
+
+    // which target columns to create: the explicit mapping, else identity over
+    // the source schema when known, else whatever the sample row carries
+    const pairs: { name: string; source: string }[] =
+      target.mapping.length > 0
+        ? target.mapping.map((m) => ({ name: m.target, source: m.source }))
+        : source
+          ? source.map((c) => ({ name: c.name, source: c.name }))
+          : Object.keys(mappedSample).map((name) => ({ name, source: name }));
+
+    return pairs.map(({ name, source: sourceName }) => {
+      const known = byName.get(sourceName);
+      return {
+        name,
+        sourceType: known ? known.sourceType : inferType(mappedSample[name]),
+        nullable: known ? known.nullable : !target.keyColumns.includes(name),
+      };
+    });
+  }
+
+  /**
+   * the source table's column shapes (name / dataType / nullable), resolved
+   * once per hook via schema introspection and cached in {@link sourceCols}.
+   * a cached `null` means the shape is unknowable (query source, or
+   * introspection failed) and callers fall back to sample-row inference.
+   */
+  private async resolveSourceCols(hook: ResolvedHook): Promise<TargetColumnShape[] | null> {
+    const cached = this.sourceCols.get(hook.id);
+    if (cached !== undefined) return cached;
+
+    let cols: TargetColumnShape[] | null = null;
+    if (hook.source.kind === 'table') {
+      const src = hook.source;
+      try {
+        const schema = await this.pool.withAdapter(src.connectionId, src.database, (a) =>
+          a.getSchema(src.database),
+        );
+        const table = schema.namespaces
+          .filter((ns) => !src.schema || ns.name === src.schema)
+          .flatMap((ns) => ns.tables)
+          .find((t) => t.name === src.table);
+        if (table) {
+          cols = table.columns.map((c) => ({
+            name: c.name,
+            sourceType: c.dataType,
+            nullable: c.nullable,
+          }));
+        }
+      } catch {
+        /* introspection unavailable (engine/permissions), fall back to inference */
+      }
+    }
+    this.sourceCols.set(hook.id, cols);
+    return cols;
   }
 }
 

--- a/apps/api/src/hooks/delivery.service.ts
+++ b/apps/api/src/hooks/delivery.service.ts
@@ -66,6 +66,9 @@ export class DeliveryService {
     const headers = this.buildHeaders(dest, idempotencyKey);
     const payload = JSON.stringify(body ?? null);
     const requestBody = payload.slice(0, RESPONSE_LIMIT);
+    // a capture cut at the cap can never be JSON.parsed back for a resend, so
+    // flag it — the retry path refuses these instead of re-sending garbage
+    const bodyTruncated = payload.length > RESPONSE_LIMIT;
     const started = performance.now();
     let lastError: string | null = null;
     let lastStatus: number | null = null;
@@ -95,6 +98,7 @@ export class DeliveryService {
             requestBody,
             responseBody: lastResponse || null,
             durationMs: Math.round(performance.now() - started),
+            bodyTruncated,
           };
         }
 
@@ -124,6 +128,7 @@ export class DeliveryService {
       requestBody,
       responseBody: lastResponse,
       durationMs: Math.round(performance.now() - started),
+      bodyTruncated,
     };
   }
 

--- a/apps/api/src/hooks/hook-run.processor.ts
+++ b/apps/api/src/hooks/hook-run.processor.ts
@@ -63,7 +63,14 @@ export class HookRunProcessor extends WorkerHost {
 
     const controller = this.registry.register(runId);
     try {
-      await this.execute(runId, row.cursorOffset, row.configSnapshotJson, controller.signal);
+      // 'resend' jobs re-POST the captured payloads of failed deliveries; a
+      // normal run streams rows from the source. both share the registry's
+      // abort machinery so cancel works identically for either mode.
+      if (job.data.mode === 'resend') {
+        await this.runs.executeResend(runId, controller.signal);
+      } else {
+        await this.execute(runId, row.cursorOffset, row.configSnapshotJson, controller.signal);
+      }
     } finally {
       this.registry.release(runId);
     }
@@ -86,6 +93,9 @@ export class HookRunProcessor extends WorkerHost {
       hook.source.kind === 'table' ? await this.resolvePk(hook.source) : null;
     // sequences we must not (re)send: already delivered, or skipped
     const done = await this.runs.settledSequences(runId);
+    // database targets that already committed inside failed deliveries: a
+    // retry must skip those targets or insert mode would duplicate their rows
+    const priorTargets = await this.runs.succeededTargetsBySequence(runId);
 
     // control polling is throttled to keep DB load negligible on big runs. it
     // serves two cross-process signals: cancellation (any worker may own the
@@ -115,7 +125,7 @@ export class HookRunProcessor extends WorkerHost {
         }
         buffer.push(item.row);
         if (buffer.length === batchSize) {
-          const stop = await this.flush(runId, table, buffer, bufferStart, done, hook, pkColumn, signal);
+          const stop = await this.flush(runId, table, buffer, bufferStart, done, priorTargets, hook, pkColumn, signal);
           buffer = [];
           bufferStart = item.index + 1;
           await this.runs.setCursor(runId, bufferStart);
@@ -132,7 +142,7 @@ export class HookRunProcessor extends WorkerHost {
           await this.runs.finalize(runId, 'canceled');
           return;
         }
-        const stop = await this.flush(runId, table, buffer, bufferStart, done, hook, pkColumn, signal);
+        const stop = await this.flush(runId, table, buffer, bufferStart, done, priorTargets, hook, pkColumn, signal);
         if (stop) {
           await this.runs.finalize(runId, 'failed', 'Stopped after a failed delivery (onError=abort).');
           return;
@@ -158,6 +168,7 @@ export class HookRunProcessor extends WorkerHost {
     rows: Record<string, unknown>[],
     startIndex: number,
     done: Set<number>,
+    priorTargets: Map<number, string[]>,
     hook: ResolvedHook,
     pkColumn: string | null,
     signal: AbortSignal,
@@ -170,7 +181,7 @@ export class HookRunProcessor extends WorkerHost {
     const { outcome } = await this.sink.deliver(
       hook,
       rows,
-      { table, now, startIndex },
+      { table, now, startIndex, skipTargets: priorTargets.get(sequence) },
       signal,
       `${runId}:${sequence}`,
     );

--- a/apps/api/src/hooks/hook-run.service.ts
+++ b/apps/api/src/hooks/hook-run.service.ts
@@ -14,6 +14,7 @@ import {
   AppError,
   BadRequestError,
   ConflictError,
+  type CdcOperation,
   type DeliveryStatus,
   type HookDelivery,
   type HookRun,
@@ -60,10 +61,19 @@ export class HookRunService implements OnModuleInit {
   ) {}
 
   /**
-   * re-send the failed deliveries of a run by re-POSTing their captured request
-   * bodies to the hook's CURRENT destination. works for every hook type
+   * queue a RESEND of a run's failed deliveries: their captured request bodies
+   * are re-POSTed to the hook's CURRENT destination, works for every hook type
    * (replay / watch / cdc), ideal after fixing a bad URL or a down endpoint.
    * a delivery that succeeds flips from failed to success (counters adjust).
+   *
+   * two retry flavors exist, keep them straight:
+   *  - resend (this): re-send the CAPTURED payloads as-is, no source access.
+   *  - retryFailed (`start({retryFailedOf})`): re-STREAM the failed rows from
+   *    the source and re-render them (fresh data, fresh config).
+   *
+   * the loop itself runs on the BullMQ worker ({@link executeResend}) so this
+   * endpoint returns immediately and the operation is cancelable through the
+   * run registry, exactly like a normal run.
    */
   async resendFailed(hookId: string, runId: string): Promise<HookRun> {
     const run = await this.getRunRow(runId);
@@ -75,51 +85,164 @@ export class HookRunService implements OnModuleInit {
         'This run is still active. Stop it (or wait for it to finish) before retrying failed deliveries.',
       );
     }
-    const hook = await this.store.resolve(hookId);
+    await this.store.get(hookId); // 404s if the hook is gone
+    const failedCount = await this.prisma.hookDelivery.count({
+      where: { runId, status: 'failed' },
+    });
+    if (failedCount === 0) throw new BadRequestError('No failed deliveries to retry.');
+
+    await this.ensureQueueReady();
+    await this.clearSettledJob(runId);
+    const row = await this.prisma.hookRun.update({
+      where: { id: runId },
+      data: { status: 'queued', error: null, finishedAt: null },
+    });
+    await this.enqueue(runId, hookId, 'resend');
+    return this.toRun(row);
+  }
+
+  /**
+   * worker-side body of a resend (see {@link resendFailed}), invoked by the
+   * processor with the run registry's abort signal so a cancel stops it
+   * between deliveries. deliveries that cannot be replayed faithfully — the
+   * captured body was truncated at the storage cap, or no rows can be
+   * recovered from it — are refused with a per-delivery error and stay
+   * failed; they must be retried from the source instead. a database delivery
+   * is NEVER flipped to success unless rows were actually written.
+   */
+  async executeResend(runId: string, signal: AbortSignal): Promise<void> {
+    const run = await this.getRunRow(runId);
+    await this.markRunning(runId);
+    const hook = await this.store.resolve(run.hookId);
     const failed = await this.prisma.hookDelivery.findMany({
       where: { runId, status: 'failed' },
       orderBy: { sequence: 'asc' },
       take: 2000,
     });
-    if (failed.length === 0) throw new BadRequestError('No failed deliveries to retry.');
-
     const dest = hook.destination;
-    const signal = new AbortController().signal;
-    for (const d of failed) {
-      let body: unknown = null;
-      if (d.requestBody) {
-        try {
-          body = JSON.parse(d.requestBody);
-        } catch {
-          body = d.requestBody;
+
+    // cross-process control polling, throttled like the run processor's.
+    // 'canceled' = a cancel was requested; 'detached' = something else already
+    // re-statused the run (e.g. watch/cdc stop() paused it out from under us),
+    // so stand down WITHOUT overwriting that externally-set status.
+    let lastControlCheck = 0;
+    const stopRequested = async (): Promise<'canceled' | 'detached' | null> => {
+      if (signal.aborted) return 'canceled';
+      const now = Date.now();
+      if (now - lastControlCheck < 750) return null;
+      lastControlCheck = now;
+      const r = await this.prisma.hookRun.findUnique({
+        where: { id: runId },
+        select: { status: true },
+      });
+      if (!r || r.status === 'canceling' || r.status === 'canceled') return 'canceled';
+      return r.status === 'running' ? null : 'detached';
+    };
+
+    try {
+      for (const d of failed) {
+        const stop = await stopRequested();
+        if (stop) {
+          if (stop === 'canceled') await this.finalize(runId, 'canceled');
+          return;
         }
-      }
-      let outcome: DeliveryOutcome;
-      if (dest.kind === 'database') {
-        // the captured requestBody is the already-mapped target row(s); replay
-        // it through the sink with identity mapping (the upsert is idempotent)
-        const rows = (Array.isArray(body) ? body : [body]).filter(
-          (r): r is Record<string, unknown> => !!r && typeof r === 'object',
+
+        // a failed delivery keeps its existing (failed) status and context,
+        // only the error text changes to say why the resend refused it
+        const refuse = (why: string): DeliveryOutcome => ({
+          status: 'failed',
+          httpStatus: d.httpStatus,
+          attempts: d.attempts,
+          error: why,
+          requestBody: d.requestBody,
+          responseBody: d.responseBody,
+          durationMs: d.durationMs ?? 0,
+        });
+
+        let outcome: DeliveryOutcome;
+        if (d.bodyTruncated) {
+          // the capture was cut at the storage cap: re-sending it would push
+          // truncated garbage (HTTP) or write nothing at all (database)
+          outcome = refuse(
+            'The captured payload was truncated at the storage cap, so it cannot be re-sent faithfully. Retry the failed rows from the source instead.',
+          );
+        } else {
+          let body: unknown = null;
+          if (d.requestBody) {
+            try {
+              body = JSON.parse(d.requestBody);
+            } catch {
+              body = d.requestBody;
+            }
+          }
+          if (dest.kind === 'database') {
+            // the captured requestBody is the already-mapped target row(s);
+            // replay it through the sink with identity mapping, preserving the
+            // persisted operation so a CDC delete retries as a keyed delete —
+            // not as an upsert that would resurrect the deleted row
+            const rows = (Array.isArray(body) ? body : [body]).filter(
+              (r): r is Record<string, unknown> => !!r && typeof r === 'object',
+            );
+            if (rows.length === 0 && d.rowCount > 0) {
+              // nothing recoverable to write: succeeding here would flip the
+              // cell green while zero rows actually landed in the target
+              outcome = refuse(
+                'No rows could be recovered from the captured payload, so nothing would be written. Retry the failed rows from the source instead.',
+              );
+            } else {
+              const retryTargets = dest.targets.map((t) => ({ ...t, mapping: [] }));
+              const skip = d.succeededTargetsJson
+                ? new Set(JSON.parse(d.succeededTargetsJson) as string[])
+                : undefined;
+              outcome = await this.databaseSink.deliver(
+                hook,
+                retryTargets,
+                rows,
+                (d.op ?? undefined) as CdcOperation | undefined,
+                skip,
+              );
+            }
+          } else {
+            const idem = dest.idempotency ? `${runId}:${d.sequence}` : undefined;
+            outcome = await this.delivery.send(body, dest, hook.delivery, signal, idem);
+          }
+        }
+        await this.recordDelivery(
+          runId,
+          {
+            sequence: d.sequence,
+            rowIndex: d.rowIndex,
+            rowCount: d.rowCount,
+            rowKeys: d.rowKeysJson ? (JSON.parse(d.rowKeysJson) as unknown[]) : null,
+          },
+          outcome,
         );
-        const retryTargets = dest.targets.map((t) => ({ ...t, mapping: [] }));
-        outcome = await this.databaseSink.deliver(hook, retryTargets, rows, undefined);
-      } else {
-        const idem = dest.idempotency ? `${runId}:${d.sequence}` : undefined;
-        outcome = await this.delivery.send(body, dest, hook.delivery, signal, idem);
+        if (hook.delivery.minDelayMs) await sleep(hook.delivery.minDelayMs, signal);
       }
-      await this.recordDelivery(
+
+      const remaining = await this.prisma.hookDelivery.count({
+        where: { runId, status: 'failed' },
+      });
+      lastControlCheck = 0; // force a real status check before finalizing
+      const stop = await stopRequested();
+      if (stop) {
+        if (stop === 'canceled') await this.finalize(runId, 'canceled');
+        return;
+      }
+      await this.finalize(
         runId,
-        {
-          sequence: d.sequence,
-          rowIndex: d.rowIndex,
-          rowCount: d.rowCount,
-          rowKeys: d.rowKeysJson ? (JSON.parse(d.rowKeysJson) as unknown[]) : null,
-        },
-        outcome,
+        remaining === 0 ? 'completed' : 'failed',
+        remaining === 0
+          ? null
+          : `${remaining} deliver${remaining === 1 ? 'y is' : 'ies are'} still failing after the retry.`,
       );
-      if (hook.delivery.minDelayMs) await sleep(hook.delivery.minDelayMs);
+    } catch (err) {
+      if (signal.aborted || (await this.cancelRequested(runId))) {
+        await this.finalize(runId, 'canceled');
+        return;
+      }
+      await this.finalize(runId, 'failed', err instanceof Error ? err.message : String(err));
     }
-    return this.getRun(hookId, runId);
   }
 
   /* ----- prepare (queue without sending) ----- */
@@ -169,7 +292,15 @@ export class HookRunService implements OnModuleInit {
     hookId: string,
     opts: { resumeRunId?: string; runId?: string; retryFailedOf?: string } = {},
   ): Promise<HookRun> {
-    await this.store.get(hookId); // 404s if the hook is gone
+    const hook = await this.store.get(hookId); // 404s if the hook is gone
+    // replay-only: watch/CDC hooks are live listeners with their own start
+    // endpoint. pushing one through the replay queue would re-stream (and
+    // re-deliver) the WHOLE table instead of its changes.
+    if (hook.trigger.kind !== 'replay') {
+      throw new BadRequestError(
+        'This hook is event-driven, not replayable. Start listening with POST /hooks/:id/watch/start instead.',
+      );
+    }
 
     if (opts.retryFailedOf) return this.retryFailed(hookId, opts.retryFailedOf);
     if (opts.resumeRunId) return this.resume(hookId, opts.resumeRunId);
@@ -313,12 +444,36 @@ export class HookRunService implements OnModuleInit {
     return this.toRun(reset);
   }
 
-  private async enqueue(runId: string, hookId: string): Promise<void> {
+  private async enqueue(
+    runId: string,
+    hookId: string,
+    mode?: 'resend',
+  ): Promise<void> {
     await this.queue.add(
-      'run',
-      { runId, hookId },
+      mode ?? 'run',
+      { runId, hookId, ...(mode ? { mode } : {}) },
       { jobId: runId, removeOnComplete: true, removeOnFail: 500, attempts: 1 },
     );
+  }
+
+  /**
+   * deterministic jobId (= runId) means `add` is a no-op if a job with that id
+   * already exists — including a LINGERING failed/completed one (removeOnFail
+   * keeps 500) — so clear those out first or the add silently does nothing.
+   * returns the lingering job's resend mode (if any) so boot recovery can
+   * re-enqueue an interrupted resend as a resend, not a fresh stream.
+   */
+  private async clearSettledJob(runId: string): Promise<'resend' | undefined> {
+    try {
+      const existing = await this.queue.getJob(runId);
+      if (!existing) return undefined;
+      const state = await existing.getState();
+      if (state === 'failed' || state === 'completed') await existing.remove();
+      return (existing.data as HookRunJob).mode;
+    } catch {
+      /* best-effort, the add that follows still surfaces real queue failures */
+      return undefined;
+    }
   }
 
   /** fail fast with a friendly message when Redis is unreachable */
@@ -552,6 +707,28 @@ export class HookRunService implements OnModuleInit {
     return new Set(rows.map((r) => r.sequence));
   }
 
+  /**
+   * per-sequence database-target keys that already committed inside a FAILED
+   * delivery (partial fan-out). the worker feeds these back to the sink on a
+   * retry so the targets that succeeded aren't written twice.
+   */
+  async succeededTargetsBySequence(runId: string): Promise<Map<number, string[]>> {
+    const rows = await this.prisma.hookDelivery.findMany({
+      where: { runId, status: 'failed', succeededTargetsJson: { not: null } },
+      select: { sequence: true, succeededTargetsJson: true },
+    });
+    const map = new Map<number, string[]>();
+    for (const r of rows) {
+      try {
+        const keys = JSON.parse(r.succeededTargetsJson!) as string[];
+        if (Array.isArray(keys) && keys.length > 0) map.set(r.sequence, keys);
+      } catch {
+        /* unreadable checkpoint: retry every target (safe for upsert/delete) */
+      }
+    }
+    return map;
+  }
+
   /** persist one delivery and advance the run's counters atomically */
   async recordDelivery(
     runId: string,
@@ -588,6 +765,25 @@ export class HookRunService implements OnModuleInit {
     if (failed !== 0) counters.failedCount = { increment: failed };
     if (skipped !== 0) counters.skippedCount = { increment: skipped };
 
+    // retry-integrity fields: `undefined` means "the outcome doesn't know",
+    // which preserves the stored value on a re-record (e.g. a refused resend
+    // must keep the original op and truncation flag intact)
+    const succeededTargetsJson =
+      outcome.succeededTargets !== undefined
+        ? {
+            succeededTargetsJson: outcome.succeededTargets?.length
+              ? JSON.stringify(outcome.succeededTargets)
+              : null,
+          }
+        : {};
+    const integrity = {
+      ...(outcome.op !== undefined ? { op: outcome.op } : {}),
+      ...(outcome.bodyTruncated !== undefined
+        ? { bodyTruncated: outcome.bodyTruncated }
+        : {}),
+      ...succeededTargetsJson,
+    };
+
     await this.prisma.$transaction([
       this.prisma.hookDelivery.upsert({
         where: { runId_sequence: { runId, sequence: meta.sequence } },
@@ -605,6 +801,7 @@ export class HookRunService implements OnModuleInit {
           requestBody: outcome.requestBody,
           responseBody: outcome.responseBody,
           durationMs: outcome.durationMs,
+          ...integrity,
         },
         update: {
           rowKeysJson,
@@ -615,6 +812,7 @@ export class HookRunService implements OnModuleInit {
           requestBody: outcome.requestBody,
           responseBody: outcome.responseBody,
           durationMs: outcome.durationMs,
+          ...integrity,
         },
       }),
       this.prisma.hookRun.update({ where: { id: runId }, data: counters }),
@@ -651,19 +849,10 @@ export class HookRunService implements OnModuleInit {
       // but are owned by their own services, never re-enqueue those here
       const hook = await this.store.get(r.hookId).catch(() => null);
       if (!hook || hook.trigger.kind !== 'replay') continue;
-      // deterministic jobId means adding is a no-op if the job already exists —
-      // including a LINGERING failed/completed one (removeOnFail keeps 500), so
-      // clear those out first or the recovery silently does nothing
-      try {
-        const existing = await this.queue.getJob(r.id);
-        if (existing) {
-          const state = await existing.getState();
-          if (state === 'failed' || state === 'completed') await existing.remove();
-        }
-      } catch {
-        /* best-effort, the add below still surfaces real queue failures */
-      }
-      await this.enqueue(r.id, r.hookId).catch((err) =>
+      // an interrupted resend must recover as a resend: re-streaming it would
+      // deliver nothing (its cursor sits at the end of the source)
+      const mode = await this.clearSettledJob(r.id);
+      await this.enqueue(r.id, r.hookId, mode).catch((err) =>
         this.logger.warn(
           `Could not re-enqueue run ${r.id}: ${(err as Error).message}`,
         ),

--- a/apps/api/src/hooks/hook-sink.service.ts
+++ b/apps/api/src/hooks/hook-sink.service.ts
@@ -29,6 +29,12 @@ export interface DeliverContext {
   startIndex: number;
   /** CDC operation, when rows came from a change stream */
   op?: CdcOperation;
+  /**
+   * database targets that already committed on a previous attempt of this same
+   * delivery (persisted target keys); the sink skips them on a retry so a
+   * partial fan-out failure can't double-write the targets that succeeded
+   */
+  skipTargets?: string[];
 }
 
 @Injectable()
@@ -54,6 +60,7 @@ export class HookSinkService {
         dest.targets,
         rows,
         ctx.op,
+        ctx.skipTargets ? new Set(ctx.skipTargets) : undefined,
       );
       return { outcome, warnings: [] };
     }
@@ -78,6 +85,8 @@ export class HookSinkService {
       signal,
       idempotencyKey,
     );
-    return { outcome, warnings };
+    // stamp the operation so it persists with the delivery row: a later resend
+    // must know e.g. that this batch was a CDC delete
+    return { outcome: { ...outcome, op: ctx.op ?? null }, warnings };
   }
 }

--- a/apps/api/src/hooks/hooks.types.ts
+++ b/apps/api/src/hooks/hooks.types.ts
@@ -4,6 +4,7 @@
  * a client (the API surface returns the redacted {@link Hook} from core).
  */
 import type {
+  CdcOperation,
   HookDeliveryConfig,
   HookDestination,
   HookSource,
@@ -23,7 +24,7 @@ export interface ResolvedHook {
   enabled: boolean;
 }
 
-/** outcome of a single HTTP delivery attempt sequence */
+/** outcome of a single delivery attempt sequence (HTTP or database sink) */
 export interface DeliveryOutcome {
   status: 'success' | 'failed';
   httpStatus: number | null;
@@ -32,12 +33,36 @@ export interface DeliveryOutcome {
   requestBody: string | null;
   responseBody: string | null;
   durationMs: number;
+  /**
+   * the CDC operation behind these rows (null = plain replay/watch write). a
+   * resend must know a delete was a delete, so it's persisted per delivery.
+   * `undefined` leaves the stored value untouched when re-recording.
+   */
+  op?: CdcOperation | null;
+  /**
+   * `requestBody` was cut at the storage cap and can no longer be replayed
+   * faithfully; the resend path refuses such deliveries instead of re-sending
+   * truncated garbage. `undefined` preserves the stored flag on re-record.
+   */
+  bodyTruncated?: boolean;
+  /**
+   * database sink only: target keys that committed. persisted on a failed
+   * fan-out delivery so a retry skips the targets that already wrote instead
+   * of double-applying them. `undefined` preserves the stored value.
+   */
+  succeededTargets?: string[] | null;
 }
 
 /** the BullMQ job payload for the `hook-runs` queue */
 export interface HookRunJob {
   runId: string;
   hookId: string;
+  /**
+   * 'resend' re-POSTs the captured request bodies of the run's failed
+   * deliveries (no source access); absent = a normal run that streams rows
+   * from the source.
+   */
+  mode?: 'resend';
 }
 
 /** the BullMQ job payload for a `hook-watch` poll cycle */

--- a/apps/api/test/database-sink.service.test.ts
+++ b/apps/api/test/database-sink.service.test.ts
@@ -1,0 +1,277 @@
+/**
+ * DatabaseSinkService tests with a stub adapter (no live database): CDC delete
+ * routing, the upsert-needs-keys guard, per-target skip on retry (fan-out
+ * partial-failure), and schema-driven typing for auto-created target tables.
+ */
+import 'reflect-metadata';
+import { describe, expect, it } from 'vitest';
+import type {
+  ColumnSchema,
+  CreateTableSpec,
+  DatabaseSchema,
+  DatabaseTarget,
+} from '@syncle/core';
+import { DatabaseSinkService } from '../src/hooks/database-sink.service';
+import type { ResolvedHook } from '../src/hooks/hooks.types';
+
+interface WriteCalls {
+  insert: Record<string, unknown>[];
+  upsert: Record<string, unknown>[];
+  delete: Record<string, unknown>[];
+  create: CreateTableSpec[];
+}
+
+/** a minimal adapter double; individual methods are overridden per test */
+function makeAdapter() {
+  const calls: WriteCalls = { insert: [], upsert: [], delete: [], create: [] };
+  const adapter = {
+    engine: 'postgres',
+    capabilities: { transactions: false },
+    browse: async (): Promise<unknown> => ({
+      rows: [],
+      columns: [],
+      rowCount: 0,
+      executionMs: 0,
+      total: 0,
+      hasMore: false,
+      primaryKey: [],
+    }),
+    getSchema: async (): Promise<DatabaseSchema> => {
+      throw new Error('introspection unavailable');
+    },
+    insertRow: async (p: Record<string, unknown>) => {
+      calls.insert.push(p);
+      return { affectedRows: 1 };
+    },
+    upsertRow: async (p: Record<string, unknown>) => {
+      calls.upsert.push(p);
+      return { affectedRows: 1 };
+    },
+    deleteRow: async (p: Record<string, unknown>) => {
+      calls.delete.push(p);
+      return { affectedRows: 1 };
+    },
+    createTable: async (spec: CreateTableSpec) => {
+      calls.create.push(spec);
+    },
+  };
+  return { adapter, calls };
+}
+
+/** service wired to stub adapters, keyed by connectionId */
+function makeService(adapters: Record<string, unknown>): DatabaseSinkService {
+  const pool = {
+    withAdapter: async (
+      connectionId: string,
+      _database: string | undefined,
+      fn: (a: unknown) => unknown,
+    ) => fn(adapters[connectionId]),
+  };
+  const connections = { resolve: async () => ({ engine: 'postgres' }) };
+  return new DatabaseSinkService(pool as never, connections as never);
+}
+
+function makeHook(): ResolvedHook {
+  return {
+    id: 'hook-1',
+    name: 'bridge',
+    source: { kind: 'table', connectionId: 'src', table: 'users' },
+    destination: { kind: 'database', targets: [] },
+    transform: { template: '{{$row}}' },
+    delivery: {
+      batchSize: 1,
+      maxAttempts: 1,
+      backoffMs: 0,
+      backoffMaxMs: 0,
+      minDelayMs: 0,
+      timeoutMs: 1000,
+      pageSize: 200,
+      onError: 'continue',
+    },
+    trigger: { kind: 'replay' },
+    enabled: true,
+  } as ResolvedHook;
+}
+
+function makeTarget(overrides: Partial<DatabaseTarget> = {}): DatabaseTarget {
+  return {
+    connectionId: 'dst',
+    table: 'users_copy',
+    writeMode: 'upsert',
+    keyColumns: ['id'],
+    mapping: [],
+    createMissingTable: false,
+    ...overrides,
+  };
+}
+
+function col(name: string, dataType: string, nullable: boolean): ColumnSchema {
+  return {
+    name,
+    dataType,
+    nullable,
+    isPrimaryKey: false,
+    isUnique: false,
+    isAutoIncrement: false,
+    defaultValue: null,
+    comment: null,
+    references: null,
+  };
+}
+
+describe('DatabaseSinkService.deliver', () => {
+  it('routes a delete op to deleteRow keyed by the target key columns', async () => {
+    const { adapter, calls } = makeAdapter();
+    const svc = makeService({ dst: adapter });
+    const outcome = await svc.deliver(
+      makeHook(),
+      [makeTarget()],
+      [{ id: 7, name: 'Ada' }],
+      'delete',
+    );
+    expect(outcome.status).toBe('success');
+    expect(outcome.op).toBe('delete'); // persisted so a resend stays a delete
+    expect(calls.delete).toEqual([
+      { schema: undefined, table: 'users_copy', identity: { id: 7 } },
+    ]);
+    expect(calls.upsert).toHaveLength(0);
+    expect(calls.insert).toHaveLength(0);
+  });
+
+  it('fails an upsert with no key columns instead of writing', async () => {
+    const { adapter, calls } = makeAdapter();
+    const svc = makeService({ dst: adapter });
+    const outcome = await svc.deliver(
+      makeHook(),
+      [makeTarget({ keyColumns: [] })],
+      [{ id: 7 }],
+      undefined,
+    );
+    expect(outcome.status).toBe('failed');
+    expect(outcome.error).toContain('key column');
+    expect(calls.upsert).toHaveLength(0);
+  });
+
+  it('skips already-succeeded targets on a fan-out retry', async () => {
+    const { adapter, calls } = makeAdapter();
+    let failB = true;
+    const upsert = adapter.upsertRow;
+    adapter.upsertRow = async (p) => {
+      if (p.table === 'users_b' && failB) throw new Error('target B unavailable');
+      return upsert(p);
+    };
+    const svc = makeService({ dst: adapter });
+    const targets = [
+      makeTarget({ table: 'users_a' }),
+      makeTarget({ table: 'users_b' }),
+    ];
+
+    const first = await svc.deliver(makeHook(), targets, [{ id: 1 }], undefined);
+    expect(first.status).toBe('failed');
+    expect(first.succeededTargets).toHaveLength(1); // A committed, B did not
+    expect(calls.upsert.map((p) => p.table)).toEqual(['users_a']);
+
+    // retry with the persisted checkpoint: A must be skipped, only B written
+    failB = false;
+    const second = await svc.deliver(
+      makeHook(),
+      targets,
+      [{ id: 1 }],
+      undefined,
+      new Set(first.succeededTargets!),
+    );
+    expect(second.status).toBe('success');
+    expect(second.succeededTargets).toBeNull(); // success clears the checkpoint
+    expect(second.responseBody).toContain('skipped');
+    expect(calls.upsert.map((p) => p.table)).toEqual(['users_a', 'users_b']);
+  });
+
+  it('types an auto-created table from the real source schema', async () => {
+    const src = makeAdapter();
+    src.adapter.getSchema = async () => ({
+      database: 'appdb',
+      namespaces: [
+        {
+          name: 'public',
+          tables: [
+            {
+              name: 'users',
+              schema: 'public',
+              kind: 'table' as const,
+              columns: [
+                col('id', 'bigint', false),
+                col('price', 'numeric(10,2)', true),
+                col('meta', 'jsonb', true),
+                col('note', 'character varying(120)', true),
+              ],
+              indexes: [],
+              foreignKeys: [],
+              primaryKey: ['id'],
+              estimatedRows: null,
+              comment: null,
+            },
+          ],
+        },
+      ],
+    });
+    const dst = makeAdapter();
+    dst.adapter.browse = async () => {
+      throw new Error('relation "users_copy" does not exist');
+    };
+    const svc = makeService({ src: src.adapter, dst: dst.adapter });
+
+    // pg drivers return bigint/numeric as strings and this sample has nulls —
+    // with the schema resolved, none of that decays the created types to TEXT
+    const outcome = await svc.deliver(
+      makeHook(),
+      [makeTarget({ createMissingTable: true })],
+      [{ id: '9007199254740993', price: '19.99', meta: null, note: null }],
+      undefined,
+    );
+    expect(outcome.status).toBe('success');
+    expect(dst.calls.create).toHaveLength(1);
+    const byName = new Map(dst.calls.create[0]!.columns.map((c) => [c.name, c]));
+    expect(byName.get('id')).toMatchObject({
+      type: 'BIGINT',
+      primaryKey: true,
+      nullable: false,
+    });
+    expect(byName.get('price')!.type).toBe('DOUBLE PRECISION');
+    expect(byName.get('meta')!.type).toBe('JSONB');
+    expect(byName.get('note')!.type).toBe('TEXT');
+  });
+
+  it('falls back to sample-row inference when no schema is available', async () => {
+    const src = makeAdapter(); // getSchema throws by default
+    const dst = makeAdapter();
+    dst.adapter.browse = async () => {
+      throw new Error('relation "users_copy" does not exist');
+    };
+    const svc = makeService({ src: src.adapter, dst: dst.adapter });
+
+    const outcome = await svc.deliver(
+      makeHook(),
+      [makeTarget({ createMissingTable: true })],
+      [{ id: 7, price: '19.99' }],
+      undefined,
+    );
+    expect(outcome.status).toBe('success');
+    const byName = new Map(dst.calls.create[0]!.columns.map((c) => [c.name, c]));
+    expect(byName.get('id')!.type).toBe('INTEGER'); // runtime number
+    expect(byName.get('price')!.type).toBe('TEXT'); // stringly value, best effort
+  });
+
+  it('flags an oversized capture as truncated', async () => {
+    const { adapter } = makeAdapter();
+    const svc = makeService({ dst: adapter });
+    const outcome = await svc.deliver(
+      makeHook(),
+      [makeTarget()],
+      [{ id: 1, blob: 'x'.repeat(20_000) }],
+      undefined,
+    );
+    expect(outcome.status).toBe('success');
+    expect(outcome.bodyTruncated).toBe(true);
+    expect(outcome.requestBody).toHaveLength(16_384);
+  });
+});

--- a/apps/api/test/delivery.service.test.ts
+++ b/apps/api/test/delivery.service.test.ts
@@ -1,0 +1,182 @@
+/**
+ * DeliveryService transport tests against a throwaway node:http server: retry
+ * classification (retryable vs terminal status), Retry-After honored and
+ * clamped, run-abort propagation, and the truncated-capture flag that keeps
+ * the resend path from replaying garbage.
+ */
+import 'reflect-metadata';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { HookDeliveryConfig, HttpDestination } from '@syncle/core';
+import { DeliveryService } from '../src/hooks/delivery.service';
+
+type Handler = (req: IncomingMessage, res: ServerResponse) => void;
+
+let server: Server | null = null;
+
+/** start a one-off server and return the URL to POST at */
+async function listen(handler: Handler): Promise<string> {
+  server = createServer(handler);
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const { port } = server!.address() as AddressInfo;
+  return `http://127.0.0.1:${port}/hook`;
+}
+
+afterEach(async () => {
+  if (server) {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+});
+
+function config(overrides: Partial<HookDeliveryConfig> = {}): HookDeliveryConfig {
+  return {
+    batchSize: 1,
+    maxAttempts: 3,
+    backoffMs: 5,
+    backoffMaxMs: 40,
+    minDelayMs: 0,
+    timeoutMs: 2000,
+    pageSize: 200,
+    onError: 'continue',
+    ...overrides,
+  };
+}
+
+function dest(url: string): HttpDestination {
+  return {
+    kind: 'http',
+    url,
+    method: 'POST',
+    headers: {},
+    auth: { type: 'none' },
+    idempotency: false,
+  };
+}
+
+describe('DeliveryService.send', () => {
+  it('retries a retryable status and succeeds', async () => {
+    let hits = 0;
+    const url = await listen((_req, res) => {
+      hits++;
+      res.statusCode = hits === 1 ? 503 : 200;
+      res.end(hits === 1 ? 'busy' : 'ok');
+    });
+    const outcome = await new DeliveryService().send(
+      { id: 1 },
+      dest(url),
+      config(),
+      new AbortController().signal,
+    );
+    expect(outcome.status).toBe('success');
+    expect(outcome.attempts).toBe(2);
+    expect(outcome.httpStatus).toBe(200);
+    expect(outcome.bodyTruncated).toBe(false);
+    expect(hits).toBe(2);
+  });
+
+  it('fails a terminal status without retrying', async () => {
+    let hits = 0;
+    const url = await listen((_req, res) => {
+      hits++;
+      res.statusCode = 400;
+      res.end('bad payload');
+    });
+    const outcome = await new DeliveryService().send(
+      { id: 1 },
+      dest(url),
+      config(),
+      new AbortController().signal,
+    );
+    expect(outcome.status).toBe('failed');
+    expect(outcome.httpStatus).toBe(400);
+    expect(outcome.error).toContain('HTTP 400');
+    expect(hits).toBe(1); // 400 is not retryable
+  });
+
+  it('honors a numeric Retry-After beyond the computed backoff', async () => {
+    const times: number[] = [];
+    const url = await listen((_req, res) => {
+      times.push(Date.now());
+      if (times.length === 1) {
+        res.statusCode = 429;
+        res.setHeader('retry-after', '1'); // 1s, far above backoffMs
+        res.end('slow down');
+      } else {
+        res.statusCode = 200;
+        res.end('ok');
+      }
+    });
+    const outcome = await new DeliveryService().send(
+      { id: 1 },
+      dest(url),
+      config({ backoffMs: 5, backoffMaxMs: 5000 }),
+      new AbortController().signal,
+    );
+    expect(outcome.status).toBe('success');
+    expect(times).toHaveLength(2);
+    expect(times[1]! - times[0]!).toBeGreaterThanOrEqual(900);
+  });
+
+  it('clamps Retry-After to backoffMaxMs', async () => {
+    const times: number[] = [];
+    const url = await listen((_req, res) => {
+      times.push(Date.now());
+      if (times.length === 1) {
+        res.statusCode = 429;
+        res.setHeader('retry-after', '3600'); // an hour — must not be waited out
+        res.end('slow down');
+      } else {
+        res.statusCode = 200;
+        res.end('ok');
+      }
+    });
+    const outcome = await new DeliveryService().send(
+      { id: 1 },
+      dest(url),
+      config({ backoffMs: 5, backoffMaxMs: 50 }),
+      new AbortController().signal,
+    );
+    expect(outcome.status).toBe('success');
+    expect(times).toHaveLength(2);
+    expect(times[1]! - times[0]!).toBeLessThan(1000); // ~50ms + jitter, not 1h
+  });
+
+  it('propagates a run-level abort as a rejection', async () => {
+    const url = await listen(() => {
+      /* never respond, the abort must cut the in-flight request */
+    });
+    const controller = new AbortController();
+    const pending = new DeliveryService().send(
+      { id: 1 },
+      dest(url),
+      config(),
+      controller.signal,
+    );
+    setTimeout(() => controller.abort(), 50);
+    await expect(pending).rejects.toHaveProperty('name', 'AbortError');
+  });
+
+  it('flags a capture cut at the storage cap as truncated', async () => {
+    const url = await listen((_req, res) => {
+      res.statusCode = 200;
+      res.end('ok');
+    });
+    const outcome = await new DeliveryService().send(
+      { blob: 'x'.repeat(20_000) },
+      dest(url),
+      config(),
+      new AbortController().signal,
+    );
+    expect(outcome.status).toBe('success');
+    expect(outcome.bodyTruncated).toBe(true);
+    expect(outcome.requestBody).toHaveLength(16_384);
+  });
+});


### PR DESCRIPTION
Closes a family of retry-path integrity bugs around hook deliveries:

- **Deletes no longer resurrect on retry.** The operation is persisted per delivery (`op` column), so a failed CDC delete retries as a keyed delete instead of an upsert re-inserting the deleted row.
- **Truncated captures can't fake success.** Bodies stored at the 16KB cap now carry a `body_truncated` flag; resend refuses them with a per-delivery error instead of re-sending cut-off JSON (HTTP) or writing zero rows and marking the cell green (database).
- **Fan-out retries stop duplicating rows.** Each delivery records which targets committed (`succeeded_targets_json`); retries skip them, closing the insert-mode duplication window the file header previously (incorrectly) claimed was safe.
- **Retry-failed moved onto the worker.** `POST …/retry-failed` now enqueues a `resend` job and returns immediately — cancelable via the run registry — instead of performing up to 2,000 live deliveries inside the HTTP request.
- **Replay-only guard.** Starting a run on a watch/CDC hook via `POST /hooks/:id/runs` now 400s instead of replaying the entire table through the replay processor.
- **Auto-created tables get real types.** Target columns come from the source's introspected schema (cached per hook) through core's type translation; sample-row inference is only a fallback, so pg BIGINT/NUMERIC no longer land as TEXT.

Includes a hand-written Prisma migration (`20260820000000_delivery_retry_integrity`) and new vitest suites for DeliveryService (real local HTTP server) and DatabaseSinkService (stub adapter) — 12 new tests, no database required. Full workspace typecheck and test suite pass.