### PR TITLE
Production-grade Docker image and CI that validates what ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# a newer push to the same branch supersedes the running check
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -18,10 +23,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      # .nvmrc is the single source of truth for the Node major — the same
+      # version the Dockerfile ships, so CI validates what runs in production
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
@@ -33,8 +40,31 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Test
-        run: pnpm test
+      - name: Lint
+        run: pnpm lint
+
+      # format:check stays local-only until the repo-wide reformat lands —
+      # 84 files predate the prettier config and would fail it today
+
+      - name: Test (with coverage summary)
+        run: pnpm test:coverage
 
       - name: Build
         run: pnpm build
+
+  # the installer path (`syncle up`) builds this image on user machines —
+  # keep it green in CI so a broken Dockerfile can't reach them
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # syntax=docker/dockerfile:1
 #
-# Single image that builds the whole Syncle monorepo (core + api + web).
-# The same image runs both the API and the web GUI — docker-compose.app.yml
+# Single image that runs both the API and the web GUI — docker-compose.app.yml
 # starts two containers from it with different commands. See `bin/syncle`.
+#
+# Two stages: `build` compiles the monorepo with the full toolchain, `runtime`
+# ships only production artifacts — the API's pruned prod install (via
+# `pnpm deploy`) and the web app's Next standalone output. No compilers, no
+# git, no dev dependencies, and it runs as the unprivileged `node` user.
 
 FROM node:22-bookworm-slim AS build
 ENV PNPM_HOME=/pnpm
@@ -30,13 +34,46 @@ RUN pnpm install --frozen-lockfile
 # 2) Build everything. NEXT_PUBLIC_API_URL is baked into the browser bundle at
 #    build time, so it must point at wherever the browser reaches the API
 #    (the host-exposed API port, default http://localhost:4002/api).
+#    NEXT_OUTPUT=standalone makes `next build` emit the self-contained server
+#    used by the runtime stage (plain `next start` keeps working outside Docker).
 COPY . .
 ARG NEXT_PUBLIC_API_URL=http://localhost:4002/api
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_OUTPUT=standalone
 RUN pnpm --filter @syncle/core build \
  && pnpm --filter @syncle/api build \
  && pnpm --filter @syncle/web build
 
+# 3) Prune the API to production dependencies only (dist + prisma + prod
+#    node_modules, including the generated client and the prisma CLI for
+#    `migrate deploy` at boot).
+# --legacy: copy workspace deps into node_modules rather than requiring the
+# repo-wide inject-workspace-packages setting (pnpm v10 default changed)
+RUN pnpm --filter @syncle/api deploy --prod --legacy /out/api
+
+# ---------------------------------------------------------------------------
+
+FROM node:22-bookworm-slim AS runtime
 ENV NODE_ENV=production
+WORKDIR /app
+
+# openssl for Prisma's engines; nothing else from the build toolchain.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openssl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# API: pruned production install.
+COPY --from=build /out/api /app/apps/api
+# Web: Next standalone server (nested under apps/web because the monorepo root
+# is the file-tracing root) plus its static assets.
+COPY --from=build /app/apps/web/.next/standalone /app/web
+COPY --from=build /app/apps/web/.next/static /app/web/apps/web/.next/static
+COPY --from=build /app/apps/web/public /app/web/apps/web/public
+
+# The api data dir must exist before the named volume mounts over it, and the
+# whole tree must be writable by the unprivileged user.
+RUN mkdir -p /app/apps/api/.syncle && chown -R node:node /app
+USER node
+
 # API 4002, Web 3002 — the actual command per container comes from compose.
 EXPOSE 4002 3002

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,8 @@
     "prisma:generate": "prisma generate",
     "migrate:dev": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test:coverage": "vitest run --passWithNoTests --coverage"
   },
   "dependencies": {
     "@nestjs/bullmq": "^10.2.3",
@@ -28,6 +29,7 @@
     "mongodb": "^6.21.0",
     "pg": "^8.13.1",
     "pg-logical-replication": "^2.0.3",
+    "prisma": "^5.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^3.23.8"
@@ -37,7 +39,7 @@
     "@nestjs/schematics": "^10.2.3",
     "@types/express": "^5.0.0",
     "@types/node": "^22.9.0",
-    "prisma": "^5.22.0",
+    "@vitest/coverage-v8": "^2.1.4",
     "typescript": "^5.6.3",
     "vitest": "^2.1.4"
   }

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 import { CryptoService } from './crypto.service';
+import { HealthController } from './health.controller';
 import { PrismaService } from './prisma.service';
 
 /**
@@ -9,6 +10,7 @@ import { PrismaService } from './prisma.service';
  */
 @Global()
 @Module({
+  controllers: [HealthController],
   providers: [PrismaService, CryptoService],
   exports: [PrismaService, CryptoService],
 })

--- a/apps/api/src/common/health.controller.ts
+++ b/apps/api/src/common/health.controller.ts
@@ -1,0 +1,21 @@
+/**
+ * liveness/readiness probe for containers and monitors. public by design —
+ * it leaks nothing beyond "the API and its metadata store are reachable",
+ * and orchestrators need it before anyone can log in.
+ */
+import { Controller, Get } from '@nestjs/common';
+import { Public } from '../auth/public.decorator';
+import { PrismaService } from './prisma.service';
+
+@Controller('health')
+export class HealthController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Public()
+  @Get()
+  async health(): Promise<{ ok: true }> {
+    // a real round-trip to the metadata store, not just "process is up"
+    await this.prisma.$queryRaw`SELECT 1`;
+    return { ok: true };
+  }
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -11,6 +11,9 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // The Docker build sets NEXT_OUTPUT=standalone to emit the self-contained
+  // server the runtime image ships; plain `next start` keeps working otherwise.
+  ...(process.env.NEXT_OUTPUT === 'standalone' ? { output: 'standalone' } : {}),
   // The web app is a pure frontend; all data access goes through the NestJS
   // API. `@syncle/core` is consumed for shared types and Zod schemas only.
   transpilePackages: ['@syncle/core'],

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -61,6 +61,18 @@ services:
       - syncle-api-data:/app/apps/api/.syncle
     ports:
       - '4002:4002'
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://127.0.0.1:4002/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     depends_on:
       postgres:
         condition: service_healthy
@@ -74,15 +86,18 @@ services:
       dockerfile: Dockerfile
     container_name: syncle-web
     restart: unless-stopped
-    working_dir: /app/apps/web
-    command: ['node', 'scripts/next-with-port.mjs', 'start']
+    working_dir: /app/web/apps/web
+    # the Next standalone server produced by the image's build stage
+    command: ['node', 'server.js']
     environment:
       NODE_ENV: production
-      WEB_PORT: '3002'
+      PORT: '3002'
+      HOSTNAME: 0.0.0.0
     ports:
       - '3002:3002'
     depends_on:
-      - api
+      api:
+        condition: service_healthy
 
 volumes:
   syncle-postgres-data:

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
+    "test:coverage": "pnpm -r --workspace-concurrency=1 test:coverage",
     "format": "prettier --write \"**/*.{ts,tsx,css,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,css,md}\"",
     "clean": "rm -rf packages/core/dist apps/api/dist apps/web/.next packages/core/tsconfig.tsbuildinfo apps/api/tsconfig.tsbuildinfo",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "better-sqlite3": "^12.11.1",
@@ -33,6 +34,7 @@
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^22.9.0",
     "@types/pg": "^8.11.10",
+    "@vitest/coverage-v8": "^2.1.4",
     "typescript": "^5.6.3",
     "vitest": "^2.1.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       pg-logical-replication:
         specifier: ^2.0.3
         version: 2.5.0
+      prisma:
+        specifier: ^5.22.0
+        version: 5.22.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -84,9 +87,9 @@ importers:
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.19
-      prisma:
-        specifier: ^5.22.0
-        version: 5.22.0
+      '@vitest/coverage-v8':
+        specifier: ^2.1.4
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.19)(terser@5.48.0))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -254,6 +257,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.20.0
+      '@vitest/coverage-v8':
+        specifier: ^2.1.4
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.19)(terser@5.48.0))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -266,6 +272,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@angular-devkit/core@17.3.11':
     resolution: {integrity: sha512-vTNDYNsLIWpYk2I969LMQFH29GTsLzxNk/0cLw5q56ARF0v5sIWfHYwGTS88jdDqIpuuettcSczbxeA7EuAmqQ==}
@@ -289,9 +299,25 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -694,6 +720,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2005,6 +2035,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -3153,6 +3192,9 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -3358,6 +3400,22 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterare@1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
@@ -3498,6 +3556,13 @@ packages:
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -4636,6 +4701,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -5043,6 +5112,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@angular-devkit/core@17.3.11(chokidar@3.6.0)':
     dependencies:
       ajv: 8.12.0
@@ -5081,7 +5155,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -5373,6 +5460,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6577,6 +6666,24 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.19)(terser@5.48.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@22.19.19)(terser@5.48.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -7977,6 +8084,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-escaper@2.0.2: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -8225,6 +8334,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterare@1.2.1: {}
 
   iterator.prototype@1.1.5:
@@ -8352,6 +8482,16 @@ snapshots:
   magic-string@0.30.8:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
 
   math-intrinsics@1.1.0: {}
 
@@ -9487,6 +9627,12 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.4.5
+      minimatch: 10.2.5
 
   thenify-all@1.6.0:
     dependencies:


### PR DESCRIPTION
Two infrastructure fixes from the review:

**Docker.** The single-stage Dockerfile shipped the build stage as the runtime image — compilers, git, dev dependencies, running as root, no healthcheck. It's now multi-stage: the API is pruned to production deps via `pnpm deploy --prod --legacy` and the web app ships as Next's standalone server. Final image is 1.02GB (verified building locally end-to-end), runs as the unprivileged `node` user, and exposes a real health probe: `GET /api/health` does a metadata-store round-trip, the app compose healthchecks the API on it, and the web container now waits for API health instead of bare `depends_on`.

**CI.** The workflow tested Node 24 while .nvmrc and the image ship 22 — it now reads `.nvmrc` directly. Added: `pnpm lint`, a coverage summary (`@vitest/coverage-v8`, visibility only, no thresholds yet), concurrency cancellation for superseded runs, and a second job that builds the Docker image with buildx layer caching so the installer path can't break invisibly. `format:check` is deliberately deferred until a repo-wide reformat lands — 84 files predate the prettier config.

Full gates pass locally: typecheck (3 workspaces), core tests 48/48, lint clean, Docker image builds.