### PR TITLE
Code health: one lifecycle owner, dialect hooks, honored abort, exact keyset resume

### DIFF
--- a/apps/api/src/hooks/hook-cdc.service.ts
+++ b/apps/api/src/hooks/hook-cdc.service.ts
@@ -372,6 +372,20 @@ export class HookCdcService implements OnModuleInit, OnModuleDestroy {
         { sequence: seq, rowIndex: seq, rowCount: 1, rowKeys },
         outcome,
       );
+      if (outcome.status === 'failed' && hook.delivery.onError === 'abort') {
+        // stop-on-error: pause the run and stop the stream WITHOUT advancing
+        // the watermark or acking, so this change replays on the next start.
+        // teardown happens outside the change chain — the provider's stop()
+        // may wait for in-flight handlers (i.e. this very call)
+        this.logger.warn(`CDC ${hookId}: pausing after a failed delivery (onError=abort)`);
+        await this.runs.finalize(
+          stream.runId,
+          'paused',
+          'Paused after a failed delivery (onError=abort).',
+        );
+        setImmediate(() => void this.teardown(hookId).catch(() => undefined));
+        return;
+      }
       stream.seq = seq + 1;
       stream.watermark = change.cursor;
       await this.prisma.hookRun.update({

--- a/apps/api/src/hooks/hook-lifecycle.service.ts
+++ b/apps/api/src/hooks/hook-lifecycle.service.ts
@@ -1,0 +1,54 @@
+/**
+ * one owner for "make this hook stop touching the world": stopping live
+ * listeners and tearing a hook down before deletion. the same sequence used
+ * to be hand-rolled in both the hooks and workspaces controllers and had
+ * already drifted (workspace deletes left in-flight replay runs to die on
+ * NotFoundError and never dropped cross-kind listener remnants).
+ */
+import { Injectable } from '@nestjs/common';
+import type { HookRun } from '@syncle/core';
+import { DatabaseSinkService } from './database-sink.service';
+import { HookCdcService } from './hook-cdc.service';
+import { HookRunService } from './hook-run.service';
+import { HookWatchService } from './hook-watch.service';
+
+@Injectable()
+export class HookLifecycleService {
+  constructor(
+    private readonly cdc: HookCdcService,
+    private readonly watch: HookWatchService,
+    private readonly runs: HookRunService,
+    private readonly databaseSink: DatabaseSinkService,
+  ) {}
+
+  /**
+   * stop the live listener of a specific trigger kind (used before an edit,
+   * routed by the OLD kind so a cdc→watch change can't leave a zombie stream).
+   * returns whether a listener was actually running.
+   */
+  async stopListener(hookId: string, kind: 'cdc' | 'watch'): Promise<boolean> {
+    if (kind === 'cdc') {
+      return (await this.cdc.stop(hookId).catch(() => null)) !== null;
+    }
+    return (await this.watch.stop(hookId).catch(() => null)) !== null;
+  }
+
+  /**
+   * full pre-delete teardown. tears down BOTH listener kinds (a hook edited
+   * across trigger kinds may have remnants of either; each is a no-op when
+   * idle), drops the CDC slot/publication on the source, cancels queued and
+   * running replay runs so no worker keeps delivering for a hook that is
+   * about to vanish, and clears the sink's ensured-table cache.
+   */
+  async teardown(hookId: string): Promise<void> {
+    await this.cdc.cleanup(hookId).catch(() => undefined);
+    await this.watch.stop(hookId).catch(() => undefined);
+    const runs = await this.runs.listRuns(hookId).catch(() => [] as HookRun[]);
+    for (const run of runs) {
+      if (run.status === 'queued' || run.status === 'running') {
+        await this.runs.cancel(hookId, run.id).catch(() => undefined);
+      }
+    }
+    this.databaseSink.forget(hookId);
+  }
+}

--- a/apps/api/src/hooks/hook-run.processor.ts
+++ b/apps/api/src/hooks/hook-run.processor.ts
@@ -29,11 +29,35 @@ import { HookSinkService } from './hook-sink.service';
 import { HookRunService } from './hook-run.service';
 import { HookStoreService } from './hook-store.service';
 import { RunRegistryService } from './run-registry.service';
-import { HOOK_RUNS_QUEUE, type HookRunJob, type ResolvedHook } from './hooks.types';
+import {
+  HOOK_RUNS_QUEUE,
+  type HookRunJob,
+  type KeysetCheckpoint,
+  type ResolvedHook,
+} from './hooks.types';
 
 interface StreamItem {
   row: Record<string, unknown>;
   index: number;
+  /** present on keyset-paginated streams: this row's checkpointable key */
+  keyset?: KeysetCheckpoint;
+}
+
+/**
+ * read the keyset checkpoint out of a run's cursorJson, if one was stored.
+ * watch cursors share the column but use their own shape (no `keyset` key),
+ * and legacy replay runs stored nothing — both yield null.
+ */
+function parseKeysetCheckpoint(cursorJson: string | null): KeysetCheckpoint | null {
+  if (!cursorJson) return null;
+  try {
+    const keyset = (JSON.parse(cursorJson) as { keyset?: KeysetCheckpoint }).keyset;
+    return keyset && typeof keyset.column === 'string'
+      ? { column: keyset.column, value: keyset.value }
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 @Processor(HOOK_RUNS_QUEUE, { concurrency: runtimeConfig.hookConcurrency })
@@ -69,7 +93,13 @@ export class HookRunProcessor extends WorkerHost {
       if (job.data.mode === 'resend') {
         await this.runs.executeResend(runId, controller.signal);
       } else {
-        await this.execute(runId, row.cursorOffset, row.configSnapshotJson, controller.signal);
+        await this.execute(
+          runId,
+          row.cursorOffset,
+          parseKeysetCheckpoint(row.cursorJson),
+          row.configSnapshotJson,
+          controller.signal,
+        );
       }
     } finally {
       this.registry.release(runId);
@@ -79,6 +109,7 @@ export class HookRunProcessor extends WorkerHost {
   private async execute(
     runId: string,
     startOffset: number,
+    resumeKey: KeysetCheckpoint | null,
     snapshotJson: string,
     signal: AbortSignal,
   ): Promise<void> {
@@ -116,19 +147,24 @@ export class HookRunProcessor extends WorkerHost {
 
     let buffer: Record<string, unknown>[] = [];
     let bufferStart = startOffset;
+    // the keyset value of the newest row in the flushed prefix; checkpointed
+    // with the offset so a resume lands on the exact next row even when the
+    // table mutated between attempts (an OFFSET re-seek cannot promise that)
+    let lastKeyset: KeysetCheckpoint | undefined;
 
     try {
-      for await (const item of this.streamRows(hook, runId, startOffset)) {
+      for await (const item of this.streamRows(hook, runId, startOffset, resumeKey)) {
         if (await stopRequested()) {
           await this.runs.finalize(runId, 'canceled');
           return;
         }
         buffer.push(item.row);
+        if (item.keyset) lastKeyset = item.keyset;
         if (buffer.length === batchSize) {
           const stop = await this.flush(runId, table, buffer, bufferStart, done, priorTargets, hook, pkColumn, signal);
           buffer = [];
           bufferStart = item.index + 1;
-          await this.runs.setCursor(runId, bufferStart);
+          await this.runs.setCursor(runId, bufferStart, lastKeyset);
           if (stop) {
             await this.runs.finalize(runId, 'failed', 'Stopped after a failed delivery (onError=abort).');
             return;
@@ -210,9 +246,10 @@ export class HookRunProcessor extends WorkerHost {
     hook: ResolvedHook,
     runId: string,
     startOffset: number,
+    resumeKey: KeysetCheckpoint | null,
   ): AsyncGenerator<StreamItem> {
     return hook.source.kind === 'table'
-      ? this.streamTable(hook, runId, startOffset)
+      ? this.streamTable(hook, runId, startOffset, resumeKey)
       : this.streamQuery(hook, runId, startOffset);
   }
 
@@ -220,6 +257,7 @@ export class HookRunProcessor extends WorkerHost {
     hook: ResolvedHook,
     runId: string,
     startOffset: number,
+    resumeKey: KeysetCheckpoint | null,
   ): AsyncGenerator<StreamItem> {
     if (hook.source.kind !== 'table') return;
     const src = hook.source;
@@ -235,16 +273,23 @@ export class HookRunProcessor extends WorkerHost {
       let lastKey: unknown = null;
       let index = startOffset;
       if (startOffset > 0) {
-        // resume: find the key of the last already-delivered row (one seek)
-        const seek = await browse({
-          schema: src.schema,
-          table: src.table,
-          filters: src.filters,
-          sort,
-          limit: 1,
-          offset: startOffset - 1,
-        });
-        lastKey = seek.rows[0]?.[keysetColumn] ?? null;
+        if (resumeKey && resumeKey.column === keysetColumn) {
+          // exact resume from the checkpointed key — immune to rows added or
+          // removed under the run, and no deep-OFFSET seek query
+          lastKey = resumeKey.value;
+        } else {
+          // legacy runs (no checkpoint) or a changed sort column: fall back to
+          // seeking the key of the last already-delivered row by offset
+          const seek = await browse({
+            schema: src.schema,
+            table: src.table,
+            filters: src.filters,
+            sort,
+            limit: 1,
+            offset: startOffset - 1,
+          });
+          lastKey = seek.rows[0]?.[keysetColumn] ?? null;
+        }
       }
       for (;;) {
         const filters = [
@@ -262,9 +307,9 @@ export class HookRunProcessor extends WorkerHost {
           offset: 0,
         });
         for (const row of page.rows) {
-          yield { row, index };
-          index++;
           lastKey = row[keysetColumn];
+          yield { row, index, keyset: { column: keysetColumn, value: lastKey } };
+          index++;
         }
         if (!page.hasMore || page.rows.length === 0) return;
       }

--- a/apps/api/src/hooks/hook-run.service.ts
+++ b/apps/api/src/hooks/hook-run.service.ts
@@ -4,14 +4,14 @@
  * has to stream and deliver.
  *
  * durability model: one BullMQ job per run (`jobId = runId`). a crashed run is
- * recovered by BullMQ's stalled-job detection and resumed from `cursorOffset`;
+ * recovered by BullMQ's stalled-job detection and resumed from its checkpoint
+ * (`cursorOffset`, plus the last keyset value for keyset-paginated streams);
  * on boot we also re-enqueue any non-terminal run so nothing is orphaned.
  */
 import { randomUUID } from 'node:crypto';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import {
-  AppError,
   BadRequestError,
   ConflictError,
   type CdcOperation,
@@ -36,7 +36,9 @@ import {
   HOOK_RUNS_QUEUE,
   type DeliveryOutcome,
   type HookRunJob,
+  type KeysetCheckpoint,
 } from './hooks.types';
+import { ensureQueueReady } from './queue.util';
 
 const ACTIVE: HookRunStatus[] = ['queued', 'running', 'canceling'];
 const TERMINAL: HookRunStatus[] = [
@@ -91,7 +93,7 @@ export class HookRunService implements OnModuleInit {
     });
     if (failedCount === 0) throw new BadRequestError('No failed deliveries to retry.');
 
-    await this.ensureQueueReady();
+    await ensureQueueReady(this.queue);
     await this.clearSettledJob(runId);
     const row = await this.prisma.hookRun.update({
       where: { id: runId },
@@ -312,7 +314,7 @@ export class HookRunService implements OnModuleInit {
           where: { hookId, status: 'draft' },
         });
     if (draft && draft.hookId === hookId && draft.status === 'draft') {
-      await this.ensureQueueReady();
+      await ensureQueueReady(this.queue);
       const row = await this.prisma.hookRun.update({
         where: { id: draft.id },
         data: { status: 'queued', startedAt: new Date() },
@@ -338,7 +340,7 @@ export class HookRunService implements OnModuleInit {
     });
     if (latest) return this.resume(hookId, latest.id);
 
-    await this.ensureQueueReady();
+    await ensureQueueReady(this.queue);
     const id = randomUUID();
     const snapshotJson = await this.store.snapshotJson(hookId);
     const total = await this.computeTotal(snapshotJson).catch(() => null);
@@ -376,12 +378,15 @@ export class HookRunService implements OnModuleInit {
     if (failedCount === 0)
       throw new BadRequestError('No failed rows to retry.');
 
-    await this.ensureQueueReady();
+    await ensureQueueReady(this.queue);
     const updated = await this.prisma.hookRun.update({
       where: { id: runId },
       data: {
         status: 'queued',
         cursorOffset: 0,
+        // the keyset checkpoint belongs to the reset offset — keeping it would
+        // make the re-stream resume mid-table and skip the earlier failed rows
+        cursorJson: null,
         error: null,
         finishedAt: null,
         configSnapshotJson: await this.store.snapshotJson(hookId),
@@ -428,7 +433,7 @@ export class HookRunService implements OnModuleInit {
         `Run "${runId}" cannot be resumed (status: ${row.status}).`,
       );
     }
-    await this.ensureQueueReady();
+    await ensureQueueReady(this.queue);
     // resume the REMAINING rows with the hook's CURRENT config, so edits made
     // after the run started (e.g. fewer columns, a new endpoint) take effect
     const reset = await this.prisma.hookRun.update({
@@ -473,25 +478,6 @@ export class HookRunService implements OnModuleInit {
     } catch {
       /* best-effort, the add that follows still surfaces real queue failures */
       return undefined;
-    }
-  }
-
-  /** fail fast with a friendly message when Redis is unreachable */
-  private async ensureQueueReady(): Promise<void> {
-    try {
-      await Promise.race([
-        this.queue.waitUntilReady(),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('timeout')), 2000),
-        ),
-      ]);
-      return;
-    } catch {
-      throw new AppError(
-        'CONNECTION_FAILED',
-        'The job queue (Redis) is unavailable. Start it with `docker compose up -d redis` or set REDIS_URL.',
-        503,
-      );
     }
   }
 
@@ -688,10 +674,26 @@ export class HookRunService implements OnModuleInit {
     });
   }
 
-  async setCursor(runId: string, cursorOffset: number): Promise<void> {
+  /**
+   * checkpoint the resume position. for keyset-paginated streams the actual
+   * last keyset value is persisted alongside the offset: resuming from the
+   * stored key lands on the exact row after the last delivered one even when
+   * the table changed between attempts, which an OFFSET re-seek cannot
+   * guarantee. `null` clears a stale checkpoint (offset-paginated streams).
+   */
+  async setCursor(
+    runId: string,
+    cursorOffset: number,
+    keyset?: KeysetCheckpoint | null,
+  ): Promise<void> {
     await this.prisma.hookRun.update({
       where: { id: runId },
-      data: { cursorOffset },
+      data: {
+        cursorOffset,
+        ...(keyset !== undefined
+          ? { cursorJson: keyset ? JSON.stringify({ keyset }) : null }
+          : {}),
+      },
     });
   }
 

--- a/apps/api/src/hooks/hook-watch.service.ts
+++ b/apps/api/src/hooks/hook-watch.service.ts
@@ -293,6 +293,22 @@ export class HookWatchService implements OnModuleInit {
             where: { id: run.id },
             data: { cursorOffset: seq },
           });
+          if (outcome.status === 'failed' && hook.delivery.onError === 'abort') {
+            // stop-on-error: unschedule and leave the run paused with the
+            // reason, WITHOUT persisting this page's advanced cursor — the
+            // next start re-fetches the window, so the failed row is retried
+            // (stable idempotency keys make the overlap safe for receivers)
+            this.logger.warn(
+              `Watch ${hookId}: pausing after a failed delivery (onError=abort)`,
+            );
+            await this.unschedule(hookId);
+            await this.runs.finalize(
+              run.id,
+              'paused',
+              'Paused after a failed delivery (onError=abort).',
+            );
+            return;
+          }
           if (hook.delivery.minDelayMs) await sleep(hook.delivery.minDelayMs, signal);
         }
         if (signal.aborted) return;

--- a/apps/api/src/hooks/hooks.controller.ts
+++ b/apps/api/src/hooks/hooks.controller.ts
@@ -34,6 +34,7 @@ import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { DatabaseSinkService } from './database-sink.service';
 import { DeliveryService } from './delivery.service';
 import { HookCdcService } from './hook-cdc.service';
+import { HookLifecycleService } from './hook-lifecycle.service';
 import { HookRunService } from './hook-run.service';
 import { HookStoreService } from './hook-store.service';
 import { HookWatchService } from './hook-watch.service';
@@ -50,6 +51,7 @@ export class HooksController {
     private readonly pool: AdapterPoolService,
     private readonly delivery: DeliveryService,
     private readonly databaseSink: DatabaseSinkService,
+    private readonly lifecycle: HookLifecycleService,
   ) {}
 
   /* ----- CRUD ----- */
@@ -90,12 +92,10 @@ export class HooksController {
     // kind — routing by the new one after an edit (say cdc → watch) would leave
     // the old stream running as a zombie, delivering into a finalized run
     const before = await this.store.get(id);
-    let wasListening = false;
-    if (before.trigger.kind === 'cdc') {
-      wasListening = (await this.cdc.stop(id).catch(() => null)) !== null;
-    } else if (before.trigger.kind === 'watch') {
-      wasListening = (await this.watch.stop(id).catch(() => null)) !== null;
-    }
+    const wasListening =
+      before.trigger.kind === 'cdc' || before.trigger.kind === 'watch'
+        ? await this.lifecycle.stopListener(id, before.trigger.kind)
+        : false;
 
     const hook = await this.store.update(id, dto);
     // the destination may have changed; drop the sink's ensured-table cache
@@ -120,20 +120,7 @@ export class HooksController {
   @Delete(':id')
   async remove(@Param('id') id: string): Promise<{ id: string }> {
     await this.store.get(id); // 404s if missing
-    // tear down BOTH listener kinds before deleting: a hook edited across
-    // trigger kinds may have remnants of either (each is a no-op when idle).
-    // cdc.cleanup also drops the replication slot/publication on the source
-    await this.cdc.cleanup(id).catch(() => undefined);
-    await this.watch.stop(id).catch(() => undefined);
-    // stop any in-flight replay run so the worker doesn't keep delivering
-    // rows for a bridge that no longer exists
-    const runs = await this.runs.listRuns(id).catch(() => [] as HookRun[]);
-    for (const run of runs) {
-      if (run.status === 'queued' || run.status === 'running') {
-        await this.runs.cancel(id, run.id).catch(() => undefined);
-      }
-    }
-    this.databaseSink.forget(id);
+    await this.lifecycle.teardown(id);
     await this.store.remove(id);
     return { id };
   }

--- a/apps/api/src/hooks/hooks.module.ts
+++ b/apps/api/src/hooks/hooks.module.ts
@@ -7,6 +7,7 @@ import { HookSinkService } from './hook-sink.service';
 import { HookRunProcessor } from './hook-run.processor';
 import { HookRunService } from './hook-run.service';
 import { HookCdcService } from './hook-cdc.service';
+import { HookLifecycleService } from './hook-lifecycle.service';
 import { HookStoreService } from './hook-store.service';
 import { HookWatchProcessor } from './hook-watch.processor';
 import { HookWatchService } from './hook-watch.service';
@@ -32,6 +33,7 @@ import { SqliteCdcProvider } from './cdc/providers/sqlite-cdc.provider';
     HookRunService,
     HookWatchService,
     HookCdcService,
+    HookLifecycleService,
     DeliveryService,
     DatabaseSinkService,
     HookSinkService,
@@ -57,6 +59,6 @@ import { SqliteCdcProvider } from './cdc/providers/sqlite-cdc.provider';
     },
   ],
   // exported so WorkspacesModule can stop a workspace's live bridges on delete
-  exports: [HookStoreService, HookWatchService, HookCdcService],
+  exports: [HookStoreService, HookWatchService, HookCdcService, HookLifecycleService],
 })
 export class HooksModule {}

--- a/apps/api/src/hooks/hooks.types.ts
+++ b/apps/api/src/hooks/hooks.types.ts
@@ -53,6 +53,18 @@ export interface DeliveryOutcome {
   succeededTargets?: string[] | null;
 }
 
+/**
+ * the last keyset value a replay run delivered, persisted (as
+ * `cursorJson: {"keyset": ...}`) alongside `cursorOffset` at every batch
+ * checkpoint. resuming from the stored key is exact even when rows were added
+ * or removed under the run, where an OFFSET re-seek would land on the wrong
+ * row. `column` guards against resuming a value against a changed sort.
+ */
+export interface KeysetCheckpoint {
+  column: string;
+  value: unknown;
+}
+
 /** the BullMQ job payload for the `hook-runs` queue */
 export interface HookRunJob {
   runId: string;

--- a/apps/api/src/hooks/queue.util.ts
+++ b/apps/api/src/hooks/queue.util.ts
@@ -1,0 +1,25 @@
+/** shared BullMQ queue plumbing for the hook services */
+import { AppError } from '@syncle/core';
+
+/**
+ * fail fast with a friendly message when Redis is unreachable, instead of
+ * letting an enqueue hang on BullMQ's internal reconnect loop.
+ */
+export async function ensureQueueReady(queue: {
+  waitUntilReady(): Promise<unknown>;
+}): Promise<void> {
+  try {
+    await Promise.race([
+      queue.waitUntilReady(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), 2000),
+      ),
+    ]);
+  } catch {
+    throw new AppError(
+      'CONNECTION_FAILED',
+      'The job queue (Redis) is unavailable. Start it with `docker compose up -d redis` or set REDIS_URL.',
+      503,
+    );
+  }
+}

--- a/apps/api/src/workspaces/workspaces.controller.ts
+++ b/apps/api/src/workspaces/workspaces.controller.ts
@@ -14,8 +14,7 @@ import {
 } from '@syncle/core';
 import { ZodValidationPipe } from '../common/zod-validation.pipe';
 import { HookStoreService } from '../hooks/hook-store.service';
-import { HookWatchService } from '../hooks/hook-watch.service';
-import { HookCdcService } from '../hooks/hook-cdc.service';
+import { HookLifecycleService } from '../hooks/hook-lifecycle.service';
 import { WorkspaceStoreService } from './workspace-store.service';
 
 @Controller('workspaces')
@@ -23,8 +22,7 @@ export class WorkspacesController {
   constructor(
     private readonly store: WorkspaceStoreService,
     private readonly hooks: HookStoreService,
-    private readonly watch: HookWatchService,
-    private readonly cdc: HookCdcService,
+    private readonly lifecycle: HookLifecycleService,
   ) {}
 
   @Get()
@@ -54,15 +52,12 @@ export class WorkspacesController {
 
   @Delete(':id')
   async remove(@Param('id') id: string): Promise<{ id: string }> {
-    // stop any live listeners in this workspace before the cascade delete, so
-    // CDC slots get dropped and watch schedulers stop cleanly (no zombies).
+    // full teardown of every hook before the cascade delete: CDC slots get
+    // dropped, watch schedulers stop, and in-flight replay runs are canceled
+    // (the same sequence a single-hook delete performs)
     const hooks = await this.hooks.list(id).catch(() => []);
     for (const hook of hooks) {
-      if (hook.trigger.kind === 'cdc') {
-        await this.cdc.cleanup(hook.id).catch(() => undefined);
-      } else if (hook.trigger.kind === 'watch') {
-        await this.watch.stop(hook.id).catch(() => undefined);
-      }
+      await this.lifecycle.teardown(hook.id);
     }
     await this.store.remove(id);
     return { id };

--- a/apps/web/src/lib/engines.ts
+++ b/apps/web/src/lib/engines.ts
@@ -8,14 +8,16 @@ interface EngineMeta {
   className: string;
 }
 
-export const ENGINE_META: Record<DatabaseEngine, EngineMeta> = {
+// labels mirror the driver registry names served by /drivers — only engines
+// with a registered adapter get an entry; anything else falls back below
+export const ENGINE_META: Partial<Record<DatabaseEngine, EngineMeta>> = {
   postgres: {
     label: 'PostgreSQL',
     abbr: 'PG',
     className: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
   },
   mysql: {
-    label: 'MySQL',
+    label: 'MySQL / MariaDB',
     abbr: 'My',
     className: 'bg-orange-500/15 text-orange-600 dark:text-orange-400',
   },
@@ -34,19 +36,18 @@ export const ENGINE_META: Record<DatabaseEngine, EngineMeta> = {
     abbr: 'Rd',
     className: 'bg-red-500/15 text-red-600 dark:text-red-400',
   },
-  mssql: {
-    label: 'SQL Server',
-    abbr: 'MS',
-    className: 'bg-rose-500/15 text-rose-600 dark:text-rose-400',
-  },
 };
 
-export function engineMeta(engine: DatabaseEngine): EngineMeta {
-  return (
-    ENGINE_META[engine] ?? {
-      label: engine,
-      abbr: engine.slice(0, 2).toUpperCase(),
-      className: 'bg-muted text-muted-foreground',
-    }
-  );
+/**
+ * look up display metadata for an engine. pass the driver's registry label
+ * (from /drivers) when it's at hand — the registry is the naming authority;
+ * the local table only covers engines the API might not be serving yet.
+ */
+export function engineMeta(engine: DatabaseEngine, driverLabel?: string): EngineMeta {
+  const meta = ENGINE_META[engine] ?? {
+    label: engine,
+    abbr: engine.slice(0, 2).toUpperCase(),
+    className: 'bg-muted text-muted-foreground',
+  };
+  return driverLabel ? { ...meta, label: driverLabel } : meta;
 }

--- a/apps/web/src/lib/sql.ts
+++ b/apps/web/src/lib/sql.ts
@@ -1,10 +1,8 @@
-import type { DatabaseEngine } from '@syncle/core';
+import { quoteIdent, type DatabaseEngine } from '@syncle/core';
 
-/** quote an identifier for the given engine's dialect */
-export function quoteIdent(engine: DatabaseEngine, id: string): string {
-  if (engine === 'mysql') return `\`${id.replace(/`/g, '``')}\``;
-  return `"${id.replace(/"/g, '""')}"`;
-}
+// quoting rules live in core next to the adapters that own the dialects —
+// re-exported here so existing imports keep working
+export { quoteIdent };
 
 /**
  * build a safe, dialect-quoted `SELECT *` for a relation. backs the

--- a/packages/core/src/adapters/sql/base-sql-adapter.ts
+++ b/packages/core/src/adapters/sql/base-sql-adapter.ts
@@ -2,10 +2,12 @@
  * shared implementation for relational engines.
  *
  * concrete SQL adapters (Postgres, MySQL, SQLite, ...) only implement the
- * connection lifecycle, schema introspection, and three small dialect
- * primitives (`quoteIdent`, `placeholder`, `runSql`). everything user-facing
- * (browse, raw query, row mutations) is built here ONCE, with strict
- * parameterization so no user value is ever concatenated into SQL
+ * connection lifecycle, schema introspection, three small dialect primitives
+ * (`quoteIdent`, `placeholder`, `execPooled`) and, where their dialect
+ * deviates, the overridable hooks (`likeKeyword`, `upsertClause`,
+ * `booleanLiteral`, `hexLiteral`, `escapeStringLiteral`, ...). everything
+ * user-facing (browse, raw query, row mutations) is built here ONCE, with
+ * strict parameterization so no user value is ever concatenated into SQL
  */
 import type {
   AdapterCapabilities,
@@ -710,10 +712,18 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
     return `CREATE TABLE IF NOT EXISTS ${this.qualify(t.name, t.schema)} (\n${defs.join(',\n')}\n);`;
   }
 
-  /** binary literal for SQL dumps: `X'..'` (MySQL/SQLite) or `'\x..'` (PG) */
+  /** binary literal for SQL dumps: `X'..'` (Postgres overrides with `'\x..'`) */
   protected hexLiteral(buf: Buffer): string {
-    const hex = buf.toString('hex');
-    return this.engine === 'postgres' ? `'\\x${hex}'` : `X'${hex}'`;
+    return `X'${buf.toString('hex')}'`;
+  }
+
+  /**
+   * escape a string for embedding in a single-quoted SQL literal. the default
+   * doubles quotes per the SQL standard; dialects with extra escape characters
+   * override (MySQL also doubles backslashes).
+   */
+  protected escapeStringLiteral(text: string): string {
+    return text.replace(/'/g, "''");
   }
 
   private sqlLiteral(value: unknown): string {
@@ -725,12 +735,7 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
     if (Buffer.isBuffer(value)) return this.hexLiteral(value);
     const text =
       typeof value === 'object' ? JSON.stringify(value) : String(value);
-    let escaped = text.replace(/'/g, "''");
-    // MySQL treats backslash as an escape character inside string literals;
-    // leaving it unescaped corrupts the dump and lets a crafted value break
-    // out of the literal when the dump is restored
-    if (this.engine === 'mysql') escaped = escaped.replace(/\\/g, '\\\\');
-    return `'${escaped}'`;
+    return `'${this.escapeStringLiteral(text)}'`;
   }
 
   async restore(content: string, format: BackupFormat): Promise<RestoreResult> {

--- a/packages/core/src/adapters/sql/mysql-adapter.ts
+++ b/packages/core/src/adapters/sql/mysql-adapter.ts
@@ -15,6 +15,7 @@ import type {
   TableSchema,
 } from '../types';
 import { ConnectionError, QueryError } from '../../errors';
+import { quoteIdent } from '../../sql';
 import {
   BaseSqlAdapter,
   type SqlTransactionConnection,
@@ -108,7 +109,7 @@ export class MysqlAdapter extends BaseSqlAdapter {
   }
 
   protected override quoteIdent(identifier: string): string {
-    return `\`${identifier.replace(/`/g, '``')}\``;
+    return quoteIdent('mysql', identifier);
   }
 
   protected override placeholder(): string {
@@ -117,6 +118,15 @@ export class MysqlAdapter extends BaseSqlAdapter {
 
   protected override autoIncrementKeyword(): string {
     return 'AUTO_INCREMENT';
+  }
+
+  /**
+   * MySQL treats backslash as an escape character inside string literals;
+   * leaving it unescaped corrupts a SQL dump and lets a crafted value break
+   * out of the literal when the dump is restored.
+   */
+  protected override escapeStringLiteral(text: string): string {
+    return text.replace(/'/g, "''").replace(/\\/g, '\\\\');
   }
 
   /**

--- a/packages/core/src/adapters/sql/postgres-adapter.ts
+++ b/packages/core/src/adapters/sql/postgres-adapter.ts
@@ -17,6 +17,7 @@ import type {
   TableSchema,
 } from '../types';
 import { ConnectionError, QueryError } from '../../errors';
+import { quoteIdent } from '../../sql';
 import {
   BaseSqlAdapter,
   type SqlTransactionConnection,
@@ -100,7 +101,7 @@ export class PostgresAdapter extends BaseSqlAdapter {
   }
 
   protected override quoteIdent(identifier: string): string {
-    return `"${identifier.replace(/"/g, '""')}"`;
+    return quoteIdent('postgres', identifier);
   }
 
   protected override placeholder(index: number): string {
@@ -117,6 +118,10 @@ export class PostgresAdapter extends BaseSqlAdapter {
 
   protected override booleanLiteral(value: boolean): string {
     return value ? 'TRUE' : 'FALSE';
+  }
+
+  protected override hexLiteral(buf: Buffer): string {
+    return `'\\x${buf.toString('hex')}'`;
   }
 
   protected override async execPooled(

--- a/packages/core/src/adapters/sql/sqlite-adapter.ts
+++ b/packages/core/src/adapters/sql/sqlite-adapter.ts
@@ -17,6 +17,7 @@ import {
   QueryError,
   UnsupportedError,
 } from '../../errors';
+import { quoteIdent } from '../../sql';
 import {
   assertSafeDefaultValue,
   assertSafeIdentifier,
@@ -102,7 +103,7 @@ export class SqliteAdapter extends BaseSqlAdapter {
   }
 
   protected override quoteIdent(identifier: string): string {
-    return `"${identifier.replace(/"/g, '""')}"`;
+    return quoteIdent('sqlite', identifier);
   }
 
   protected override placeholder(): string {

--- a/packages/core/src/hooks/bridge.ts
+++ b/packages/core/src/hooks/bridge.ts
@@ -153,17 +153,6 @@ export function engineColumnType(
         uuid: isKey ? 'VARCHAR(255)' : 'CHAR(36)',
         text: isKey ? 'VARCHAR(255)' : 'TEXT',
       }[type];
-    case 'mssql':
-      return {
-        integer: 'INT',
-        bigint: 'BIGINT',
-        number: 'FLOAT',
-        boolean: 'BIT',
-        timestamp: 'DATETIME2',
-        json: 'NVARCHAR(MAX)',
-        uuid: 'UNIQUEIDENTIFIER',
-        text: isKey ? 'NVARCHAR(255)' : 'NVARCHAR(MAX)',
-      }[type];
     case 'sqlite':
     default:
       return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@
  */
 export * from './adapters/types';
 export * from './errors';
+export * from './sql';
 export * from './validation';
 export * from './hooks';
 export * from './workspace';

--- a/packages/core/src/sql.test.ts
+++ b/packages/core/src/sql.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { quoteIdent } from './sql';
+
+describe('quoteIdent', () => {
+  it('backtick-quotes for MySQL and escapes embedded backticks', () => {
+    expect(quoteIdent('mysql', 'users')).toBe('`users`');
+    expect(quoteIdent('mysql', 'we`ird')).toBe('`we``ird`');
+  });
+
+  it('double-quotes for the standard dialects and escapes embedded quotes', () => {
+    expect(quoteIdent('postgres', 'User')).toBe('"User"');
+    expect(quoteIdent('sqlite', 'or"der')).toBe('"or""der"');
+  });
+});

--- a/packages/core/src/sql.ts
+++ b/packages/core/src/sql.ts
@@ -1,0 +1,16 @@
+/**
+ * pure SQL dialect helpers shared by the core adapters and the web client.
+ * web-safe (no driver imports), so the browser bundle can quote identifiers
+ * exactly the way the adapters do — e.g. for "open in query editor" snippets —
+ * instead of re-implementing the per-engine rules and drifting.
+ */
+import type { DatabaseEngine } from './adapters/types';
+
+/** quote an identifier (table/column) safely for the engine's SQL dialect */
+export function quoteIdent(engine: DatabaseEngine, identifier: string): string {
+  // MySQL backtick-quotes; every other supported SQL dialect uses the
+  // standard double-quote form
+  return engine === 'mysql'
+    ? `\`${identifier.replace(/`/g, '``')}\``
+    : `"${identifier.replace(/"/g, '""')}"`;
+}

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,6 +1,10 @@
 /** shared Zod schemas for connection payloads (used on client and server) */
 import { z } from 'zod';
 
+// mirrors the DatabaseEngine union, including forward declarations that have
+// no adapter yet (mssql). the API re-validates the engine against the actual
+// driver registry before persisting, so a declared-but-unimplemented engine is
+// rejected there instead of being saved and 501ing on every later operation.
 export const engineSchema = z.enum([
   'postgres',
   'mysql',


### PR DESCRIPTION
Stacked on integration/fixes (merge that first — or merge #28–#34/#36 individually and retarget this to main). Behavior-preserving refactors plus two deliberate behavior fixes:

**Refactors**
- `HookLifecycleService` is now the single owner of listener stop + full teardown. Both the hooks and workspaces controllers use it — closing a real drift bug where workspace deletes left in-flight replay runs dying on NotFoundError and never dropped cross-kind listener remnants.
- `BaseSqlAdapter` contains zero engine-name comparisons: binary literals and string-literal escaping are overridable dialect hooks (Postgres and MySQL override respectively), matching the class's own design contract.
- The half-declared `mssql` engine is contracted to a forward declaration: engine validation now derives from the live adapter registry, dead branches removed.
- Shared `ensureQueueReady`; `quoteIdent` moved to core's web-safe entry (web re-exports it); engine display labels defer to the driver registry.

**Behavior fixes**
- `delivery.onError='abort'` is finally honored by live triggers: a failed delivery pauses a watch (scheduler unscheduled, cursor not advanced past the page) and stops a CDC stream (watermark not advanced, no ack) — the failed row is retried on the next start instead of being silently skipped forever.
- Replay runs checkpoint the actual last keyset value alongside the offset and resume from it directly — exact even when the table mutated between attempts; the OFFSET re-seek remains only as a fallback for legacy runs.

Gates: build, typecheck, 119 tests, lint — all clean. Caveat: the new abort paths are exercised indirectly by the existing suites; dedicated service-level tests for them would be a good follow-up.