### PR TITLE
Fix CDC data loss and ordering bugs in event-based hooks

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "dev": "prisma generate && prisma migrate deploy && nest start --watch",
     "start": "prisma generate && prisma migrate deploy && node dist/main.js",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "prisma:generate": "prisma generate",
     "migrate:dev": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",

--- a/apps/api/src/hooks/cdc/cdc-provider.ts
+++ b/apps/api/src/hooks/cdc/cdc-provider.ts
@@ -30,9 +30,9 @@ export interface CdcChange {
   row: Record<string, unknown>;
   /**
    * opaque engine-specific position string, used BOTH as the resume cursor and
-   * the idempotency seed. Postgres: LSN "H/L"; MySQL: "file:pos"; MongoDB:
-   * serialized resumeToken; Redis: synthetic, non-durable. orchestrator
-   * persists it verbatim and hands it back on resume.
+   * the idempotency seed. Postgres: LSN "H/L"; MySQL: "file:pos:row[:s]";
+   * MongoDB: serialized resumeToken; Redis: synthetic, non-durable.
+   * orchestrator persists it verbatim and hands it back on resume.
    */
   cursor: string;
 }
@@ -62,10 +62,27 @@ export interface CdcStreamContext {
 /** handle to a running stream so the orchestrator can stop it cleanly */
 export interface CdcStreamHandle {
   stop(): Promise<void>;
+  /**
+   * confirm to the SOURCE that everything up to and including `cursor` is
+   * durably checkpointed on our side. the orchestrator calls this only AFTER
+   * persisting the cursor, so engines with a server-side ack point (the
+   * Postgres slot's confirmed LSN) never advance it past unpersisted changes.
+   * best-effort: a missed ack just widens the at-least-once replay window,
+   * which the orchestrator's watermark dedupe absorbs. must not throw.
+   */
+  ack?(cursor: string): Promise<void>;
 }
 
 export interface CdcProvider {
   readonly engine: DatabaseEngine;
+
+  /**
+   * true when the provider applies the hook's source filters itself, with
+   * engine-native semantics (Redis: the `key` filter value is a glob applied
+   * at the subscription). the orchestrator then skips its own generic
+   * in-process filter evaluation for changes from this provider.
+   */
+  readonly handlesSourceFilters?: boolean;
 
   /**
    * can this engine/connection stream changes right now? drives the builder's

--- a/apps/api/src/hooks/cdc/filter-match.test.ts
+++ b/apps/api/src/hooks/cdc/filter-match.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import type { FilterSpec } from '@syncle/core';
+import { rowMatchesFilters } from './filter-match';
+
+const f = (column: string, operator: FilterSpec['operator'], value?: unknown): FilterSpec => ({
+  column,
+  operator,
+  value,
+});
+
+describe('rowMatchesFilters', () => {
+  it('an empty or missing filter list matches every row', () => {
+    expect(rowMatchesFilters({ a: 1 }, undefined)).toBe(true);
+    expect(rowMatchesFilters({ a: 1 }, [])).toBe(true);
+  });
+
+  it('filters AND together', () => {
+    const filters = [f('status', 'eq', 'active'), f('amount', 'gt', 10)];
+    expect(rowMatchesFilters({ status: 'active', amount: 11 }, filters)).toBe(true);
+    expect(rowMatchesFilters({ status: 'active', amount: 10 }, filters)).toBe(false);
+    expect(rowMatchesFilters({ status: 'archived', amount: 11 }, filters)).toBe(false);
+  });
+
+  describe('eq / neq', () => {
+    it('compares numeric-looking strings numerically (pgoutput sends text)', () => {
+      expect(rowMatchesFilters({ id: '42' }, [f('id', 'eq', 42)])).toBe(true);
+      expect(rowMatchesFilters({ id: 42 }, [f('id', 'eq', '42')])).toBe(true);
+      expect(rowMatchesFilters({ id: 41 }, [f('id', 'eq', 42)])).toBe(false);
+    });
+
+    it('string equality is case-sensitive, like SQL =', () => {
+      expect(rowMatchesFilters({ s: 'Ab' }, [f('s', 'eq', 'ab')])).toBe(false);
+      expect(rowMatchesFilters({ s: 'ab' }, [f('s', 'eq', 'ab')])).toBe(true);
+    });
+
+    it('booleans match 0/1 row values (MySQL tinyint booleans)', () => {
+      expect(rowMatchesFilters({ ok: 1 }, [f('ok', 'eq', true)])).toBe(true);
+      expect(rowMatchesFilters({ ok: 0 }, [f('ok', 'eq', false)])).toBe(true);
+    });
+
+    it('NULL never matches a comparison, including neq (SQL three-valued logic)', () => {
+      expect(rowMatchesFilters({ v: null }, [f('v', 'eq', 'x')])).toBe(false);
+      expect(rowMatchesFilters({ v: null }, [f('v', 'neq', 'x')])).toBe(false);
+      expect(rowMatchesFilters({}, [f('v', 'neq', 'x')])).toBe(false);
+      expect(rowMatchesFilters({ v: 'y' }, [f('v', 'neq', 'x')])).toBe(true);
+    });
+  });
+
+  describe('ordering operators', () => {
+    it('lt/lte/gt/gte compare numbers, numeric strings included', () => {
+      expect(rowMatchesFilters({ n: '9' }, [f('n', 'lt', 10)])).toBe(true);
+      expect(rowMatchesFilters({ n: 10 }, [f('n', 'lte', '10')])).toBe(true);
+      expect(rowMatchesFilters({ n: 11 }, [f('n', 'gt', 10)])).toBe(true);
+      expect(rowMatchesFilters({ n: 9 }, [f('n', 'gte', 10)])).toBe(false);
+      // numeric compare, NOT the lexicographic '9' > '10'
+      expect(rowMatchesFilters({ n: '9' }, [f('n', 'gt', '10')])).toBe(false);
+    });
+
+    it('compares Date row values against ISO strings by instant', () => {
+      const row = { at: new Date('2026-01-02T00:00:00Z') };
+      expect(rowMatchesFilters(row, [f('at', 'gt', '2026-01-01')])).toBe(true);
+      expect(rowMatchesFilters(row, [f('at', 'lt', '2026-01-01')])).toBe(false);
+    });
+
+    it('null is incomparable', () => {
+      expect(rowMatchesFilters({ n: null }, [f('n', 'lt', 10)])).toBe(false);
+      expect(rowMatchesFilters({ n: 5 }, [f('n', 'lt', null)])).toBe(false);
+    });
+  });
+
+  describe('LIKE-style operators', () => {
+    it('contains/startsWith/endsWith are case-insensitive, like ILIKE', () => {
+      expect(rowMatchesFilters({ s: 'Hello World' }, [f('s', 'contains', 'o w')])).toBe(true);
+      expect(rowMatchesFilters({ s: 'Hello World' }, [f('s', 'startsWith', 'hell')])).toBe(true);
+      expect(rowMatchesFilters({ s: 'Hello World' }, [f('s', 'endsWith', 'WORLD')])).toBe(true);
+      expect(rowMatchesFilters({ s: 'Hello World' }, [f('s', 'contains', 'mars')])).toBe(false);
+    });
+
+    it('stringifies non-string row values, and NULL never matches', () => {
+      expect(rowMatchesFilters({ n: 12345 }, [f('n', 'contains', '234')])).toBe(true);
+      expect(rowMatchesFilters({ n: null }, [f('n', 'contains', '')])).toBe(false);
+    });
+  });
+
+  describe('isNull / notNull / in', () => {
+    it('isNull sees null AND a missing column; notNull is the inverse', () => {
+      expect(rowMatchesFilters({ v: null }, [f('v', 'isNull')])).toBe(true);
+      expect(rowMatchesFilters({}, [f('v', 'isNull')])).toBe(true);
+      expect(rowMatchesFilters({ v: 0 }, [f('v', 'isNull')])).toBe(false);
+      expect(rowMatchesFilters({ v: 0 }, [f('v', 'notNull')])).toBe(true);
+      expect(rowMatchesFilters({ v: null }, [f('v', 'notNull')])).toBe(false);
+    });
+
+    it('in matches any listed value; empty or non-array matches nothing', () => {
+      expect(rowMatchesFilters({ v: 'b' }, [f('v', 'in', ['a', 'b'])])).toBe(true);
+      expect(rowMatchesFilters({ v: '2' }, [f('v', 'in', [1, 2])])).toBe(true);
+      expect(rowMatchesFilters({ v: 'c' }, [f('v', 'in', ['a', 'b'])])).toBe(false);
+      expect(rowMatchesFilters({ v: 'c' }, [f('v', 'in', [])])).toBe(false);
+      expect(rowMatchesFilters({ v: 'c' }, [f('v', 'in', 'c')])).toBe(false);
+    });
+  });
+
+  describe('partial delete images', () => {
+    const filters = [f('status', 'eq', 'active')];
+
+    it('a missing column fails by default (SQL NULL semantics)', () => {
+      expect(rowMatchesFilters({ id: 7 }, filters)).toBe(false);
+    });
+
+    it('passMissingColumns lets a key-only delete image through', () => {
+      expect(rowMatchesFilters({ id: 7 }, filters, { passMissingColumns: true })).toBe(true);
+      // but a PRESENT column still has to match
+      expect(
+        rowMatchesFilters({ id: 7, status: 'archived' }, filters, { passMissingColumns: true }),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/hooks/cdc/filter-match.ts
+++ b/apps/api/src/hooks/cdc/filter-match.ts
@@ -1,0 +1,139 @@
+/**
+ * in-process evaluation of a hook's source filters against one change row.
+ *
+ * replay and polling push `hook.source.filters` into the engine (SQL WHERE /
+ * Mongo find), but a CDC stream sees every row of the table, so the same
+ * predicates have to run here. semantics mirror the adapters' `buildWhere` /
+ * `buildMongoFilter`:
+ *  - filters AND together
+ *  - comparisons against SQL NULL (a null/undefined row value) never match,
+ *    including `neq` — only `isNull` sees them
+ *  - contains/startsWith/endsWith are case-insensitive, like ILIKE, MySQL's
+ *    default collation, and the Mongo `$options: 'i'` regexes
+ *  - `in` with an empty (or non-array) value matches nothing (`1 = 0`)
+ *  - numeric-looking values compare numerically, so a pgoutput text value
+ *    "42" still matches a numeric filter 42
+ */
+import type { FilterSpec } from '@syncle/core';
+
+export interface FilterMatchOptions {
+  /**
+   * pass filters whose column is ABSENT from the row (present-but-null still
+   * fails). delete images may carry only the key columns (Postgres REPLICA
+   * IDENTITY DEFAULT), and dropping every delete because the filtered column
+   * isn't in the image would silently stop deletes from syncing.
+   */
+  passMissingColumns?: boolean;
+}
+
+/** true when `row` satisfies every filter (an empty/missing list matches all) */
+export function rowMatchesFilters(
+  row: Record<string, unknown>,
+  filters: FilterSpec[] | undefined,
+  opts: FilterMatchOptions = {},
+): boolean {
+  if (!filters || filters.length === 0) return true;
+  for (const f of filters) {
+    if (opts.passMissingColumns && !(f.column in row)) continue;
+    if (!matchesOne(row[f.column], f)) return false;
+  }
+  return true;
+}
+
+function matchesOne(value: unknown, f: FilterSpec): boolean {
+  switch (f.operator) {
+    case 'isNull':
+      return value == null;
+    case 'notNull':
+      return value != null;
+    case 'eq':
+      return compare(value, f.value) === 0;
+    case 'neq': {
+      const c = compare(value, f.value);
+      return c !== null && c !== 0;
+    }
+    case 'lt': {
+      const c = compare(value, f.value);
+      return c !== null && c < 0;
+    }
+    case 'lte': {
+      const c = compare(value, f.value);
+      return c !== null && c <= 0;
+    }
+    case 'gt': {
+      const c = compare(value, f.value);
+      return c !== null && c > 0;
+    }
+    case 'gte': {
+      const c = compare(value, f.value);
+      return c !== null && c >= 0;
+    }
+    case 'contains':
+      return likeHaystack(value)?.includes(likeNeedle(f.value)) ?? false;
+    case 'startsWith':
+      return likeHaystack(value)?.startsWith(likeNeedle(f.value)) ?? false;
+    case 'endsWith':
+      return likeHaystack(value)?.endsWith(likeNeedle(f.value)) ?? false;
+    case 'in':
+      return Array.isArray(f.value) && f.value.some((v) => compare(value, v) === 0);
+    default:
+      // configs are zod-validated, so an unknown operator can only mean a
+      // schema drift — fail closed rather than stream unfiltered rows
+      return false;
+  }
+}
+
+/** three-way compare with light cross-type coercion. null = incomparable */
+function compare(row: unknown, filter: unknown): -1 | 0 | 1 | null {
+  if (row == null || filter == null) return null;
+  const nr = toNumber(row);
+  const nf = toNumber(filter);
+  if (nr !== null && nf !== null) return nr === nf ? 0 : nr < nf ? -1 : 1;
+  // Date row values (Mongo) compare by instant against ISO-ish filter strings
+  if (row instanceof Date || filter instanceof Date) {
+    const tr = toTime(row);
+    const tf = toTime(filter);
+    if (tr !== null && tf !== null) return tr === tf ? 0 : tr < tf ? -1 : 1;
+  }
+  const sr = asString(row);
+  const sf = asString(filter);
+  return sr === sf ? 0 : sr < sf ? -1 : 1;
+}
+
+function toNumber(v: unknown): number | null {
+  if (typeof v === 'number') return Number.isNaN(v) ? null : v;
+  if (typeof v === 'bigint') return Number(v);
+  if (typeof v === 'boolean') return v ? 1 : 0;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    return Number.isNaN(n) ? null : n;
+  }
+  return null;
+}
+
+function toTime(v: unknown): number | null {
+  const t = v instanceof Date ? v.getTime() : typeof v === 'string' ? Date.parse(v) : NaN;
+  return Number.isNaN(t) ? null : t;
+}
+
+function asString(v: unknown): string {
+  if (typeof v === 'object' && v !== null) {
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  }
+  return String(v);
+}
+
+/** the row side of a LIKE-style match, lowercased; null when SQL NULL */
+function likeHaystack(v: unknown): string | null {
+  if (v == null) return null;
+  return asString(v).toLowerCase();
+}
+
+/** the pattern side of a LIKE-style match (`buildWhere` stringifies it too) */
+function likeNeedle(v: unknown): string {
+  return String(v ?? '').toLowerCase();
+}

--- a/apps/api/src/hooks/cdc/providers/mysql-cdc.provider.test.ts
+++ b/apps/api/src/hooks/cdc/providers/mysql-cdc.provider.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { AdapterPoolService } from '../../../connections/adapter-pool.service';
+import { MysqlCdcProvider, binlogEventStart } from './mysql-cdc.provider';
+
+// cursorAfter/splitCursor are pure, the pool is only used by readiness()
+const provider = new MysqlCdcProvider(null as unknown as AdapterPoolService);
+const split = (c: string) => provider['splitCursor'](c);
+
+describe('splitCursor', () => {
+  it('parses the current start-format cursor "file:pos:row:s"', () => {
+    expect(split('binlog.000042:1540:3:s')).toEqual(['binlog.000042', 1540, 3, true]);
+  });
+
+  it('parses the legacy end-format cursor "file:pos:row"', () => {
+    expect(split('binlog.000042:1540:3')).toEqual(['binlog.000042', 1540, 3, false]);
+  });
+
+  it('parses the oldest "file:pos" cursor with row index -1', () => {
+    expect(split('binlog.000042:1540')).toEqual(['binlog.000042', 1540, -1, false]);
+  });
+
+  it('keeps a filename containing colons intact', () => {
+    expect(split('my:log.000001:200:0:s')).toEqual(['my:log.000001', 200, 0, true]);
+    expect(split('my:log.000001:200:0')).toEqual(['my:log.000001', 200, 0, false]);
+  });
+});
+
+describe('cursorAfter', () => {
+  it('a null watermark means everything is new', () => {
+    expect(provider.cursorAfter('binlog.000001:4:0:s', null)).toBe(true);
+  });
+
+  it('orders by file first (zero-padded names compare lexically)', () => {
+    expect(provider.cursorAfter('binlog.000002:4:0:s', 'binlog.000001:9999:5:s')).toBe(true);
+    expect(provider.cursorAfter('binlog.000001:9999:5:s', 'binlog.000002:4:0:s')).toBe(false);
+  });
+
+  it('then by position, then by row index', () => {
+    expect(provider.cursorAfter('b.000001:200:0:s', 'b.000001:100:9:s')).toBe(true);
+    expect(provider.cursorAfter('b.000001:100:4:s', 'b.000001:100:3:s')).toBe(true);
+    expect(provider.cursorAfter('b.000001:100:3:s', 'b.000001:100:3:s')).toBe(false);
+    expect(provider.cursorAfter('b.000001:100:2:s', 'b.000001:100:3:s')).toBe(false);
+  });
+
+  it('drops the already-delivered prefix of a replayed statement (mid-event resume)', () => {
+    // crash happened after row 2 of a 5-row statement whose tablemap starts at 500
+    const watermark = 'b.000001:500:2:s';
+    // resume re-enters at 500 and replays rows 0..4
+    expect(provider.cursorAfter('b.000001:500:0:s', watermark)).toBe(false);
+    expect(provider.cursorAfter('b.000001:500:2:s', watermark)).toBe(false);
+    expect(provider.cursorAfter('b.000001:500:3:s', watermark)).toBe(true);
+    expect(provider.cursorAfter('b.000001:500:4:s', watermark)).toBe(true);
+  });
+
+  it('a start-format cursor at the offset where a legacy cursor ENDED is after it', () => {
+    // legacy watermark: event ended at 800; the next statement's tablemap can
+    // start at exactly 800, and its rows must not be dropped by the tie
+    expect(provider.cursorAfter('b.000001:800:0:s', 'b.000001:800:7')).toBe(true);
+    // and the mirror image: a legacy cursor at a start-format watermark's
+    // offset belongs to the event BEFORE it
+    expect(provider.cursorAfter('b.000001:800:7', 'b.000001:800:0:s')).toBe(false);
+  });
+
+  it('legacy 2-part watermarks compare as row -1, so row 0 still delivers', () => {
+    expect(provider.cursorAfter('b.000001:800:0', 'b.000001:800')).toBe(true);
+    expect(provider.cursorAfter('b.000001:799:0', 'b.000001:800')).toBe(false);
+  });
+});
+
+describe('binlogEventStart (resume-position math)', () => {
+  it('subtracts payload size and the 19-byte header', () => {
+    // tablemap payload of 41 bytes ending at 560 starts at 560 - 41 - 19 = 500
+    expect(binlogEventStart({ nextPosition: 560, size: 41 }, false)).toBe(500);
+  });
+
+  it('accounts for the 4-byte CRC32 when binlog_checksum is on', () => {
+    // zongji strips the checksum from `size`, but next_position includes it
+    expect(binlogEventStart({ nextPosition: 564, size: 41 }, true)).toBe(500);
+  });
+});

--- a/apps/api/src/hooks/cdc/providers/mysql-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/mysql-cdc.provider.ts
@@ -2,8 +2,9 @@
  * MySQL CDC via the binary log (row-based replication), read with
  * `@powersync/mysql-zongji`. Syncle registers as a replication client and
  * decodes Write/Update/Delete row events in real time. durable and resumable:
- * the cursor is the binlog `"file:position"`, so a restart resumes exactly
- * where it left off.
+ * the cursor is the binlog `"file:position:row"` (position of the statement's
+ * tablemap event), so a restart resumes exactly where it left off — even in
+ * the middle of a multi-row event.
  *
  * prereqs (checked by readiness): `log_bin=ON`, `binlog_format=ROW`,
  * `binlog_row_image=FULL`, and a user with `REPLICATION SLAVE` + `REPLICATION
@@ -38,6 +39,19 @@ interface ZongjiConn {
 /** row events we care about. `rotate`/`tablemap` are needed for bookkeeping */
 const ROW_EVENTS = new Set(['writerows', 'updaterows', 'deleterows']);
 
+/**
+ * byte offset where a binlog event STARTS. zongji's `size` is the payload
+ * length only — the on-disk event_length that `nextPosition` advances by also
+ * counts the 19-byte common header, plus a 4-byte CRC32 when the server runs
+ * with `binlog_checksum` (the default on modern MySQL).
+ */
+export function binlogEventStart(
+  evt: { nextPosition: number; size: number },
+  useChecksum: boolean,
+): number {
+  return evt.nextPosition - evt.size - (useChecksum ? 23 : 19);
+}
+
 @Injectable()
 export class MysqlCdcProvider implements CdcProvider {
   readonly engine: DatabaseEngine = 'mysql';
@@ -45,33 +59,50 @@ export class MysqlCdcProvider implements CdcProvider {
 
   constructor(private readonly pool: AdapterPoolService) {}
 
-  /** compare "file:pos[:row]" cursors: filename, then position, then row index */
+  /**
+   * compare cursors: filename, then position, then row index. positions from
+   * the two formats can collide at one byte offset (an old cursor's END is
+   * where the next statement's tablemap STARTS), so a start-format cursor at
+   * the same offset as an end-format one is strictly after it.
+   */
   cursorAfter(a: string, b: string | null): boolean {
     if (!b) return true;
-    const [fa, pa, ra] = this.splitCursor(a);
-    const [fb, pb, rb] = this.splitCursor(b);
+    const [fa, pa, ra, sa] = this.splitCursor(a);
+    const [fb, pb, rb, sb] = this.splitCursor(b);
     if (fa !== fb) return fa > fb; // zero-padded binlog names compare lexically
     if (pa !== pb) return pa > pb;
+    if (sa !== sb) return sa;
     return ra > rb;
   }
 
   /**
-   * parse "file:pos:rowIdx" (or legacy "file:pos" persisted before per-row
-   * cursors existed — a missing row index compares as -1, so every row of the
-   * next multi-row event still counts as "after" the old watermark)
+   * parse a cursor into [file, pos, rowIdx, isStart]. three formats:
+   *  - "file:pos:rowIdx:s" (current) — pos is the START of the statement's
+   *    tablemap event, so a resume re-enters the statement and the row-index
+   *    watermark drops the already-delivered prefix
+   *  - "file:pos:rowIdx" (legacy) — pos is the END of the row event, which
+   *    on resume skipped the rest of a half-processed multi-row event
+   *  - "file:pos" (oldest) — no row index; compares as -1 so every row of the
+   *    next multi-row event still counts as "after" the old watermark
    */
-  private splitCursor(c: string): [string, number, number] {
-    const parts = c.split(':');
+  private splitCursor(c: string): [string, number, number, boolean] {
+    let rest = c;
+    let isStart = false;
+    if (rest.endsWith(':s')) {
+      rest = rest.slice(0, -2);
+      isStart = true;
+    }
+    const parts = rest.split(':');
     if (parts.length >= 3) {
       const row = Number(parts[parts.length - 1]);
       const pos = Number(parts[parts.length - 2]);
       if (Number.isFinite(row) && Number.isFinite(pos)) {
-        return [parts.slice(0, -2).join(':'), pos, row];
+        return [parts.slice(0, -2).join(':'), pos, row, isStart];
       }
     }
-    const idx = c.lastIndexOf(':');
-    if (idx < 0) return [c, 0, -1];
-    return [c.slice(0, idx), Number(c.slice(idx + 1)) || 0, -1];
+    const idx = rest.lastIndexOf(':');
+    if (idx < 0) return [rest, 0, -1, isStart];
+    return [rest.slice(0, idx), Number(rest.slice(idx + 1)) || 0, -1, isStart];
   }
 
   /* ----- connection details, zongji needs discrete fields ----- */
@@ -194,9 +225,19 @@ export class MysqlCdcProvider implements CdcProvider {
     let stopped = false;
     let zongji: ZongJi | null = null;
     let attempt = 0;
-    // resume bookkeeping: tracks the last processed binlog position so both the
+    // resume bookkeeping: tracks the last SAFE binlog position so both the
     // initial start AND every reconnect resume exactly where we left off
-    let [binlogName, position] = fromCursor ? this.splitCursor(fromCursor) : ['', 0, -1];
+    const resume = fromCursor ? this.splitCursor(fromCursor) : null;
+    let binlogName = resume?.[0] ?? '';
+    let position = resume?.[1] ?? 0;
+    // the statement group currently being decoded: `groupStart` is the byte
+    // offset of its tablemap event, `groupRow` a running row counter across
+    // the (possibly several) row events that follow it. cursors carry the
+    // tablemap start because a row event replayed WITHOUT its tablemap can't
+    // be decoded (zongji silently filters it) — resuming at the tablemap
+    // re-enters the statement and the row watermark drops the delivered prefix
+    let groupStart = -1;
+    let groupRow = 0;
 
     const onEvent = async (evt: BinLogEvent): Promise<void> => {
       const name = evt.getEventName();
@@ -208,6 +249,23 @@ export class MysqlCdcProvider implements CdcProvider {
           // rotate (binlogName still empty) must not fabricate a resume point
           if (binlogName) position = 4;
           binlogName = next;
+          groupStart = -1;
+          groupRow = 0;
+        }
+        return;
+      }
+      if (name === 'tablemap') {
+        // a new statement group begins. its tablemap is the safe re-entry
+        // point for every row event it covers, so it becomes the resume
+        // position until the next group starts
+        const start = binlogEventStart(
+          evt,
+          (zongji as unknown as { useChecksum?: boolean } | null)?.useChecksum === true,
+        );
+        if (start > 0) {
+          groupStart = start;
+          groupRow = 0;
+          position = start;
         }
         return;
       }
@@ -221,33 +279,42 @@ export class MysqlCdcProvider implements CdcProvider {
       };
       const meta = rowEvt.tableMap[rowEvt.tableId];
       if (!meta || meta.parentSchema !== db || meta.tableName !== src.table) {
-        position = rowEvt.nextPosition; // nothing to deliver, safe to skip on reconnect
-        return;
+        return; // nothing to deliver; the resume point stays on our last group
       }
 
       const op: CdcOperation =
         name === 'writerows' ? 'insert' : name === 'deleterows' ? 'delete' : 'update';
       if (!ops.has(op)) {
-        position = rowEvt.nextPosition;
+        // rows of a disabled operation still consume row indices, so the
+        // group counter stays aligned with the binlog on a replay
+        groupRow += rowEvt.rows.length;
         return;
       }
 
       // backpressure: pause the binlog socket while we deliver this batch
       if (zongji && !stopped) zongji.pause();
       try {
-        // per-ROW cursor: every row in a multi-row event needs its own position,
-        // otherwise the orchestrator's strict watermark drops rows 2..N
+        // per-ROW cursor: every row needs its own position, otherwise the
+        // orchestrator's strict watermark drops rows 2..N of a multi-row event
+        const startKnown = groupStart > 0;
         for (let i = 0; i < rowEvt.rows.length; i++) {
           const r = rowEvt.rows[i]!;
           const row =
             op === 'update'
               ? (r as { after: Record<string, unknown> }).after
               : (r as Record<string, unknown>);
-          await handlers.onChange({ op, row, cursor: `${binlogName}:${rowEvt.nextPosition}:${i}` });
+          const idx = groupRow++;
+          // defensive fallback: a row event with no seen tablemap (shouldn't
+          // happen) keeps the legacy end-position cursor format
+          const cursor = startKnown
+            ? `${binlogName}:${groupStart}:${idx}:s`
+            : `${binlogName}:${rowEvt.nextPosition}:${i}`;
+          await handlers.onChange({ op, row, cursor });
         }
-        // remember the resume point so a reconnect continues from here instead
-        // of silently jumping to the end of the binlog
-        position = rowEvt.nextPosition;
+        // the resume point stays at the group's tablemap: the statement may
+        // have more row events coming, and re-entering it mid-way is not
+        // decodable — replayed rows are dropped by the watermark instead
+        if (!startKnown) position = rowEvt.nextPosition;
       } finally {
         if (zongji && !stopped) zongji.resume();
       }
@@ -280,8 +347,9 @@ export class MysqlCdcProvider implements CdcProvider {
         serverId,
       };
       if (binlogName && position > 0) {
-        // resume from the last processed position — kept up to date by onEvent,
-        // so a mid-stream reconnect never loses the events in between
+        // resume from the last safe position — kept up to date by onEvent
+        // (the current statement's tablemap), so a mid-stream reconnect never
+        // loses the events in between and replayed rows still decode
         startOpts.filename = binlogName;
         startOpts.position = position;
       } else {

--- a/apps/api/src/hooks/cdc/providers/postgres-cdc.provider.test.ts
+++ b/apps/api/src/hooks/cdc/providers/postgres-cdc.provider.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { lsnAfter } from './postgres-cdc.provider';
+
+describe('lsnAfter', () => {
+  it('a null watermark means everything is new', () => {
+    expect(lsnAfter('0/1', null)).toBe(true);
+  });
+
+  it('compares the low word numerically, not lexically', () => {
+    expect(lsnAfter('0/A', '0/9')).toBe(true);
+    expect(lsnAfter('0/10', '0/F')).toBe(true); // 0x10 > 0xF, but '10' < 'F' as strings
+    expect(lsnAfter('0/F', '0/10')).toBe(false);
+  });
+
+  it('the high word dominates the low word', () => {
+    // 1/0 is after 0/FFFFFFFF even though its low word is smaller
+    expect(lsnAfter('1/0', '0/FFFFFFFF')).toBe(true);
+    expect(lsnAfter('0/FFFFFFFF', '1/0')).toBe(false);
+    expect(lsnAfter('A/5', '9/FFFFFFF0')).toBe(true);
+  });
+
+  it('equal LSNs are not after each other (strict ordering)', () => {
+    expect(lsnAfter('16/B374D848', '16/B374D848')).toBe(false);
+  });
+
+  it('is conservative on malformed input: not-after, so no duplicate delivery', () => {
+    expect(lsnAfter('junk', '0/1')).toBe(false);
+    expect(lsnAfter('0/1', 'junk')).toBe(false);
+    expect(lsnAfter('0', '0/1')).toBe(false);
+  });
+});

--- a/apps/api/src/hooks/cdc/providers/postgres-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/postgres-cdc.provider.ts
@@ -31,7 +31,7 @@ import {
 } from '../cdc-provider';
 
 /** compare Postgres LSNs ("H/L" hex). true if `a` is strictly after `b` */
-function lsnAfter(a: string, b: string | null): boolean {
+export function lsnAfter(a: string, b: string | null): boolean {
   if (!b) return true;
   try {
     const big = (l: string) => {
@@ -205,6 +205,10 @@ export class PostgresCdcProvider implements CdcProvider {
     let stopped = false;
     let current: LogicalReplicationService | null = null;
     let attempt = 0;
+    // highest LSN the orchestrator has durably checkpointed (seeded from the
+    // resume cursor). this is the ONLY position we ever confirm to the server,
+    // so the slot can never advance past a change that isn't persisted yet
+    let ackedLsn: string | null = ctx.fromCursor;
     // surface each distinct failure ONCE (a slot already in use, bad auth, …)
     // instead of spamming onError on every backoff retry
     let lastReported: string | null = null;
@@ -216,9 +220,23 @@ export class PostgresCdcProvider implements CdcProvider {
 
     const makeService = (): LogicalReplicationService => {
       const service = new LogicalReplicationService(this.clientConfig(conn, src.database), {
-        acknowledge: { auto: true, timeoutSeconds: 10 },
+        // manual acknowledge: auto-ack confirms an LSN on receipt, so a crash
+        // between receipt and the orchestrator persisting the cursor would
+        // silently lose that change (the slot had already moved past it).
+        // timeoutSeconds MUST be 0 too — the library's standby-status timer
+        // acks the last *received* LSN even with auto:false
+        acknowledge: { auto: false, timeoutSeconds: 0 },
         flowControl: { enabled: true }, // backpressure, await each delivery
       });
+
+      // messages we don't deliver are deterministically skippable (begin/
+      // commit/relation, disabled ops, other tables), and flow control has
+      // fully processed everything before them, so confirming their LSN is
+      // safe and keeps the slot from pinning WAL on a mostly-filtered stream
+      const ackSkipped = (lsn: string): void => {
+        ackedLsn = lsn;
+        void service.acknowledge(lsn).catch(() => undefined);
+      };
 
       service.on(
         'data',
@@ -235,9 +253,16 @@ export class PostgresCdcProvider implements CdcProvider {
           // data is flowing, so the subscription is healthy: reset the backoff
           attempt = 0;
           lastReported = null;
-          if (msg.tag !== 'insert' && msg.tag !== 'update' && msg.tag !== 'delete') return;
-          if (!ops.has(msg.tag as CdcOperation)) return;
+          if (msg.tag !== 'insert' && msg.tag !== 'update' && msg.tag !== 'delete') {
+            ackSkipped(lsn);
+            return;
+          }
+          if (!ops.has(msg.tag as CdcOperation)) {
+            ackSkipped(lsn);
+            return;
+          }
           if (!msg.relation || msg.relation.name !== src.table || msg.relation.schema !== schema) {
+            ackSkipped(lsn);
             return;
           }
           const row = msg.tag === 'delete' ? (msg.old ?? msg.key ?? {}) : (msg.new ?? {});
@@ -245,6 +270,15 @@ export class PostgresCdcProvider implements CdcProvider {
           await handlers.onChange(change);
         },
       );
+
+      // with the ack timer off, keepalive replies are our only standby-status
+      // traffic. reply with the last PERSISTED position (the server ignores
+      // stale ones) or wal_sender_timeout would kill an idle stream
+      service.on('heartbeat', (_lsn: string, _ts: number, shouldRespond: boolean) => {
+        if (shouldRespond && ackedLsn) {
+          void service.acknowledge(ackedLsn).catch(() => undefined);
+        }
+      });
 
       service.on('error', (err: Error) => report(err));
       return service;
@@ -275,6 +309,12 @@ export class PostgresCdcProvider implements CdcProvider {
     void loop().catch((err) => handlers.onError(err as Error));
 
     return {
+      // called by the orchestrator once the cursor for this change is durably
+      // persisted: only now may the slot's confirmed LSN move past the change
+      ack: async (cursor: string) => {
+        ackedLsn = cursor;
+        await current?.acknowledge(cursor).catch(() => undefined);
+      },
       stop: async () => {
         stopped = true;
         await current?.stop().catch(() => undefined);

--- a/apps/api/src/hooks/cdc/providers/redis-cdc.provider.test.ts
+++ b/apps/api/src/hooks/cdc/providers/redis-cdc.provider.test.ts
@@ -1,0 +1,117 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import type { ConnectionConfig } from '@syncle/core';
+import type { ResolvedHook } from '../../hooks.types';
+import type { CdcChange, CdcStreamContext } from '../cdc-provider';
+import { RedisCdcProvider } from './redis-cdc.provider';
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** just enough of an ioredis client for startStream's subscriber connection */
+class FakeSub extends EventEmitter {
+  async connect(): Promise<void> {}
+  async psubscribe(_pattern: string): Promise<void> {}
+  disconnect(): void {}
+}
+
+/** value reader whose TYPE/GET round-trips take real (fake) time */
+class FakeReader {
+  constructor(private readonly values: Map<string, string>) {}
+  async connect(): Promise<void> {}
+  disconnect(): void {}
+  async type(key: string): Promise<string> {
+    await delay(15); // the window the DEL used to slip through
+    return this.values.has(key) ? 'string' : 'none';
+  }
+  async get(key: string): Promise<string | null> {
+    await delay(5);
+    return this.values.get(key) ?? null;
+  }
+}
+
+const HOOK = {
+  source: { kind: 'table', connectionId: 'c1', table: 'keys' },
+  trigger: { kind: 'cdc', operations: ['insert', 'update', 'delete'] },
+} as unknown as ResolvedHook;
+
+const CONN = { engine: 'redis' } as unknown as ConnectionConfig;
+
+async function startFakeStream(reader: FakeReader) {
+  const provider = new RedisCdcProvider();
+  const sub = new FakeSub();
+  vi.spyOn(provider as unknown as { newClient: () => unknown }, 'newClient')
+    .mockImplementationOnce(() => sub)
+    .mockImplementationOnce(() => reader);
+
+  const seen: string[] = [];
+  const errors: string[] = [];
+  const handle = await provider.startStream({
+    hookId: 'h1',
+    hook: HOOK,
+    conn: CONN,
+    fromCursor: null,
+    handlers: {
+      onChange: async (change: CdcChange) => {
+        if (change.row.key === 'boom') throw new Error('sink exploded');
+        seen.push(`${change.op}:${String(change.row.key)}`);
+      },
+      onError: (err: Error) => {
+        errors.push(err.message);
+      },
+    },
+  } as CdcStreamContext);
+
+  const emit = (event: string, key: string) =>
+    sub.emit('pmessage', '__keyevent@0__:*', `__keyevent@0__:${event}`, key);
+  return { seen, errors, handle, emit };
+}
+
+describe('RedisCdcProvider event ordering', () => {
+  it('SET then DEL delivers as update then delete, never resurrecting the key', async () => {
+    const { seen, emit, handle } = await startFakeStream(
+      new FakeReader(new Map([['user:1', 'v1']])),
+    );
+
+    // the SET's value read is in flight when the DEL arrives; unchained, the
+    // DEL's instant buildRow would win and the order would invert
+    emit('set', 'user:1');
+    emit('del', 'user:1');
+
+    await vi.waitFor(() => expect(seen).toHaveLength(2));
+    expect(seen).toEqual(['update:user:1', 'delete:user:1']);
+    await handle.stop();
+  });
+
+  it('keeps arrival order across keys too', async () => {
+    const { seen, emit, handle } = await startFakeStream(
+      new FakeReader(
+        new Map([
+          ['a', '1'],
+          ['b', '2'],
+        ]),
+      ),
+    );
+
+    emit('set', 'a');
+    emit('set', 'b');
+    emit('del', 'a');
+
+    await vi.waitFor(() => expect(seen).toHaveLength(3));
+    expect(seen).toEqual(['update:a', 'update:b', 'delete:a']);
+    await handle.stop();
+  });
+
+  it('a failing delivery reports onError and later events still flow', async () => {
+    const { seen, errors, emit, handle } = await startFakeStream(
+      new FakeReader(new Map([['ok', 'v']])),
+    );
+
+    emit('set', 'boom');
+    emit('set', 'ok');
+
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen).toEqual(['update:ok']);
+    expect(errors).toEqual(['sink exploded']);
+    await handle.stop();
+  });
+});

--- a/apps/api/src/hooks/cdc/providers/redis-cdc.provider.ts
+++ b/apps/api/src/hooks/cdc/providers/redis-cdc.provider.ts
@@ -42,6 +42,10 @@ export class RedisCdcProvider implements CdcProvider {
   readonly engine: DatabaseEngine = 'redis';
   private readonly logger = new Logger('HookCdc:redis');
 
+  // the `key` filter is a glob applied at the subscription (see keyPattern),
+  // so the orchestrator must not ALSO evaluate it as a literal equality
+  readonly handlesSourceFilters = true;
+
   // no durable position, every delivered event is "new"
   cursorAfter(): boolean {
     return true;
@@ -169,6 +173,12 @@ export class RedisCdcProvider implements CdcProvider {
     let seq = 0;
     sub.on('error', (err: Error) => handlers.onError(err));
 
+    // admission chain: events must enter the pipeline in pmessage arrival
+    // order. buildRow awaits TYPE+GET for writes but resolves instantly for
+    // deletes, so firing them unchained lets a DEL overtake the SET before it
+    // and the destination applies delete-then-upsert, resurrecting the key
+    let chain: Promise<void> = Promise.resolve();
+
     sub.on('pmessage', (_pattern: string, channel: string, key: string) => {
       // channel: __keyevent@<db>__:<event>   message: <key>
       const event = channel.slice(channel.indexOf(':') + 1);
@@ -179,9 +189,13 @@ export class RedisCdcProvider implements CdcProvider {
       const op: CdcOperation = isDelete ? 'delete' : 'update';
       const cursor = `${Date.now()}:${seq++}`; // synthetic, non-durable
 
-      // resolve value out-of-band, never block the subscriber socket on it
-      void this.buildRow(reader, key, event, isDelete)
-        .then((row) => handlers.onChange({ op, row, cursor }))
+      // resolve the value off the subscriber socket, but chained: each event's
+      // read AND delivery complete before the next event's read begins
+      chain = chain
+        .then(async () => {
+          const row = await this.buildRow(reader, key, event, isDelete);
+          await handlers.onChange({ op, row, cursor });
+        })
         .catch((err) => handlers.onError(err as Error));
     });
 

--- a/apps/api/src/hooks/hook-cdc.service.ts
+++ b/apps/api/src/hooks/hook-cdc.service.ts
@@ -43,6 +43,7 @@ import {
   type CdcProvider,
   type CdcStreamHandle,
 } from './cdc/cdc-provider';
+import { rowMatchesFilters } from './cdc/filter-match';
 
 /** live runtime state for one active CDC stream */
 interface Stream {
@@ -308,7 +309,7 @@ export class HookCdcService implements OnModuleInit, OnModuleDestroy {
     return stream.pending;
   }
 
-  /** for one change: dedupe, render, deliver, record, persist cursor */
+  /** for one change: dedupe, filter, render, deliver, record, persist cursor, ack */
   private async processChange(
     hookId: string,
     hook: ResolvedHook,
@@ -320,6 +321,30 @@ export class HookCdcService implements OnModuleInit, OnModuleDestroy {
     // strict exactly-once: never re-process a position we've already done
     // (durable engines replay from the last acked cursor after a reconnect)
     if (!stream.provider.cursorAfter(change.cursor, stream.watermark)) return;
+
+    // source filters: replay pushes them into SQL, but a CDC stream sees every
+    // row of the table, so evaluate them in-process here. skipped rows still
+    // advance the durable cursor (and the provider's server-side ack point) so
+    // a filtered-out backlog never replays on resume or pins WAL on the source.
+    // delete images may carry only the key columns, hence passMissingColumns
+    if (
+      !stream.provider.handlesSourceFilters &&
+      !rowMatchesFilters(change.row, hook.source.filters, {
+        passMissingColumns: change.op === 'delete',
+      })
+    ) {
+      stream.watermark = change.cursor;
+      try {
+        await this.prisma.hookRun.update({
+          where: { id: stream.runId },
+          data: { cursorJson: JSON.stringify({ cursor: change.cursor }) },
+        });
+        await stream.handle.ack?.(change.cursor);
+      } catch {
+        /* a replay after a restart just re-evaluates the filter and skips again */
+      }
+      return;
+    }
 
     const seq = stream.seq;
     const now = new Date().toISOString();
@@ -353,6 +378,14 @@ export class HookCdcService implements OnModuleInit, OnModuleDestroy {
         where: { id: stream.runId },
         data: { cursorOffset: stream.seq, cursorJson: JSON.stringify({ cursor: change.cursor }) },
       });
+      // the checkpoint is durable, so the provider may now advance its
+      // server-side ack point (the Postgres slot's confirmed LSN). a missed
+      // ack only widens the replay window the watermark dedupe absorbs
+      try {
+        await stream.handle.ack?.(change.cursor);
+      } catch {
+        /* best-effort by contract */
+      }
     } catch (err) {
       // a transient pipeline error (Prisma/pool hiccup) must leave a trace: the
       // event becomes a FAILED delivery row, visible in the timeline + retryable


### PR DESCRIPTION
Four reliability fixes in the CDC pipeline, plus the unit tests the api package was missing.

**Postgres: slot no longer acks ahead of the checkpoint.** `pg-logical-replication` was configured with `acknowledge: { auto: true }`, so the slot's confirmed LSN advanced as soon as a change was received — but the orchestrator only persists the resume cursor after deliver + record. A crash in that window lost the change permanently (the slot had already moved past it). The stream now runs with manual acknowledge (`auto: false, timeoutSeconds: 0` — the standby-status timer acks the last received LSN even with auto off), and the orchestrator confirms each LSN through a new optional `ack()` on `CdcStreamHandle` only after the cursor row is persisted. Skipped messages (begin/commit/relation, disabled operations, other tables) are still confirmed so a mostly-filtered stream can't pin WAL, and keepalives are answered with the last persisted LSN so idle streams survive `wal_sender_timeout`. The existing watermark dedupe absorbs the resulting at-least-once replays.

**MySQL: mid-event crash no longer skips rows.** Cursors carried `file:nextPosition:i` where `nextPosition` points after the whole binlog event, so dying after row k of an N-row event resumed past the event and silently skipped rows k+1..N-1. Cursors now carry the start of the statement's tablemap event plus a running row index (`file:tablemapStart:row:s`). The tablemap start is the only safe re-entry point — a row event replayed without its tablemap is silently dropped by zongji — and the row-index watermark discards the already-delivered prefix on replay. Legacy 2-part and 3-part cursors still parse, and a tie between old end-position and new start-position cursors at the same byte offset resolves in binlog order.

**Redis: SET-then-DEL can no longer invert.** `buildRow` resolves instantly for deletes but awaits TYPE+GET for writes, so a delete published after a write could reach the pipeline first and the destination applied delete-then-upsert, resurrecting the key. Events are now chained in pmessage arrival order: each event's value read and delivery complete before the next begins.

**Source filters are finally enforced.** The CDC pipeline never evaluated `hook.source.filters`, so a filtered bridge streamed the whole table. The orchestrator now evaluates the filters in-process per change with the same semantics as the adapters' `buildWhere` / `buildMongoFilter` (AND, SQL NULL rules, case-insensitive LIKE, empty `in` matches nothing, numeric-string coercion). Filtered rows still advance the cursor and the ack point so a skipped backlog never replays or pins WAL. Key-only delete images (REPLICA IDENTITY DEFAULT) pass filters on absent columns so deletes keep syncing. Redis keeps its native key-glob handling and opts out via `handlesSourceFilters`.

**Tests:** new vitest suites for the MySQL cursor parsing/ordering and resume-position math, the Postgres LSN comparison, the Redis ordering chain (with fake clients, no live server), and the filter evaluator. `--passWithNoTests` is removed from the api test script now that tests exist. `pnpm build:core`, `pnpm typecheck`, and `pnpm -r test` all pass.