### PR TITLE
refactor: split the bridge builder into sections with a single draft reducer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "node scripts/next-with-port.mjs start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
@@ -53,6 +54,7 @@
     "eslint-config-next": "^15.1.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.14",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
   }
 }

--- a/apps/web/src/components/bridges/bridge-builder.tsx
+++ b/apps/web/src/components/bridges/bridge-builder.tsx
@@ -1,28 +1,16 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Check,
-  Database,
-  Loader2,
-  Pencil,
-  Plus,
-  Radio,
-  RefreshCw,
-  Trash2,
-  Webhook,
-  X,
-} from 'lucide-react';
+/**
+ * full-screen bridge editor. this file is the orchestrator: it owns the draft
+ * reducer, the source queries, and the save flow, and composes the section
+ * components in `./builder/`. the draft state + cascades live in
+ * `./builder/draft.ts`, the pure load/save mappings in `./builder/mapping.ts`.
+ */
+import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { Loader2, Webhook } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
-import {
-  mapRow,
-  renderRow,
-  type FilterSpec,
-  type BridgeInputDTO,
-  type SortSpec,
-  type TableSchema,
-} from '@syncle/core';
+import type { TableSchema } from '@syncle/core';
 import { api, ApiError } from '@/lib/api';
 import {
   useBrowse,
@@ -33,109 +21,20 @@ import {
   useUpdateBridge,
 } from '@/lib/queries';
 import { useStudio } from '@/lib/store';
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Badge } from '@/components/ui/badge';
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from '@/components/ui/resizable';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-
-const PAGE_SIZE = 100;
-
-type AuthType = 'none' | 'bearer' | 'header';
-
-interface Destination {
-  url: string;
-  method: 'POST' | 'PUT' | 'PATCH';
-  authType: AuthType;
-  authToken: string;
-  authHeaderName: string;
-  authHeaderValue: string;
-  headers: { key: string; value: string }[];
-  idempotency: boolean;
-}
-
-/** a single database a bridge writes into (UI shape) */
-interface DbTarget {
-  connectionId: string;
-  database: string;
-  schema: string;
-  table: string;
-  writeMode: 'upsert' | 'insert';
-  /** target column names that uniquely identify a row (for upsert) */
-  keyColumns: string[];
-  createMissingTable: boolean;
-  /** optional source column → target column renames (default identity) */
-  renames: Record<string, string>;
-}
-
-function blankDbTarget(): DbTarget {
-  return {
-    connectionId: '',
-    database: '',
-    schema: '',
-    table: '',
-    writeMode: 'upsert',
-    keyColumns: [],
-    createMissingTable: true,
-    renames: {},
-  };
-}
-
-interface Delivery {
-  batchSize: number;
-  maxAttempts: number;
-  minDelayMs: number;
-  timeoutMs: number;
-  onError: 'continue' | 'abort';
-}
-
-function blankDestination(): Destination {
-  return {
-    url: '',
-    method: 'POST',
-    authType: 'none',
-    authToken: '',
-    authHeaderName: '',
-    authHeaderValue: '',
-    headers: [],
-    idempotency: false,
-  };
-}
-
-function blankDelivery(): Delivery {
-  return {
-    batchSize: 1,
-    maxAttempts: 3,
-    minDelayMs: 0,
-    timeoutMs: 15000,
-    onError: 'continue',
-  };
-}
-
-function jsType(v: unknown): string {
-  if (v === null || v === undefined) return 'null';
-  if (Array.isArray(v)) return 'array';
-  return typeof v;
-}
-
-function formatCell(value: unknown): string {
-  if (value === null || value === undefined) return 'NULL';
-  if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
-}
+import { PAGE_SIZE, builderReducer, initialDraft } from './builder/draft';
+import { buildInput, loadBridge } from './builder/mapping';
+import { SourceSection } from './builder/source-section';
+import { TriggerSection } from './builder/trigger-section';
+import { PayloadSection } from './builder/payload-section';
+import { DestinationSection } from './builder/destination-section';
+import { DeliverySection } from './builder/delivery-section';
 
 export function BridgeBuilder() {
   const t = useTranslations('bridgeBuilder');
@@ -145,47 +44,9 @@ export function BridgeBuilder() {
   const create = useCreateBridge();
   const update = useUpdateBridge();
 
-  // ----- source -----
-  const [name, setName] = useState('');
-  const [connectionId, setConnectionId] = useState('');
-  const [database, setDatabase] = useState('');
-  const [schema, setSchema] = useState('');
-  const [table, setTable] = useState('');
-  const [mode, setMode] = useState<'selected' | 'all'>('all');
-  const [selectedKeys, setSelectedKeys] = useState<Map<string, unknown>>(
-    new Map(),
-  );
-  const [included, setIncluded] = useState<Set<string>>(new Set());
-  /** column preference: null = all columns, array = a pinned subset (editing) */
-  const [fieldsPref, setFieldsPref] = useState<string[] | null>(null);
-  const [offset, setOffset] = useState(0);
-
-  // ----- trigger -----
-  // the builder is locked to one of two modes, decided by the toggle (new)
-  // or the bridge's existing trigger (editing). 'oneTime' = a replay-only
-  // job, 'live' = listen-only (polling/CDC). they never share trigger UI
-  const [syncMode, setSyncMode] = useState<'oneTime' | 'live'>('oneTime');
-  const [triggerKind, setTriggerKind] = useState<'replay' | 'watch' | 'cdc'>('replay');
-  const [watchStrategy, setWatchStrategy] = useState<
-    'increment' | 'timestamp' | 'snapshot'
-  >('increment');
-  const [watchColumn, setWatchColumn] = useState('');
-  const [pollSeconds, setPollSeconds] = useState(5);
-  const [watchStartFrom, setWatchStartFrom] = useState<'now' | 'beginning'>('now');
-  const [cdcOps, setCdcOps] = useState<Set<'insert' | 'update' | 'delete'>>(
-    new Set(['insert', 'update', 'delete']),
-  );
-  const [readiness, setReadiness] = useState<import('@syncle/core').CdcReadiness | null>(null);
-  const [checkingCdc, setCheckingCdc] = useState(false);
-
-  // ----- payload / destination / delivery -----
-  const [wrapKey, setWrapKey] = useState('');
-  const [destKind, setDestKind] = useState<'http' | 'database'>('http');
-  const [dest, setDest] = useState<Destination>(blankDestination);
-  const [dbTargets, setDbTargets] = useState<DbTarget[]>([blankDbTarget()]);
-  const [delivery, setDelivery] = useState<Delivery>(blankDelivery);
-  /** preserved on edit so saving doesn't silently re-enable a disabled bridge */
-  const [enabled, setEnabled] = useState(true);
+  const [draft, dispatch] = useReducer(builderReducer, undefined, initialDraft);
+  const { connectionId, database, schema, table, mode, selectedKeys, included } =
+    draft;
 
   const { data: connections } = useConnections();
   const { data: databases } = useDatabases(connectionId || null);
@@ -201,9 +62,9 @@ export function BridgeBuilder() {
   const browseParams = useMemo(
     () =>
       table
-        ? { schema: schema || undefined, table, limit: PAGE_SIZE, offset }
+        ? { schema: schema || undefined, table, limit: PAGE_SIZE, offset: draft.offset }
         : null,
-    [table, schema, offset],
+    [table, schema, draft.offset],
   );
   const {
     data: browse,
@@ -222,11 +83,11 @@ export function BridgeBuilder() {
     if (editing) {
       // start clean, and ignore the response if the editor moved on to a
       // different bridge (or closed) before this load resolved
-      reset();
+      dispatch({ type: 'reset' });
       let stale = false;
       api.getBridge(editing).then(
         (h) => {
-          if (!stale) loadBridge(h);
+          if (!stale) dispatch({ type: 'load', draft: loadBridge(h) });
         },
         (err) => {
           if (stale) return;
@@ -239,17 +100,18 @@ export function BridgeBuilder() {
         stale = true;
       };
     }
-    reset();
-    // a new bridge runs an on-demand job by default; the user can switch it to a
-    // live bridge in the "What runs in this bridge" selector
-    setSyncMode('oneTime');
-    setTriggerKind('replay');
+    // a new bridge runs an on-demand job by default (the reset draft); the user
+    // can switch it to a live bridge in the "What runs in this bridge" selector
+    dispatch({ type: 'reset' });
     if (bridgeEditor.seed) {
-      setConnectionId(bridgeEditor.seed.connectionId);
-      setDatabase(bridgeEditor.seed.database ?? '');
-      setSchema(bridgeEditor.seed.schema ?? '');
-      setTable(bridgeEditor.seed.table);
-      setName(t('defaultName', { table: bridgeEditor.seed.table }));
+      dispatch({
+        type: 'applySeed',
+        connectionId: bridgeEditor.seed.connectionId,
+        database: bridgeEditor.seed.database ?? '',
+        schema: bridgeEditor.seed.schema ?? '',
+        table: bridgeEditor.seed.table,
+        name: t('defaultName', { table: bridgeEditor.seed.table }),
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bridgeEditor.open, editing, bridgeEditor.seed]);
@@ -258,134 +120,26 @@ export function BridgeBuilder() {
    * whenever a (new) table's columns load, include ALL of them by default.
    * keyed on the column signature so switching between tables (even ones with
    * the same column count) re-initializes. when editing a bridge that pinned a
-   * subset, `pendingFields` is applied once instead.
+   * subset, the draft's `fieldsPref` is applied once instead.
    */
   const colSig = columns.map((c) => c.name).join(' ');
   const appliedKey = useRef('');
   useEffect(() => {
     if (columns.length === 0) return;
-    const key = `${colSig}|${fieldsPref ? fieldsPref.join(' ') : '*'}`;
+    const key = `${colSig}|${draft.fieldsPref ? draft.fieldsPref.join(' ') : '*'}`;
     if (appliedKey.current === key) return;
     appliedKey.current = key;
     const all = columns.map((c) => c.name);
-    if (fieldsPref && fieldsPref.length > 0) {
-      const allow = new Set(fieldsPref);
-      setIncluded(new Set(all.filter((n) => allow.has(n))));
-    } else {
-      setIncluded(new Set(all));
-    }
-  }, [colSig, fieldsPref, columns]);
-
-  function reset() {
-    setName('');
-    setConnectionId('');
-    setDatabase('');
-    setSchema('');
-    setTable('');
-    setMode('all');
-    setSelectedKeys(new Map());
-    setIncluded(new Set());
-    setFieldsPref(null);
-    setOffset(0);
-    setTriggerKind('replay');
-    setWatchStrategy('increment');
-    setWatchColumn('');
-    setPollSeconds(5);
-    setWatchStartFrom('now');
-    setCdcOps(new Set(['insert', 'update', 'delete']));
-    setReadiness(null);
-    setWrapKey('');
-    setDestKind('http');
-    setDest(blankDestination());
-    setDbTargets([blankDbTarget()]);
-    setDelivery(blankDelivery());
-    setEnabled(true);
-  }
-
-  function loadBridge(h: import('@syncle/core').Bridge) {
-    setName(h.name);
-    setConnectionId(h.source.connectionId);
-    setDatabase(h.source.database ?? '');
-    setMode('all');
-    setSelectedKeys(new Map());
-    if (h.source.kind === 'table') {
-      setSchema(h.source.schema ?? '');
-      setTable(h.source.table);
-      const inFilter = h.source.filters?.find((f) => f.operator === 'in');
-      if (inFilter && Array.isArray(inFilter.value)) {
-        setMode('selected');
-        setSelectedKeys(
-          new Map((inFilter.value as unknown[]).map((v) => [String(v), v])),
-        );
-      }
-    }
-    // applied when the table's columns load (subset = pinned fields, none = all)
-    setFieldsPref(h.transform.fields ?? null);
-    setWrapKey(h.transform.wrapKey ?? '');
-    if (h.trigger.kind === 'watch') {
-      setSyncMode('live');
-      setTriggerKind('watch');
-      setWatchStrategy(h.trigger.strategy.strategy);
-      setWatchColumn(
-        h.trigger.strategy.strategy === 'snapshot' ? '' : h.trigger.strategy.column,
-      );
-      setPollSeconds(Math.round(h.trigger.pollIntervalMs / 1000));
-      setWatchStartFrom(h.trigger.startFrom);
-    } else if (h.trigger.kind === 'cdc') {
-      setSyncMode('live');
-      setTriggerKind('cdc');
-      setCdcOps(new Set(h.trigger.operations));
-    } else {
-      setSyncMode('oneTime');
-      setTriggerKind('replay');
-    }
-    if (h.destination.kind === 'database') {
-      setDestKind('database');
-      setDbTargets(
-        h.destination.targets.map((t) => ({
-          connectionId: t.connectionId,
-          database: t.database ?? '',
-          schema: t.schema ?? '',
-          table: t.table,
-          writeMode: t.writeMode,
-          keyColumns: t.keyColumns,
-          createMissingTable: t.createMissingTable,
-          renames: Object.fromEntries(
-            t.mapping
-              .filter((m) => m.source !== m.target)
-              .map((m) => [m.source, m.target]),
-          ),
-        })),
-      );
-      setDest(blankDestination());
-    } else {
-      setDestKind('http');
-      setDbTargets([blankDbTarget()]);
-      setDest({
-        url: h.destination.url,
-        method: h.destination.method,
-        authType: h.destination.auth.type,
-        authToken:
-          h.destination.auth.type === 'bearer' ? h.destination.auth.token : '',
-        authHeaderName:
-          h.destination.auth.type === 'header' ? h.destination.auth.name : '',
-        authHeaderValue:
-          h.destination.auth.type === 'header' ? h.destination.auth.value : '',
-        headers: Object.entries(h.destination.headers ?? {}).map(
-          ([key, value]) => ({ key, value }),
-        ),
-        idempotency: h.destination.idempotency,
+    if (draft.fieldsPref && draft.fieldsPref.length > 0) {
+      const allow = new Set(draft.fieldsPref);
+      dispatch({
+        type: 'setIncluded',
+        included: new Set(all.filter((n) => allow.has(n))),
       });
+    } else {
+      dispatch({ type: 'setIncluded', included: new Set(all) });
     }
-    setDelivery({
-      batchSize: h.delivery.batchSize,
-      maxAttempts: h.delivery.maxAttempts,
-      minDelayMs: h.delivery.minDelayMs,
-      timeoutMs: h.delivery.timeoutMs,
-      onError: h.delivery.onError,
-    });
-    setEnabled(h.enabled);
-  }
+  }, [colSig, draft.fieldsPref, columns]);
 
   /* row used to preview the payload: a selected one if available, else first */
   const sampleRow = useMemo(() => {
@@ -401,88 +155,19 @@ export function BridgeBuilder() {
     [columns, included],
   );
 
-  /* live payload: schema (field → type) + a real sample body */
-  const preview = useMemo(() => {
-    if (!sampleRow || includedList.length === 0) return null;
-    const schemaShape: Record<string, string> = {};
-    for (const c of includedList) schemaShape[c] = jsType(sampleRow[c]);
-    let body: unknown = null;
-    let error: string | null = null;
-    try {
-      if (destKind === 'database') {
-        const renames = dbTargets[0]?.renames ?? {};
-        body = mapRow(
-          sampleRow,
-          includedList.map((s) => ({ source: s, target: renames[s]?.trim() || s })),
-        );
-      } else {
-        body = renderRow(
-          sampleRow,
-          {
-            template: '{{$row}}',
-            fields: includedList,
-            wrapKey: wrapKey || undefined,
-          },
-          { table: table || '(table)', now: new Date().toISOString(), index: 0 },
-        ).body;
-      }
-    } catch (err) {
-      error = err instanceof Error ? err.message : String(err);
-    }
-    return {
-      schema: wrapKey ? { [wrapKey]: schemaShape } : schemaShape,
-      body,
-      error,
-    };
-  }, [sampleRow, includedList, wrapKey, table, destKind, dbTargets]);
-
-  /* ----- selection helpers ----- */
-
-  function toggleRow(row: Record<string, unknown>) {
-    if (!singlePk) return;
-    const key = String(row[singlePk]);
-    setSelectedKeys((prev) => {
-      const next = new Map(prev);
-      if (next.has(key)) next.delete(key);
-      else next.set(key, row[singlePk]);
-      return next;
-    });
-  }
-
-  function togglePage() {
-    if (!singlePk) return;
-    setSelectedKeys((prev) => {
-      const next = new Map(prev);
-      const allOn = rows.every((r) => next.has(String(r[singlePk])));
-      for (const r of rows) {
-        const key = String(r[singlePk]);
-        if (allOn) next.delete(key);
-        else next.set(key, r[singlePk]);
-      }
-      return next;
-    });
-  }
-
-  function toggleColumn(name: string) {
-    setIncluded((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
-      return next;
-    });
-  }
-
   /* ----- save ----- */
 
   const sendCount =
     mode === 'selected' ? selectedKeys.size : (browse?.total ?? null);
   const watchNeedsColumn =
-    triggerKind === 'watch' && watchStrategy !== 'snapshot' && !watchColumn;
+    draft.triggerKind === 'watch' &&
+    draft.watchStrategy !== 'snapshot' &&
+    !draft.watchColumn;
   const destReady =
-    destKind === 'http'
-      ? dest.url.trim().length > 0
-      : dbTargets.length > 0 &&
-        dbTargets.every(
+    draft.destKind === 'http'
+      ? draft.dest.url.trim().length > 0
+      : draft.dbTargets.length > 0 &&
+        draft.dbTargets.every(
           (t) =>
             !!t.connectionId &&
             t.table.trim().length > 0 &&
@@ -496,141 +181,13 @@ export function BridgeBuilder() {
     !(mode === 'selected' && (!singlePk || selectedKeys.size === 0)) &&
     !watchNeedsColumn;
 
-  function buildInput(): BridgeInputDTO {
-    const filters: FilterSpec[] = [];
-    if (mode === 'selected' && singlePk) {
-      filters.push({
-        column: singlePk,
-        operator: 'in',
-        value: [...selectedKeys.values()],
-      });
-    }
-    const sort: SortSpec[] | undefined = singlePk
-      ? [{ column: singlePk, direction: 'asc' }]
-      : undefined;
-
-    const auth: Extract<
-      BridgeInputDTO['destination'],
-      { kind: 'http' }
-    >['auth'] =
-      dest.authType === 'bearer'
-        ? { type: 'bearer', token: dest.authToken }
-        : dest.authType === 'header'
-          ? {
-              type: 'header',
-              name: dest.authHeaderName,
-              value: dest.authHeaderValue,
-            }
-          : { type: 'none' };
-    const headerEntries = dest.headers
-      .filter((h) => h.key.trim())
-      .map((h) => [h.key.trim(), h.value] as const);
-
-    const allIncluded = includedList.length === columns.length;
-
-    const destination: BridgeInputDTO['destination'] =
-      destKind === 'database'
-        ? {
-            kind: 'database',
-            targets: dbTargets.map((t) => ({
-              connectionId: t.connectionId,
-              database: t.database || undefined,
-              schema: t.schema || undefined,
-              table: t.table.trim(),
-              writeMode: t.writeMode,
-              keyColumns: t.keyColumns,
-              // always send the full projection so the included-column choice is
-              // honored; renames apply where the target name differs
-              mapping: includedList.map((s) => ({
-                source: s,
-                target: (t.renames[s]?.trim() || s),
-              })),
-              createMissingTable: t.createMissingTable,
-            })),
-          }
-        : {
-            kind: 'http',
-            url: dest.url.trim(),
-            method: dest.method,
-            headers: headerEntries.length
-              ? Object.fromEntries(headerEntries)
-              : undefined,
-            auth,
-            idempotency: dest.idempotency,
-          };
-
-    return {
-      name: name.trim() || t('defaultName', { table }),
-      source: {
-        kind: 'table',
-        connectionId,
-        database: database || undefined,
-        schema: schema || undefined,
-        table,
-        filters: filters.length ? filters : undefined,
-        sort,
-      },
-      destination,
-      transform: {
-        template: '{{$row}}',
-        fields: allIncluded ? undefined : includedList,
-        wrapKey: wrapKey || undefined,
-      },
-      delivery: {
-        batchSize: delivery.batchSize,
-        maxAttempts: delivery.maxAttempts,
-        minDelayMs: delivery.minDelayMs,
-        timeoutMs: delivery.timeoutMs,
-        onError: delivery.onError,
-        backoffMs: 500,
-        backoffMaxMs: 30000,
-        pageSize: 200,
-      },
-      trigger:
-        triggerKind === 'cdc'
-          ? { kind: 'cdc', operations: [...cdcOps] }
-          : triggerKind === 'watch'
-            ? {
-                kind: 'watch',
-                strategy:
-                  watchStrategy === 'snapshot'
-                    ? { strategy: 'snapshot', maxTracked: 50000 }
-                    : watchStrategy === 'timestamp'
-                      ? { strategy: 'timestamp', column: watchColumn, lookbackMs: 3000 }
-                      : { strategy: 'increment', column: watchColumn },
-                pollIntervalMs: Math.max(1000, Math.round(pollSeconds * 1000)),
-                startFrom: watchStartFrom,
-                maxPerPoll: 500,
-              }
-            : { kind: 'replay' },
-      enabled,
-    };
-  }
-
-  async function checkReadiness() {
-    if (!connectionId || !table) return;
-    setCheckingCdc(true);
-    try {
-      setReadiness(
-        await api.cdcReadiness({
-          connectionId,
-          database: database || undefined,
-          schema: schema || undefined,
-          table,
-        }),
-      );
-    } catch (err) {
-      toast.error(t('readinessFailed'), {
-        description: err instanceof ApiError ? err.message : String(err),
-      });
-    } finally {
-      setCheckingCdc(false);
-    }
-  }
-
   async function handleSave() {
     try {
-      const input = buildInput();
+      const input = buildInput(draft, {
+        columns: columns.map((c) => c.name),
+        singlePk,
+        fallbackName: t('defaultName', { table }),
+      });
       if (editing) {
         await update.mutateAsync({ id: editing, input });
         toast.success(t('bridgeUpdated'));
@@ -656,13 +213,13 @@ export function BridgeBuilder() {
       <div className="flex items-center gap-3 border-b px-4 py-2.5">
         <Webhook className="text-primary h-5 w-5" />
         <Input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={draft.name}
+          onChange={(e) => dispatch({ type: 'setName', name: e.target.value })}
           placeholder={t('namePlaceholder')}
           className="h-8 max-w-xs font-medium"
         />
         <div className="text-muted-foreground ml-2 text-sm">
-          {syncMode === 'oneTime'
+          {draft.syncMode === 'oneTime'
             ? sendCount != null && (
                 <span>
                   {mode === 'selected'
@@ -701,324 +258,21 @@ export function BridgeBuilder() {
       <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1">
         {/* ---- source / grid ---- */}
         <ResizablePanel defaultSize={64} minSize={40}>
-          <div className="flex h-full flex-col">
-            {/* source pickers */}
-            <div className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
-              <div className="flex items-center gap-1">
-                <Select
-                  value={connectionId}
-                  onValueChange={(v) => {
-                    setConnectionId(v);
-                    setTable('');
-                    setDatabase('');
-                    setIncluded(new Set());
-                    setFieldsPref(null);
-                    setSelectedKeys(new Map());
-                  }}
-                >
-                  <SelectTrigger className="h-8 w-44">
-                    <SelectValue placeholder={t('connection')} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(connections?.length ?? 0) === 0 && (
-                      <div className="text-muted-foreground px-2 py-1.5 text-xs">
-                        {t('noConnections')}
-                      </div>
-                    )}
-                    {connections?.map((c) => (
-                      <SelectItem key={c.id} value={c.id}>
-                        {c.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {connectionId ? (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    title={t('editConnection')}
-                    onClick={() => openConnectionDialog(connectionId)}
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                  </Button>
-                ) : (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-8"
-                    onClick={() => openConnectionDialog()}
-                  >
-                    <Plus className="mr-1 h-3.5 w-3.5" /> {t('connectDatabase')}
-                  </Button>
-                )}
-              </div>
-
-              {(databases?.length ?? 0) > 0 && (
-                <Select
-                  value={database || '__default'}
-                  onValueChange={(v) => {
-                    setDatabase(v === '__default' ? '' : v);
-                    setTable('');
-                    setIncluded(new Set());
-                    setFieldsPref(null);
-                  }}
-                >
-                  <SelectTrigger className="h-8 w-40">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__default">{t('defaultDb')}</SelectItem>
-                    {databases?.map((d) => (
-                      <SelectItem key={d} value={d}>
-                        {d}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-
-              <Select
-                value={table}
-                onValueChange={(v) => {
-                  setTable(v);
-                  setOffset(0);
-                  setIncluded(new Set());
-                  setFieldsPref(null);
-                  setSelectedKeys(new Map());
-                  setReadiness(null);
-                }}
-              >
-                <SelectTrigger className="h-8 w-52">
-                  <SelectValue placeholder={t('table')} />
-                </SelectTrigger>
-                <SelectContent>
-                  {tables.map((t) => (
-                    <SelectItem
-                      key={`${t.schema ?? ''}.${t.name}`}
-                      value={t.name}
-                    >
-                      {t.schema ? `${t.schema}.${t.name}` : t.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              {table && (
-                <>
-                  {syncMode === 'oneTime' && (
-                    <>
-                      <div className="ml-2 flex items-center overflow-hidden rounded-md border text-xs">
-                        {(['selected', 'all'] as const).map((m) => (
-                          <button
-                            key={m}
-                            disabled={m === 'selected' && !singlePk}
-                            onClick={() => setMode(m)}
-                            className={cn(
-                              'px-2.5 py-1.5 transition-colors disabled:opacity-40',
-                              mode === m
-                                ? 'bg-primary text-primary-foreground'
-                                : 'hover:bg-accent',
-                            )}
-                            title={
-                              m === 'selected' && !singlePk
-                                ? t('needsSinglePk')
-                                : undefined
-                            }
-                          >
-                            {m === 'selected' ? t('selectedRows') : t('allRows')}
-                          </button>
-                        ))}
-                      </div>
-                      {mode === 'selected' && (
-                        <Badge variant="secondary" className="font-normal">
-                          {t('nSelected', { count: selectedKeys.size })}
-                        </Badge>
-                      )}
-                    </>
-                  )}
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="ml-auto h-8 w-8"
-                    onClick={() => refetch()}
-                  >
-                    {isFetching ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <RefreshCw className="h-4 w-4" />
-                    )}
-                  </Button>
-                </>
-              )}
-            </div>
-
-            {/* live-mode preview banner */}
-            {syncMode === 'live' && table && (
-              <div className="flex items-start gap-2 border-b bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-950/30 dark:text-blue-300">
-                <Radio className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                <span>
-                  <strong>{t('columnSelectionOnly')}</strong> {t('liveBannerRest')}
-                </span>
-              </div>
-            )}
-
-            {/* grid */}
-            <div className="scrollbar-thin min-h-0 flex-1 overflow-auto">
-              {!table ? (
-                <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
-                  {syncMode === 'live'
-                    ? t('pickLive')
-                    : t('pickOneTime')}
-                </div>
-              ) : (
-                <table className="w-full border-collapse text-sm">
-                  <thead className="bg-muted/95 sticky top-0 z-10 backdrop-blur">
-                    <tr>
-                      {mode === 'selected' && (
-                        <th className="w-8 border-b border-r px-2 py-1.5">
-                          <input
-                            type="checkbox"
-                            className="accent-primary h-3.5 w-3.5 cursor-pointer"
-                            disabled={!singlePk}
-                            checked={
-                              rows.length > 0 &&
-                              !!singlePk &&
-                              rows.every((r) =>
-                                selectedKeys.has(String(r[singlePk])),
-                              )
-                            }
-                            onChange={togglePage}
-                          />
-                        </th>
-                      )}
-                      {columns.map((col) => {
-                        const on = included.has(col.name);
-                        return (
-                          <th
-                            key={col.name}
-                            className={cn(
-                              'border-b border-r px-3 py-1.5 text-left font-medium',
-                              !on && 'opacity-40',
-                            )}
-                          >
-                            <button
-                              className="flex items-center gap-1.5 whitespace-nowrap"
-                              onClick={() => toggleColumn(col.name)}
-                              title={
-                                on
-                                  ? t('includedClickExclude')
-                                  : t('excludedClickInclude')
-                              }
-                            >
-                              <span
-                                className={cn(
-                                  'flex h-3.5 w-3.5 items-center justify-center rounded border',
-                                  on
-                                    ? 'bg-primary border-primary text-primary-foreground'
-                                    : 'border-muted-foreground/40',
-                                )}
-                              >
-                                {on && <Check className="h-3 w-3" />}
-                              </span>
-                              <span>{col.name}</span>
-                              {pk.includes(col.name) && (
-                                <span className="text-[10px] text-amber-500">
-                                  PK
-                                </span>
-                              )}
-                            </button>
-                          </th>
-                        );
-                      })}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {rows.map((row, i) => {
-                      const isSel =
-                        !!singlePk && selectedKeys.has(String(row[singlePk]));
-                      return (
-                        <tr
-                          key={i}
-                          className={cn(
-                            'hover:bg-accent/40',
-                            mode === 'selected' && isSel && 'bg-primary/5',
-                          )}
-                        >
-                          {mode === 'selected' && (
-                            <td className="border-b border-r px-2 text-center">
-                              <input
-                                type="checkbox"
-                                className="accent-primary h-3.5 w-3.5 cursor-pointer"
-                                disabled={!singlePk}
-                                checked={isSel}
-                                onChange={() => toggleRow(row)}
-                              />
-                            </td>
-                          )}
-                          {columns.map((col) => (
-                            <td
-                              key={col.name}
-                              className={cn(
-                                'max-w-[360px] border-b border-r px-3 py-1',
-                                !included.has(col.name) && 'opacity-40',
-                              )}
-                            >
-                              <span
-                                className={cn(
-                                  'block truncate font-mono text-xs',
-                                  row[col.name] == null &&
-                                    'text-muted-foreground/60 italic',
-                                )}
-                                title={formatCell(row[col.name])}
-                              >
-                                {formatCell(row[col.name])}
-                              </span>
-                            </td>
-                          ))}
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              )}
-            </div>
-
-            {/* pagination */}
-            {table && (
-              <div className="text-muted-foreground flex items-center gap-2 border-t px-3 py-1.5 text-xs">
-                <span>
-                  {syncMode === 'live' ? t('previewRows') + ' ' : t('rows') + ' '}
-                  {rows.length ? offset + 1 : 0}–{offset + rows.length}
-                  {syncMode === 'oneTime' && browse?.total != null
-                    ? t('ofTotal', {
-                        total: `${browse.estimated ? '~' : ''}${browse.total.toLocaleString()}`,
-                      })
-                    : ''}
-                </span>
-                <div className="ml-auto flex gap-1">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7"
-                    disabled={offset === 0}
-                    onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                  >
-                    {t('prev')}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7"
-                    disabled={!browse?.hasMore}
-                    onClick={() => setOffset(offset + PAGE_SIZE)}
-                  >
-                    {t('next')}
-                  </Button>
-                </div>
-              </div>
-            )}
-          </div>
+          <SourceSection
+            draft={draft}
+            dispatch={dispatch}
+            connections={connections}
+            databases={databases}
+            tables={tables}
+            columns={columns}
+            rows={rows}
+            pk={pk}
+            singlePk={singlePk}
+            browse={browse}
+            isFetching={isFetching}
+            onRefetch={refetch}
+            openConnectionDialog={openConnectionDialog}
+          />
         </ResizablePanel>
 
         <ResizableHandle />
@@ -1027,860 +281,24 @@ export function BridgeBuilder() {
         <ResizablePanel defaultSize={36} minSize={26}>
           <div className="h-full overflow-y-auto">
             <div className="space-y-5 p-4">
-              {/* what runs in this bridge: an on-demand job or a live bridge */}
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold">{t('whatRuns')}</h3>
-                <div className="flex overflow-hidden rounded-md border text-xs">
-                  {(
-                    [
-                      ['oneTime', t('modeOneTime')],
-                      ['live', t('modeLive')],
-                    ] as const
-                  ).map(([k, label]) => (
-                    <button
-                      key={k}
-                      onClick={() => {
-                        setSyncMode(k);
-                        setTriggerKind(k === 'live' ? 'watch' : 'replay');
-                      }}
-                      className={cn(
-                        'flex-1 px-2.5 py-1.5 transition-colors',
-                        syncMode === k
-                          ? 'bg-accent font-medium'
-                          : 'text-muted-foreground hover:bg-accent/50',
-                      )}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-muted-foreground text-[11px]">
-                  {syncMode === 'oneTime'
-                    ? t('oneTimeDesc')
-                    : t('liveDesc')}
-                </p>
-              </section>
-
-              {/* trigger, live bridges only. one-time jobs are always a one-shot replay */}
-              {syncMode === 'live' && (
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold">{t('howItListens')}</h3>
-                  <div className="flex overflow-hidden rounded-md border text-xs">
-                    {(
-                      [
-                        ['watch', t('polling')],
-                        ['cdc', t('eventBased')],
-                      ] as const
-                    ).map(([k, label]) => (
-                      <button
-                        key={k}
-                        onClick={() => setTriggerKind(k)}
-                        className={cn(
-                          'flex-1 px-2.5 py-1.5 transition-colors',
-                          triggerKind === k
-                            ? 'bg-accent font-medium'
-                            : 'text-muted-foreground hover:bg-accent/50',
-                        )}
-                      >
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-
-                  {triggerKind === 'cdc' && (
-                    <div className="grid gap-2 rounded-md border p-2.5">
-                    <Label className="text-xs">{t('operationsToDeliver')}</Label>
-                    <div className="flex gap-3 text-xs">
-                      {(['insert', 'update', 'delete'] as const).map((op) => (
-                        <label key={op} className="flex items-center gap-1.5">
-                          <input
-                            type="checkbox"
-                            className="accent-primary h-3.5 w-3.5"
-                            checked={cdcOps.has(op)}
-                            onChange={() =>
-                              setCdcOps((prev) => {
-                                const next = new Set(prev);
-                                if (next.has(op)) next.delete(op);
-                                else next.add(op);
-                                return next;
-                              })
-                            }
-                          />
-                          {op === 'insert'
-                            ? t('opInsert')
-                            : op === 'update'
-                              ? t('opUpdate')
-                              : t('opDelete')}
-                        </label>
-                      ))}
-                    </div>
-
-                    {/* readiness / setup */}
-                    <div className="flex items-center justify-between">
-                      <span className="text-muted-foreground text-[11px]">
-                        {t('cdcDesc')}
-                      </span>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="h-7"
-                        disabled={!connectionId || !table || checkingCdc}
-                        onClick={checkReadiness}
-                      >
-                        {checkingCdc ? (
-                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                        ) : null}
-                        {t('checkReadiness')}
-                      </Button>
-                    </div>
-
-                    {readiness && (
-                      <div className="space-y-1.5 rounded-md border p-2 text-[11px]">
-                        {!readiness.supported ? (
-                          <p className="text-amber-600">
-                            {readiness.instructions[0]}
-                          </p>
-                        ) : (
-                          <>
-                            <p
-                              className={cn(
-                                'font-medium',
-                                readiness.ready ? 'text-emerald-600' : 'text-amber-600',
-                              )}
-                            >
-                              {readiness.ready
-                                ? t('cdcReady')
-                                : t('setupNeeded')}
-                            </p>
-                            {readiness.checks.map((c) => (
-                              <div key={c.label} className="flex items-center gap-1.5">
-                                <span className={c.ok ? 'text-emerald-600' : 'text-destructive'}>
-                                  {c.ok ? '✓' : '✗'}
-                                </span>
-                                <span>
-                                  {c.label}
-                                  {c.detail ? ` (${c.detail})` : ''}
-                                </span>
-                              </div>
-                            ))}
-                            {readiness.instructions.map((ins, i) => (
-                              <p key={i} className="text-muted-foreground pl-1">
-                                • {ins}
-                              </p>
-                            ))}
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {triggerKind === 'watch' && (
-                  <div className="grid gap-2 rounded-md border p-2.5">
-                    <div className="grid gap-1.5">
-                      <Label className="text-xs">{t('detectNewRowsBy')}</Label>
-                      <Select
-                        value={watchStrategy}
-                        onValueChange={(v) =>
-                          setWatchStrategy(v as 'increment' | 'timestamp' | 'snapshot')
-                        }
-                      >
-                        <SelectTrigger className="h-8">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="increment">
-                            {t('strategyIncrement')}
-                          </SelectItem>
-                          <SelectItem value="timestamp">
-                            {t('strategyTimestamp')}
-                          </SelectItem>
-                          <SelectItem value="snapshot">
-                            {t('strategySnapshot')}
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    {watchStrategy !== 'snapshot' && (
-                      <div className="grid gap-1.5">
-                        <Label className="text-xs">
-                          {watchStrategy === 'timestamp'
-                            ? t('timestampColumn')
-                            : t('incrementingColumn')}
-                        </Label>
-                        <Select value={watchColumn} onValueChange={setWatchColumn}>
-                          <SelectTrigger className="h-8">
-                            <SelectValue placeholder={t('selectColumn')} />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {columns.map((c) => (
-                              <SelectItem key={c.name} value={c.name}>
-                                {c.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    )}
-
-                    <div className="grid grid-cols-2 gap-2">
-                      <NumField
-                        label={t('pollEvery')}
-                        value={pollSeconds}
-                        min={1}
-                        onChange={setPollSeconds}
-                      />
-                      <div className="grid gap-1.5">
-                        <Label className="text-xs">{t('startFrom')}</Label>
-                        <Select
-                          value={watchStartFrom}
-                          onValueChange={(v) =>
-                            setWatchStartFrom(v as 'now' | 'beginning')
-                          }
-                        >
-                          <SelectTrigger className="h-8">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="now">{t('fromNow')}</SelectItem>
-                            <SelectItem value="beginning">{t('fromBeginning')}</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-                      <p className="text-muted-foreground text-[11px]">
-                        {t('watchDesc')}
-                      </p>
-                    </div>
-                  )}
-                </section>
-              )}
-
-              {/* payload */}
-              <section>
-                <h3 className="mb-2 text-sm font-semibold">{t('whatGetsSent')}</h3>
-                <div className="grid grid-cols-2 gap-2">
-                  <div className="grid gap-1.5">
-                    <Label className="text-xs">{t('wrapKey')}</Label>
-                    <Input
-                      value={wrapKey}
-                      placeholder={t('wrapKeyPlaceholder')}
-                      className="h-8"
-                      onChange={(e) => setWrapKey(e.target.value)}
-                    />
-                  </div>
-                </div>
-                {preview?.error ? (
-                  <p className="text-destructive mt-2 text-xs">
-                    {preview.error}
-                  </p>
-                ) : preview ? (
-                  <div className="mt-2 space-y-2">
-                    <div>
-                      <p className="text-muted-foreground mb-1 text-xs">
-                        {t('schemaTypes')}
-                      </p>
-                      <pre className="bg-muted max-h-40 overflow-auto rounded-md p-2 font-mono text-[11px] leading-relaxed">
-                        {JSON.stringify(preview.schema, null, 2)}
-                      </pre>
-                    </div>
-                    <div>
-                      <p className="text-muted-foreground mb-1 text-xs">
-                        {t('samplePayload')}
-                      </p>
-                      <pre className="bg-muted max-h-48 overflow-auto rounded-md p-2 font-mono text-[11px] leading-relaxed">
-                        {JSON.stringify(preview.body, null, 2)}
-                      </pre>
-                    </div>
-                  </div>
-                ) : (
-                  <p className="text-muted-foreground mt-2 text-xs">
-                    {t('previewHint')}
-                  </p>
-                )}
-              </section>
-
-              {/* destination */}
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold">{t('destination')}</h3>
-                <div className="flex overflow-hidden rounded-md border text-xs">
-                  {(
-                    [
-                      ['http', t('httpEndpoint')],
-                      ['database', t('database')],
-                    ] as const
-                  ).map(([k, label]) => (
-                    <button
-                      key={k}
-                      onClick={() => {
-                        setDestKind(k);
-                        // seed the first target's key with the source PK so an
-                        // upsert works out of the box
-                        if (k === 'database' && singlePk) {
-                          setDbTargets((prev) =>
-                            prev.map((t, i) =>
-                              i === 0 && t.keyColumns.length === 0
-                                ? { ...t, keyColumns: [singlePk] }
-                                : t,
-                            ),
-                          );
-                        }
-                      }}
-                      className={cn(
-                        'flex flex-1 items-center justify-center gap-1.5 px-2.5 py-1.5 transition-colors',
-                        destKind === k
-                          ? 'bg-accent font-medium'
-                          : 'text-muted-foreground hover:bg-accent/50',
-                      )}
-                    >
-                      {k === 'http' ? (
-                        <Webhook className="h-3.5 w-3.5" />
-                      ) : (
-                        <Database className="h-3.5 w-3.5" />
-                      )}
-                      {label}
-                    </button>
-                  ))}
-                </div>
-
-                {destKind === 'database' && (
-                  <DbTargetsEditor
-                    targets={dbTargets}
-                    setTargets={setDbTargets}
-                    sourceColumns={includedList}
-                    sourcePk={singlePk}
-                  />
-                )}
-
-                {destKind === 'http' && (
-                <>
-                <div className="grid grid-cols-[90px_1fr] gap-2">
-                  <Select
-                    value={dest.method}
-                    onValueChange={(v) =>
-                      setDest((d) => ({
-                        ...d,
-                        method: v as Destination['method'],
-                      }))
-                    }
-                  >
-                    <SelectTrigger className="h-8">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="POST">POST</SelectItem>
-                      <SelectItem value="PUT">PUT</SelectItem>
-                      <SelectItem value="PATCH">PATCH</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    value={dest.url}
-                    placeholder="https://api.example.com/webhook"
-                    className="h-8"
-                    onChange={(e) =>
-                      setDest((d) => ({ ...d, url: e.target.value }))
-                    }
-                  />
-                </div>
-
-                <Select
-                  value={dest.authType}
-                  onValueChange={(v) =>
-                    setDest((d) => ({ ...d, authType: v as AuthType }))
-                  }
-                >
-                  <SelectTrigger className="h-8">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">{t('authNone')}</SelectItem>
-                    <SelectItem value="bearer">{t('authBearer')}</SelectItem>
-                    <SelectItem value="header">{t('authHeader')}</SelectItem>
-                  </SelectContent>
-                </Select>
-                {dest.authType === 'bearer' && (
-                  <Input
-                    type="password"
-                    className="h-8"
-                    placeholder={t('token')}
-                    value={dest.authToken}
-                    onChange={(e) =>
-                      setDest((d) => ({ ...d, authToken: e.target.value }))
-                    }
-                  />
-                )}
-                {dest.authType === 'header' && (
-                  <div className="grid grid-cols-2 gap-2">
-                    <Input
-                      className="h-8"
-                      placeholder="X-API-Key"
-                      value={dest.authHeaderName}
-                      onChange={(e) =>
-                        setDest((d) => ({
-                          ...d,
-                          authHeaderName: e.target.value,
-                        }))
-                      }
-                    />
-                    <Input
-                      className="h-8"
-                      type="password"
-                      placeholder={t('value')}
-                      value={dest.authHeaderValue}
-                      onChange={(e) =>
-                        setDest((d) => ({
-                          ...d,
-                          authHeaderValue: e.target.value,
-                        }))
-                      }
-                    />
-                  </div>
-                )}
-
-                {dest.headers.map((h, i) => (
-                  <div
-                    key={i}
-                    className="grid grid-cols-[1fr_1fr_auto] gap-1.5"
-                  >
-                    <Input
-                      className="h-8"
-                      placeholder={t('header')}
-                      value={h.key}
-                      onChange={(e) =>
-                        setDest((d) => ({
-                          ...d,
-                          headers: d.headers.map((x, j) =>
-                            j === i ? { ...x, key: e.target.value } : x,
-                          ),
-                        }))
-                      }
-                    />
-                    <Input
-                      className="h-8"
-                      placeholder={t('value')}
-                      value={h.value}
-                      onChange={(e) =>
-                        setDest((d) => ({
-                          ...d,
-                          headers: d.headers.map((x, j) =>
-                            j === i ? { ...x, value: e.target.value } : x,
-                          ),
-                        }))
-                      }
-                    />
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      onClick={() =>
-                        setDest((d) => ({
-                          ...d,
-                          headers: d.headers.filter((_, j) => j !== i),
-                        }))
-                      }
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7"
-                  onClick={() =>
-                    setDest((d) => ({
-                      ...d,
-                      headers: [...d.headers, { key: '', value: '' }],
-                    }))
-                  }
-                >
-                  <Plus className="mr-1 h-3.5 w-3.5" /> {t('header')}
-                </Button>
-
-                <label className="flex items-center justify-between rounded-md border p-2.5">
-                  <span className="text-xs">
-                    {t('send')} <code>Idempotency-Key</code>
-                  </span>
-                  <Switch
-                    checked={dest.idempotency}
-                    onCheckedChange={(v) =>
-                      setDest((d) => ({ ...d, idempotency: v }))
-                    }
-                  />
-                </label>
-                </>
-                )}
-              </section>
-
-              {/* delivery */}
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold">{t('delivery')}</h3>
-                <div className="grid grid-cols-2 gap-2">
-                  {syncMode === 'oneTime' && (
-                    <NumField
-                      label={t('batchSize')}
-                      value={delivery.batchSize}
-                      min={1}
-                      onChange={(v) =>
-                        setDelivery((d) => ({ ...d, batchSize: v }))
-                      }
-                    />
-                  )}
-                  <NumField
-                    label={t('maxAttempts')}
-                    value={delivery.maxAttempts}
-                    min={1}
-                    onChange={(v) =>
-                      setDelivery((d) => ({ ...d, maxAttempts: v }))
-                    }
-                  />
-                  {syncMode === 'oneTime' && (
-                    <NumField
-                      label={t('delayBetween')}
-                      value={delivery.minDelayMs}
-                      min={0}
-                      onChange={(v) =>
-                        setDelivery((d) => ({ ...d, minDelayMs: v }))
-                      }
-                    />
-                  )}
-                  <NumField
-                    label={t('timeout')}
-                    value={delivery.timeoutMs}
-                    min={100}
-                    onChange={(v) =>
-                      setDelivery((d) => ({ ...d, timeoutMs: v }))
-                    }
-                  />
-                </div>
-                {/* on-failure abort is a job concept. a listener must never stop on one bad delivery */}
-                {syncMode === 'oneTime' && (
-                  <div className="grid gap-1.5">
-                    <Label className="text-xs">{t('onFailure')}</Label>
-                    <Select
-                      value={delivery.onError}
-                      onValueChange={(v) =>
-                        setDelivery((d) => ({
-                          ...d,
-                          onError: v as 'continue' | 'abort',
-                        }))
-                      }
-                    >
-                      <SelectTrigger className="h-8">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="continue">
-                          {t('logContinue')}
-                        </SelectItem>
-                        <SelectItem value="abort">{t('stopJob')}</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
-              </section>
+              <TriggerSection draft={draft} dispatch={dispatch} columns={columns} />
+              <PayloadSection
+                draft={draft}
+                dispatch={dispatch}
+                sampleRow={sampleRow}
+                includedList={includedList}
+              />
+              <DestinationSection
+                draft={draft}
+                dispatch={dispatch}
+                includedList={includedList}
+                singlePk={singlePk}
+              />
+              <DeliverySection draft={draft} dispatch={dispatch} />
             </div>
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>
-    </div>
-  );
-}
-
-function NumField({
-  label,
-  value,
-  min,
-  onChange,
-}: {
-  label: string;
-  value: number;
-  min?: number;
-  onChange: (v: number) => void;
-}) {
-  return (
-    <div className="grid gap-1.5">
-      <Label className="text-xs">{label}</Label>
-      <Input
-        type="number"
-        min={min}
-        className="h-8"
-        value={value}
-        onChange={(e) => {
-          // a cleared input coerces to 0 — clamp so e.g. batchSize can't be 0
-          const n = Number(e.target.value);
-          const floor = min ?? 0;
-          onChange(Number.isFinite(n) ? Math.max(floor, n) : floor);
-        }}
-      />
-    </div>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* database destination editor                                                */
-/* -------------------------------------------------------------------------- */
-
-function DbTargetsEditor({
-  targets,
-  setTargets,
-  sourceColumns,
-  sourcePk,
-}: {
-  targets: DbTarget[];
-  setTargets: React.Dispatch<React.SetStateAction<DbTarget[]>>;
-  sourceColumns: string[];
-  sourcePk: string | null;
-}) {
-  const t = useTranslations('bridgeBuilder');
-  const patch = (i: number, p: Partial<DbTarget>) =>
-    setTargets((prev) => prev.map((t, j) => (j === i ? { ...t, ...p } : t)));
-  const add = () =>
-    setTargets((prev) => [
-      ...prev,
-      { ...blankDbTarget(), keyColumns: sourcePk ? [sourcePk] : [] },
-    ]);
-  const remove = (i: number) =>
-    setTargets((prev) => prev.filter((_, j) => j !== i));
-
-  return (
-    <div className="space-y-2">
-      <p className="text-muted-foreground text-[11px]">
-        {t('dbDescPre')} <strong>{t('dbDescUpsert')}</strong> {t('dbDescPost')}
-      </p>
-      {targets.map((t, i) => (
-        <DbTargetCard
-          key={i}
-          target={t}
-          sourceColumns={sourceColumns}
-          onChange={(p) => patch(i, p)}
-          onRemove={targets.length > 1 ? () => remove(i) : undefined}
-        />
-      ))}
-      <Button variant="outline" size="sm" className="h-7" onClick={add}>
-        <Plus className="mr-1 h-3.5 w-3.5" /> {t('addTargetDb')}
-      </Button>
-    </div>
-  );
-}
-
-function DbTargetCard({
-  target,
-  sourceColumns,
-  onChange,
-  onRemove,
-}: {
-  target: DbTarget;
-  sourceColumns: string[];
-  onChange: (patch: Partial<DbTarget>) => void;
-  onRemove?: () => void;
-}) {
-  const t = useTranslations('bridgeBuilder');
-  const { data: connections } = useConnections();
-  const { data: databases } = useDatabases(target.connectionId || null);
-  const { data: schemaData } = useSchema(
-    target.connectionId || null,
-    target.database || undefined,
-  );
-  const [showMap, setShowMap] = useState(false);
-  const tables = useMemo<TableSchema[]>(
-    () => schemaData?.namespaces.flatMap((ns) => ns.tables) ?? [],
-    [schemaData],
-  );
-  const conn = connections?.find((c) => c.id === target.connectionId);
-  // target column names the row will be written under (after renames)
-  const targetNames = sourceColumns.map(
-    (s) => target.renames[s]?.trim() || s,
-  );
-
-  const toggleKey = (name: string) =>
-    onChange({
-      keyColumns: target.keyColumns.includes(name)
-        ? target.keyColumns.filter((k) => k !== name)
-        : [...target.keyColumns, name],
-    });
-
-  return (
-    <div className="space-y-2 rounded-md border p-2.5">
-      <div className="flex items-center gap-2">
-        <Select
-          value={target.connectionId}
-          onValueChange={(v) =>
-            onChange({ connectionId: v, database: '', schema: '', table: '' })
-          }
-        >
-          <SelectTrigger className="h-8 flex-1">
-            <SelectValue placeholder={t('targetConnection')} />
-          </SelectTrigger>
-          <SelectContent>
-            {(connections?.length ?? 0) === 0 && (
-              <div className="text-muted-foreground px-2 py-1.5 text-xs">
-                {t('noConnections')}
-              </div>
-            )}
-            {connections?.map((c) => (
-              <SelectItem key={c.id} value={c.id}>
-                {c.name}
-                <span className="text-muted-foreground ml-1.5 text-[10px] uppercase">
-                  {c.engine}
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {onRemove && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 shrink-0"
-            onClick={onRemove}
-            title={t('removeTarget')}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        )}
-      </div>
-
-      <div className="grid grid-cols-2 gap-2">
-        {(databases?.length ?? 0) > 0 && (
-          <Select
-            value={target.database || '__default'}
-            onValueChange={(v) =>
-              onChange({ database: v === '__default' ? '' : v, table: '' })
-            }
-          >
-            <SelectTrigger className="h-8">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__default">{t('defaultDb')}</SelectItem>
-              {databases?.map((d) => (
-                <SelectItem key={d} value={d}>
-                  {d}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-        {conn?.engine === 'postgres' && (
-          <Input
-            className="h-8"
-            placeholder={t('schemaPlaceholder')}
-            value={target.schema}
-            onChange={(e) => onChange({ schema: e.target.value })}
-          />
-        )}
-      </div>
-
-      <div className="grid gap-1.5">
-        <Label className="text-xs">{t('targetTable')}</Label>
-        <Input
-          className="h-8"
-          list={`tables-${target.connectionId}`}
-          placeholder={t('tableNamePlaceholder')}
-          value={target.table}
-          onChange={(e) => onChange({ table: e.target.value })}
-        />
-        <datalist id={`tables-${target.connectionId}`}>
-          {tables.map((t) => (
-            <option key={`${t.schema ?? ''}.${t.name}`} value={t.name} />
-          ))}
-        </datalist>
-      </div>
-
-      <div className="grid grid-cols-2 gap-2">
-        <div className="grid gap-1.5">
-          <Label className="text-xs">{t('writeMode')}</Label>
-          <Select
-            value={target.writeMode}
-            onValueChange={(v) =>
-              onChange({ writeMode: v as DbTarget['writeMode'] })
-            }
-          >
-            <SelectTrigger className="h-8">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="upsert">{t('upsertOpt')}</SelectItem>
-              <SelectItem value="insert">{t('insertOpt')}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <label className="flex items-end justify-between gap-2 pb-1">
-          <span className="text-xs">{t('createIfMissing')}</span>
-          <Switch
-            checked={target.createMissingTable}
-            onCheckedChange={(v) => onChange({ createMissingTable: v })}
-          />
-        </label>
-      </div>
-
-      {target.writeMode === 'upsert' && (
-        <div className="grid gap-1.5">
-          <Label className="text-xs">
-            {t('keyColumns')}{' '}
-            <span className="text-muted-foreground">
-              {t('keyColumnsHint')}
-            </span>
-          </Label>
-          <div className="flex flex-wrap gap-1.5">
-            {targetNames.length === 0 && (
-              <span className="text-muted-foreground text-[11px]">
-                {t('selectSourceFirst')}
-              </span>
-            )}
-            {targetNames.map((name) => {
-              const on = target.keyColumns.includes(name);
-              return (
-                <button
-                  key={name}
-                  onClick={() => toggleKey(name)}
-                  className={cn(
-                    'rounded border px-1.5 py-0.5 text-[11px] transition-colors',
-                    on
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'hover:bg-accent',
-                  )}
-                >
-                  {name}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      <button
-        onClick={() => setShowMap((s) => !s)}
-        className="text-muted-foreground hover:text-foreground text-[11px] underline"
-      >
-        {showMap ? t('hideMapping') : t('mapRename')}
-      </button>
-      {showMap && (
-        <div className="grid gap-1 rounded-md border p-2">
-          <div className="text-muted-foreground grid grid-cols-2 gap-2 text-[10px] uppercase">
-            <span>{t('sourceColumn')}</span>
-            <span>{t('targetColumn')}</span>
-          </div>
-          {sourceColumns.map((s) => (
-            <div key={s} className="grid grid-cols-2 items-center gap-2">
-              <span className="truncate font-mono text-[11px]">{s}</span>
-              <Input
-                className="h-7 text-xs"
-                value={target.renames[s] ?? ''}
-                placeholder={s}
-                onChange={(e) => {
-                  const renames = { ...target.renames };
-                  if (e.target.value.trim()) renames[s] = e.target.value;
-                  else delete renames[s];
-                  onChange({ renames });
-                }}
-              />
-            </div>
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/bridges/builder/db-targets-editor.tsx
+++ b/apps/web/src/components/bridges/builder/db-targets-editor.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+/* -------------------------------------------------------------------------- */
+/* database destination editor                                                */
+/* -------------------------------------------------------------------------- */
+
+import { useMemo, useState, type Dispatch } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import type { TableSchema } from '@syncle/core';
+import { useConnections, useDatabases, useSchema } from '@/lib/queries';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { BuilderAction, DbTarget } from './draft';
+
+export function DbTargetsEditor({
+  targets,
+  dispatch,
+  sourceColumns,
+  sourcePk,
+}: {
+  targets: DbTarget[];
+  dispatch: Dispatch<BuilderAction>;
+  sourceColumns: string[];
+  sourcePk: string | null;
+}) {
+  const t = useTranslations('bridgeBuilder');
+  const patch = (i: number, p: Partial<DbTarget>) =>
+    dispatch({ type: 'patchDbTarget', index: i, patch: p });
+  const add = () => dispatch({ type: 'addDbTarget', sourcePk });
+  const remove = (i: number) => dispatch({ type: 'removeDbTarget', index: i });
+
+  return (
+    <div className="space-y-2">
+      <p className="text-muted-foreground text-[11px]">
+        {t('dbDescPre')} <strong>{t('dbDescUpsert')}</strong> {t('dbDescPost')}
+      </p>
+      {targets.map((t, i) => (
+        <DbTargetCard
+          key={i}
+          target={t}
+          sourceColumns={sourceColumns}
+          onChange={(p) => patch(i, p)}
+          onRemove={targets.length > 1 ? () => remove(i) : undefined}
+        />
+      ))}
+      <Button variant="outline" size="sm" className="h-7" onClick={add}>
+        <Plus className="mr-1 h-3.5 w-3.5" /> {t('addTargetDb')}
+      </Button>
+    </div>
+  );
+}
+
+function DbTargetCard({
+  target,
+  sourceColumns,
+  onChange,
+  onRemove,
+}: {
+  target: DbTarget;
+  sourceColumns: string[];
+  onChange: (patch: Partial<DbTarget>) => void;
+  onRemove?: () => void;
+}) {
+  const t = useTranslations('bridgeBuilder');
+  const { data: connections } = useConnections();
+  const { data: databases } = useDatabases(target.connectionId || null);
+  const { data: schemaData } = useSchema(
+    target.connectionId || null,
+    target.database || undefined,
+  );
+  const [showMap, setShowMap] = useState(false);
+  const tables = useMemo<TableSchema[]>(
+    () => schemaData?.namespaces.flatMap((ns) => ns.tables) ?? [],
+    [schemaData],
+  );
+  const conn = connections?.find((c) => c.id === target.connectionId);
+  // target column names the row will be written under (after renames)
+  const targetNames = sourceColumns.map(
+    (s) => target.renames[s]?.trim() || s,
+  );
+
+  const toggleKey = (name: string) =>
+    onChange({
+      keyColumns: target.keyColumns.includes(name)
+        ? target.keyColumns.filter((k) => k !== name)
+        : [...target.keyColumns, name],
+    });
+
+  return (
+    <div className="space-y-2 rounded-md border p-2.5">
+      <div className="flex items-center gap-2">
+        <Select
+          value={target.connectionId}
+          onValueChange={(v) =>
+            onChange({ connectionId: v, database: '', schema: '', table: '' })
+          }
+        >
+          <SelectTrigger className="h-8 flex-1">
+            <SelectValue placeholder={t('targetConnection')} />
+          </SelectTrigger>
+          <SelectContent>
+            {(connections?.length ?? 0) === 0 && (
+              <div className="text-muted-foreground px-2 py-1.5 text-xs">
+                {t('noConnections')}
+              </div>
+            )}
+            {connections?.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+                <span className="text-muted-foreground ml-1.5 text-[10px] uppercase">
+                  {c.engine}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {onRemove && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onClick={onRemove}
+            title={t('removeTarget')}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        {(databases?.length ?? 0) > 0 && (
+          <Select
+            value={target.database || '__default'}
+            onValueChange={(v) =>
+              onChange({ database: v === '__default' ? '' : v, table: '' })
+            }
+          >
+            <SelectTrigger className="h-8">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__default">{t('defaultDb')}</SelectItem>
+              {databases?.map((d) => (
+                <SelectItem key={d} value={d}>
+                  {d}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {conn?.engine === 'postgres' && (
+          <Input
+            className="h-8"
+            placeholder={t('schemaPlaceholder')}
+            value={target.schema}
+            onChange={(e) => onChange({ schema: e.target.value })}
+          />
+        )}
+      </div>
+
+      <div className="grid gap-1.5">
+        <Label className="text-xs">{t('targetTable')}</Label>
+        <Input
+          className="h-8"
+          list={`tables-${target.connectionId}`}
+          placeholder={t('tableNamePlaceholder')}
+          value={target.table}
+          onChange={(e) => onChange({ table: e.target.value })}
+        />
+        <datalist id={`tables-${target.connectionId}`}>
+          {tables.map((t) => (
+            <option key={`${t.schema ?? ''}.${t.name}`} value={t.name} />
+          ))}
+        </datalist>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="grid gap-1.5">
+          <Label className="text-xs">{t('writeMode')}</Label>
+          <Select
+            value={target.writeMode}
+            onValueChange={(v) =>
+              onChange({ writeMode: v as DbTarget['writeMode'] })
+            }
+          >
+            <SelectTrigger className="h-8">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="upsert">{t('upsertOpt')}</SelectItem>
+              <SelectItem value="insert">{t('insertOpt')}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <label className="flex items-end justify-between gap-2 pb-1">
+          <span className="text-xs">{t('createIfMissing')}</span>
+          <Switch
+            checked={target.createMissingTable}
+            onCheckedChange={(v) => onChange({ createMissingTable: v })}
+          />
+        </label>
+      </div>
+
+      {target.writeMode === 'upsert' && (
+        <div className="grid gap-1.5">
+          <Label className="text-xs">
+            {t('keyColumns')}{' '}
+            <span className="text-muted-foreground">
+              {t('keyColumnsHint')}
+            </span>
+          </Label>
+          <div className="flex flex-wrap gap-1.5">
+            {targetNames.length === 0 && (
+              <span className="text-muted-foreground text-[11px]">
+                {t('selectSourceFirst')}
+              </span>
+            )}
+            {targetNames.map((name) => {
+              const on = target.keyColumns.includes(name);
+              return (
+                <button
+                  key={name}
+                  onClick={() => toggleKey(name)}
+                  className={cn(
+                    'rounded border px-1.5 py-0.5 text-[11px] transition-colors',
+                    on
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'hover:bg-accent',
+                  )}
+                >
+                  {name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <button
+        onClick={() => setShowMap((s) => !s)}
+        className="text-muted-foreground hover:text-foreground text-[11px] underline"
+      >
+        {showMap ? t('hideMapping') : t('mapRename')}
+      </button>
+      {showMap && (
+        <div className="grid gap-1 rounded-md border p-2">
+          <div className="text-muted-foreground grid grid-cols-2 gap-2 text-[10px] uppercase">
+            <span>{t('sourceColumn')}</span>
+            <span>{t('targetColumn')}</span>
+          </div>
+          {sourceColumns.map((s) => (
+            <div key={s} className="grid grid-cols-2 items-center gap-2">
+              <span className="truncate font-mono text-[11px]">{s}</span>
+              <Input
+                className="h-7 text-xs"
+                value={target.renames[s] ?? ''}
+                placeholder={s}
+                onChange={(e) => {
+                  const renames = { ...target.renames };
+                  if (e.target.value.trim()) renames[s] = e.target.value;
+                  else delete renames[s];
+                  onChange({ renames });
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/bridges/builder/delivery-section.tsx
+++ b/apps/web/src/components/bridges/builder/delivery-section.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+/** delivery tuning: batching, retries, pacing, and on-failure policy */
+import type { Dispatch } from 'react';
+import { useTranslations } from 'next-intl';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { NumField } from './num-field';
+import type { BuilderAction, BuilderDraft } from './draft';
+
+export function DeliverySection({
+  draft,
+  dispatch,
+}: {
+  draft: Pick<BuilderDraft, 'delivery' | 'syncMode'>;
+  dispatch: Dispatch<BuilderAction>;
+}) {
+  const t = useTranslations('bridgeBuilder');
+  const { delivery, syncMode } = draft;
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-semibold">{t('delivery')}</h3>
+      <div className="grid grid-cols-2 gap-2">
+        {syncMode === 'oneTime' && (
+          <NumField
+            label={t('batchSize')}
+            value={delivery.batchSize}
+            min={1}
+            onChange={(v) =>
+              dispatch({ type: 'patchDelivery', patch: { batchSize: v } })
+            }
+          />
+        )}
+        <NumField
+          label={t('maxAttempts')}
+          value={delivery.maxAttempts}
+          min={1}
+          onChange={(v) =>
+            dispatch({ type: 'patchDelivery', patch: { maxAttempts: v } })
+          }
+        />
+        {syncMode === 'oneTime' && (
+          <NumField
+            label={t('delayBetween')}
+            value={delivery.minDelayMs}
+            min={0}
+            onChange={(v) =>
+              dispatch({ type: 'patchDelivery', patch: { minDelayMs: v } })
+            }
+          />
+        )}
+        <NumField
+          label={t('timeout')}
+          value={delivery.timeoutMs}
+          min={100}
+          onChange={(v) =>
+            dispatch({ type: 'patchDelivery', patch: { timeoutMs: v } })
+          }
+        />
+      </div>
+      {/* on-failure abort is a job concept. a listener must never stop on one bad delivery */}
+      {syncMode === 'oneTime' && (
+        <div className="grid gap-1.5">
+          <Label className="text-xs">{t('onFailure')}</Label>
+          <Select
+            value={delivery.onError}
+            onValueChange={(v) =>
+              dispatch({
+                type: 'patchDelivery',
+                patch: { onError: v as 'continue' | 'abort' },
+              })
+            }
+          >
+            <SelectTrigger className="h-8">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="continue">
+                {t('logContinue')}
+              </SelectItem>
+              <SelectItem value="abort">{t('stopJob')}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/bridges/builder/destination-section.tsx
+++ b/apps/web/src/components/bridges/builder/destination-section.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+/**
+ * where rows go: the HTTP-vs-database toggle, the HTTP endpoint form
+ * (method/URL, auth, extra headers, idempotency), or the database targets
+ * editor.
+ */
+import type { Dispatch } from 'react';
+import { Database, Plus, Webhook, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { DbTargetsEditor } from './db-targets-editor';
+import type { AuthType, BuilderAction, BuilderDraft, Destination } from './draft';
+
+export function DestinationSection({
+  draft,
+  dispatch,
+  includedList,
+  singlePk,
+}: {
+  draft: Pick<BuilderDraft, 'destKind' | 'dest' | 'dbTargets'>;
+  dispatch: Dispatch<BuilderAction>;
+  includedList: string[];
+  singlePk: string | null;
+}) {
+  const t = useTranslations('bridgeBuilder');
+  const { destKind, dest, dbTargets } = draft;
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-semibold">{t('destination')}</h3>
+      <div className="flex overflow-hidden rounded-md border text-xs">
+        {(
+          [
+            ['http', t('httpEndpoint')],
+            ['database', t('database')],
+          ] as const
+        ).map(([k, label]) => (
+          <button
+            key={k}
+            onClick={() =>
+              dispatch({ type: 'setDestKind', destKind: k, sourcePk: singlePk })
+            }
+            className={cn(
+              'flex flex-1 items-center justify-center gap-1.5 px-2.5 py-1.5 transition-colors',
+              destKind === k
+                ? 'bg-accent font-medium'
+                : 'text-muted-foreground hover:bg-accent/50',
+            )}
+          >
+            {k === 'http' ? (
+              <Webhook className="h-3.5 w-3.5" />
+            ) : (
+              <Database className="h-3.5 w-3.5" />
+            )}
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {destKind === 'database' && (
+        <DbTargetsEditor
+          targets={dbTargets}
+          dispatch={dispatch}
+          sourceColumns={includedList}
+          sourcePk={singlePk}
+        />
+      )}
+
+      {destKind === 'http' && (
+      <>
+      <div className="grid grid-cols-[90px_1fr] gap-2">
+        <Select
+          value={dest.method}
+          onValueChange={(v) =>
+            dispatch({
+              type: 'patchDest',
+              patch: { method: v as Destination['method'] },
+            })
+          }
+        >
+          <SelectTrigger className="h-8">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="POST">POST</SelectItem>
+            <SelectItem value="PUT">PUT</SelectItem>
+            <SelectItem value="PATCH">PATCH</SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          value={dest.url}
+          placeholder="https://api.example.com/webhook"
+          className="h-8"
+          onChange={(e) =>
+            dispatch({ type: 'patchDest', patch: { url: e.target.value } })
+          }
+        />
+      </div>
+
+      <Select
+        value={dest.authType}
+        onValueChange={(v) =>
+          dispatch({ type: 'patchDest', patch: { authType: v as AuthType } })
+        }
+      >
+        <SelectTrigger className="h-8">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="none">{t('authNone')}</SelectItem>
+          <SelectItem value="bearer">{t('authBearer')}</SelectItem>
+          <SelectItem value="header">{t('authHeader')}</SelectItem>
+        </SelectContent>
+      </Select>
+      {dest.authType === 'bearer' && (
+        <Input
+          type="password"
+          className="h-8"
+          placeholder={t('token')}
+          value={dest.authToken}
+          onChange={(e) =>
+            dispatch({ type: 'patchDest', patch: { authToken: e.target.value } })
+          }
+        />
+      )}
+      {dest.authType === 'header' && (
+        <div className="grid grid-cols-2 gap-2">
+          <Input
+            className="h-8"
+            placeholder="X-API-Key"
+            value={dest.authHeaderName}
+            onChange={(e) =>
+              dispatch({
+                type: 'patchDest',
+                patch: { authHeaderName: e.target.value },
+              })
+            }
+          />
+          <Input
+            className="h-8"
+            type="password"
+            placeholder={t('value')}
+            value={dest.authHeaderValue}
+            onChange={(e) =>
+              dispatch({
+                type: 'patchDest',
+                patch: { authHeaderValue: e.target.value },
+              })
+            }
+          />
+        </div>
+      )}
+
+      {dest.headers.map((h, i) => (
+        <div
+          key={i}
+          className="grid grid-cols-[1fr_1fr_auto] gap-1.5"
+        >
+          <Input
+            className="h-8"
+            placeholder={t('header')}
+            value={h.key}
+            onChange={(e) =>
+              dispatch({
+                type: 'patchDestHeader',
+                index: i,
+                patch: { key: e.target.value },
+              })
+            }
+          />
+          <Input
+            className="h-8"
+            placeholder={t('value')}
+            value={h.value}
+            onChange={(e) =>
+              dispatch({
+                type: 'patchDestHeader',
+                index: i,
+                patch: { value: e.target.value },
+              })
+            }
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => dispatch({ type: 'removeDestHeader', index: i })}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7"
+        onClick={() => dispatch({ type: 'addDestHeader' })}
+      >
+        <Plus className="mr-1 h-3.5 w-3.5" /> {t('header')}
+      </Button>
+
+      <label className="flex items-center justify-between rounded-md border p-2.5">
+        <span className="text-xs">
+          {t('send')} <code>Idempotency-Key</code>
+        </span>
+        <Switch
+          checked={dest.idempotency}
+          onCheckedChange={(v) =>
+            dispatch({ type: 'patchDest', patch: { idempotency: v } })
+          }
+        />
+      </label>
+      </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/bridges/builder/draft.ts
+++ b/apps/web/src/components/bridges/builder/draft.ts
@@ -1,0 +1,363 @@
+/**
+ * the bridge builder's draft state: one typed object + a reducer, replacing the
+ * pile of useState calls the builder used to juggle. every cross-field cascade
+ * (changing the connection resets the table, changing the table resets the
+ * column/row selections, toggling the sync mode adjusts the trigger, …) lives
+ * here so a section can never forget one.
+ */
+import type { CdcReadiness } from '@syncle/core';
+
+export const PAGE_SIZE = 100;
+
+export type AuthType = 'none' | 'bearer' | 'header';
+
+export interface Destination {
+  url: string;
+  method: 'POST' | 'PUT' | 'PATCH';
+  authType: AuthType;
+  authToken: string;
+  authHeaderName: string;
+  authHeaderValue: string;
+  headers: { key: string; value: string }[];
+  idempotency: boolean;
+}
+
+/** a single database a bridge writes into (UI shape) */
+export interface DbTarget {
+  connectionId: string;
+  database: string;
+  schema: string;
+  table: string;
+  writeMode: 'upsert' | 'insert';
+  /** target column names that uniquely identify a row (for upsert) */
+  keyColumns: string[];
+  createMissingTable: boolean;
+  /** optional source column → target column renames (default identity) */
+  renames: Record<string, string>;
+}
+
+export interface Delivery {
+  batchSize: number;
+  maxAttempts: number;
+  minDelayMs: number;
+  timeoutMs: number;
+  onError: 'continue' | 'abort';
+}
+
+export function blankDbTarget(): DbTarget {
+  return {
+    connectionId: '',
+    database: '',
+    schema: '',
+    table: '',
+    writeMode: 'upsert',
+    keyColumns: [],
+    createMissingTable: true,
+    renames: {},
+  };
+}
+
+export function blankDestination(): Destination {
+  return {
+    url: '',
+    method: 'POST',
+    authType: 'none',
+    authToken: '',
+    authHeaderName: '',
+    authHeaderValue: '',
+    headers: [],
+    idempotency: false,
+  };
+}
+
+export function blankDelivery(): Delivery {
+  return {
+    batchSize: 1,
+    maxAttempts: 3,
+    minDelayMs: 0,
+    timeoutMs: 15000,
+    onError: 'continue',
+  };
+}
+
+export type SyncMode = 'oneTime' | 'live';
+export type TriggerKind = 'replay' | 'watch' | 'cdc';
+export type WatchStrategy = 'increment' | 'timestamp' | 'snapshot';
+export type CdcOp = 'insert' | 'update' | 'delete';
+export type RowMode = 'selected' | 'all';
+
+export interface BuilderDraft {
+  // ----- source -----
+  name: string;
+  connectionId: string;
+  database: string;
+  schema: string;
+  table: string;
+  mode: RowMode;
+  selectedKeys: Map<string, unknown>;
+  included: Set<string>;
+  /** column preference: null = all columns, array = a pinned subset (editing) */
+  fieldsPref: string[] | null;
+  offset: number;
+  // ----- trigger -----
+  // the builder is locked to one of two modes, decided by the toggle (new)
+  // or the bridge's existing trigger (editing). 'oneTime' = a replay-only
+  // job, 'live' = listen-only (polling/CDC). they never share trigger UI
+  syncMode: SyncMode;
+  triggerKind: TriggerKind;
+  watchStrategy: WatchStrategy;
+  watchColumn: string;
+  pollSeconds: number;
+  watchStartFrom: 'now' | 'beginning';
+  cdcOps: Set<CdcOp>;
+  readiness: CdcReadiness | null;
+  checkingCdc: boolean;
+  // ----- payload / destination / delivery -----
+  wrapKey: string;
+  destKind: 'http' | 'database';
+  dest: Destination;
+  dbTargets: DbTarget[];
+  delivery: Delivery;
+  /** preserved on edit so saving doesn't silently re-enable a disabled bridge */
+  enabled: boolean;
+}
+
+export function initialDraft(): BuilderDraft {
+  return {
+    name: '',
+    connectionId: '',
+    database: '',
+    schema: '',
+    table: '',
+    mode: 'all',
+    selectedKeys: new Map(),
+    included: new Set(),
+    fieldsPref: null,
+    offset: 0,
+    syncMode: 'oneTime',
+    triggerKind: 'replay',
+    watchStrategy: 'increment',
+    watchColumn: '',
+    pollSeconds: 5,
+    watchStartFrom: 'now',
+    cdcOps: new Set(['insert', 'update', 'delete']),
+    readiness: null,
+    checkingCdc: false,
+    wrapKey: '',
+    destKind: 'http',
+    dest: blankDestination(),
+    dbTargets: [blankDbTarget()],
+    delivery: blankDelivery(),
+    enabled: true,
+  };
+}
+
+export type BuilderAction =
+  /** back to a blank draft (opening the editor, or before an edit load) */
+  | { type: 'reset' }
+  /** replace the draft with a fully hydrated one (edit-mode load) */
+  | { type: 'load'; draft: BuilderDraft }
+  /** prefill source fields when opened from the schema tree */
+  | {
+      type: 'applySeed';
+      connectionId: string;
+      database: string;
+      schema: string;
+      table: string;
+      name: string;
+    }
+  | { type: 'setName'; name: string }
+  | { type: 'selectConnection'; connectionId: string }
+  | { type: 'selectDatabase'; database: string }
+  | { type: 'selectTable'; table: string }
+  | { type: 'setMode'; mode: RowMode }
+  | { type: 'toggleRow'; key: string; value: unknown }
+  | { type: 'togglePage'; entries: { key: string; value: unknown }[] }
+  | { type: 'toggleColumn'; name: string }
+  | { type: 'setIncluded'; included: Set<string> }
+  | { type: 'setOffset'; offset: number }
+  | { type: 'setSyncMode'; syncMode: SyncMode }
+  | { type: 'setTriggerKind'; triggerKind: TriggerKind }
+  | { type: 'setWatchStrategy'; strategy: WatchStrategy }
+  | { type: 'setWatchColumn'; column: string }
+  | { type: 'setPollSeconds'; seconds: number }
+  | { type: 'setWatchStartFrom'; startFrom: 'now' | 'beginning' }
+  | { type: 'toggleCdcOp'; op: CdcOp }
+  | { type: 'setReadiness'; readiness: CdcReadiness | null }
+  | { type: 'setCheckingCdc'; checking: boolean }
+  | { type: 'setWrapKey'; wrapKey: string }
+  | { type: 'setDestKind'; destKind: 'http' | 'database'; sourcePk: string | null }
+  | { type: 'patchDest'; patch: Partial<Destination> }
+  | { type: 'addDestHeader' }
+  | { type: 'patchDestHeader'; index: number; patch: Partial<{ key: string; value: string }> }
+  | { type: 'removeDestHeader'; index: number }
+  | { type: 'patchDbTarget'; index: number; patch: Partial<DbTarget> }
+  | { type: 'addDbTarget'; sourcePk: string | null }
+  | { type: 'removeDbTarget'; index: number }
+  | { type: 'patchDelivery'; patch: Partial<Delivery> };
+
+export function builderReducer(d: BuilderDraft, action: BuilderAction): BuilderDraft {
+  switch (action.type) {
+    case 'reset':
+      // an in-flight readiness probe keeps its spinner; its own finally clears it
+      return { ...initialDraft(), checkingCdc: d.checkingCdc };
+    case 'load':
+      return { ...action.draft, checkingCdc: d.checkingCdc };
+    case 'applySeed':
+      return {
+        ...d,
+        connectionId: action.connectionId,
+        database: action.database,
+        schema: action.schema,
+        table: action.table,
+        name: action.name,
+      };
+    case 'setName':
+      return { ...d, name: action.name };
+    case 'selectConnection':
+      // a new connection invalidates everything picked under the old one
+      return {
+        ...d,
+        connectionId: action.connectionId,
+        table: '',
+        database: '',
+        included: new Set(),
+        fieldsPref: null,
+        selectedKeys: new Map(),
+      };
+    case 'selectDatabase':
+      return {
+        ...d,
+        database: action.database,
+        table: '',
+        included: new Set(),
+        fieldsPref: null,
+      };
+    case 'selectTable':
+      return {
+        ...d,
+        table: action.table,
+        offset: 0,
+        included: new Set(),
+        fieldsPref: null,
+        selectedKeys: new Map(),
+        readiness: null,
+      };
+    case 'setMode':
+      return { ...d, mode: action.mode };
+    case 'toggleRow': {
+      const next = new Map(d.selectedKeys);
+      if (next.has(action.key)) next.delete(action.key);
+      else next.set(action.key, action.value);
+      return { ...d, selectedKeys: next };
+    }
+    case 'togglePage': {
+      const next = new Map(d.selectedKeys);
+      const allOn = action.entries.every((e) => next.has(e.key));
+      for (const e of action.entries) {
+        if (allOn) next.delete(e.key);
+        else next.set(e.key, e.value);
+      }
+      return { ...d, selectedKeys: next };
+    }
+    case 'toggleColumn': {
+      const next = new Set(d.included);
+      if (next.has(action.name)) next.delete(action.name);
+      else next.add(action.name);
+      return { ...d, included: next };
+    }
+    case 'setIncluded':
+      return { ...d, included: action.included };
+    case 'setOffset':
+      return { ...d, offset: action.offset };
+    case 'setSyncMode':
+      // the two modes never share trigger UI, so the kind follows the mode
+      return {
+        ...d,
+        syncMode: action.syncMode,
+        triggerKind: action.syncMode === 'live' ? 'watch' : 'replay',
+      };
+    case 'setTriggerKind':
+      return { ...d, triggerKind: action.triggerKind };
+    case 'setWatchStrategy':
+      return { ...d, watchStrategy: action.strategy };
+    case 'setWatchColumn':
+      return { ...d, watchColumn: action.column };
+    case 'setPollSeconds':
+      return { ...d, pollSeconds: action.seconds };
+    case 'setWatchStartFrom':
+      return { ...d, watchStartFrom: action.startFrom };
+    case 'toggleCdcOp': {
+      const next = new Set(d.cdcOps);
+      if (next.has(action.op)) next.delete(action.op);
+      else next.add(action.op);
+      return { ...d, cdcOps: next };
+    }
+    case 'setReadiness':
+      return { ...d, readiness: action.readiness };
+    case 'setCheckingCdc':
+      return { ...d, checkingCdc: action.checking };
+    case 'setWrapKey':
+      return { ...d, wrapKey: action.wrapKey };
+    case 'setDestKind': {
+      // seed the first target's key with the source PK so an upsert works out
+      // of the box
+      const dbTargets =
+        action.destKind === 'database' && action.sourcePk
+          ? d.dbTargets.map((t, i) =>
+              i === 0 && t.keyColumns.length === 0
+                ? { ...t, keyColumns: [action.sourcePk as string] }
+                : t,
+            )
+          : d.dbTargets;
+      return { ...d, destKind: action.destKind, dbTargets };
+    }
+    case 'patchDest':
+      return { ...d, dest: { ...d.dest, ...action.patch } };
+    case 'addDestHeader':
+      return {
+        ...d,
+        dest: { ...d.dest, headers: [...d.dest.headers, { key: '', value: '' }] },
+      };
+    case 'patchDestHeader':
+      return {
+        ...d,
+        dest: {
+          ...d.dest,
+          headers: d.dest.headers.map((x, j) =>
+            j === action.index ? { ...x, ...action.patch } : x,
+          ),
+        },
+      };
+    case 'removeDestHeader':
+      return {
+        ...d,
+        dest: {
+          ...d.dest,
+          headers: d.dest.headers.filter((_, j) => j !== action.index),
+        },
+      };
+    case 'patchDbTarget':
+      return {
+        ...d,
+        dbTargets: d.dbTargets.map((t, j) =>
+          j === action.index ? { ...t, ...action.patch } : t,
+        ),
+      };
+    case 'addDbTarget':
+      return {
+        ...d,
+        dbTargets: [
+          ...d.dbTargets,
+          { ...blankDbTarget(), keyColumns: action.sourcePk ? [action.sourcePk] : [] },
+        ],
+      };
+    case 'removeDbTarget':
+      return {
+        ...d,
+        dbTargets: d.dbTargets.filter((_, j) => j !== action.index),
+      };
+    case 'patchDelivery':
+      return { ...d, delivery: { ...d.delivery, ...action.patch } };
+  }
+}

--- a/apps/web/src/components/bridges/builder/mapping.test.ts
+++ b/apps/web/src/components/bridges/builder/mapping.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from 'vitest';
+import type { Bridge } from '@syncle/core';
+import { initialDraft } from './draft';
+import { buildInput, loadBridge, type BuildInputContext } from './mapping';
+
+/* -------------------------------------------------------------------------- */
+/* fixtures                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function httpBridge(overrides: Partial<Bridge> = {}): Bridge {
+  return {
+    id: 'b1',
+    name: 'Users to CRM',
+    workspaceId: 'ws1',
+    source: {
+      kind: 'table',
+      connectionId: 'c1',
+      database: 'app',
+      schema: 'public',
+      table: 'users',
+    },
+    destination: {
+      kind: 'http',
+      url: 'https://api.example.com/webhook',
+      method: 'POST',
+      headers: { 'X-Env': 'prod' },
+      auth: { type: 'bearer', token: 'secret' },
+      idempotency: true,
+    },
+    transform: { template: '{{$row}}', fields: ['id', 'email'], wrapKey: 'user' },
+    delivery: {
+      batchSize: 10,
+      maxAttempts: 5,
+      backoffMs: 500,
+      backoffMaxMs: 30000,
+      minDelayMs: 250,
+      timeoutMs: 20000,
+      pageSize: 200,
+      onError: 'abort',
+    },
+    trigger: { kind: 'replay' },
+    enabled: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function ctx(overrides: Partial<BuildInputContext> = {}): BuildInputContext {
+  return {
+    columns: ['id', 'email', 'name'],
+    singlePk: 'id',
+    fallbackName: 'Send users',
+    ...overrides,
+  };
+}
+
+/** a draft as the builder would hold it right before saving an HTTP bridge */
+function readyDraft() {
+  const d = initialDraft();
+  d.name = 'Users to CRM';
+  d.connectionId = 'c1';
+  d.database = 'app';
+  d.schema = 'public';
+  d.table = 'users';
+  d.included = new Set(['id', 'email', 'name']);
+  d.dest = { ...d.dest, url: 'https://api.example.com/webhook' };
+  return d;
+}
+
+/* -------------------------------------------------------------------------- */
+/* loadBridge: bridge → draft (edit-mode hydration)                           */
+/* -------------------------------------------------------------------------- */
+
+describe('loadBridge', () => {
+  it('hydrates source, transform, delivery and enabled from an http bridge', () => {
+    const d = loadBridge(httpBridge());
+    expect(d.name).toBe('Users to CRM');
+    expect(d.connectionId).toBe('c1');
+    expect(d.database).toBe('app');
+    expect(d.schema).toBe('public');
+    expect(d.table).toBe('users');
+    expect(d.mode).toBe('all');
+    expect(d.selectedKeys.size).toBe(0);
+    // pinned fields are deferred until the table's columns load
+    expect(d.fieldsPref).toEqual(['id', 'email']);
+    expect(d.included.size).toBe(0);
+    expect(d.wrapKey).toBe('user');
+    expect(d.destKind).toBe('http');
+    expect(d.dest).toEqual({
+      url: 'https://api.example.com/webhook',
+      method: 'POST',
+      authType: 'bearer',
+      authToken: 'secret',
+      authHeaderName: '',
+      authHeaderValue: '',
+      headers: [{ key: 'X-Env', value: 'prod' }],
+      idempotency: true,
+    });
+    expect(d.delivery).toEqual({
+      batchSize: 10,
+      maxAttempts: 5,
+      minDelayMs: 250,
+      timeoutMs: 20000,
+      onError: 'abort',
+    });
+    expect(d.enabled).toBe(false);
+    // a replay trigger is a one-time job
+    expect(d.syncMode).toBe('oneTime');
+    expect(d.triggerKind).toBe('replay');
+    expect(d.offset).toBe(0);
+    expect(d.readiness).toBeNull();
+  });
+
+  it('maps an in-filter to selected-rows mode, keyed by String(value)', () => {
+    const d = loadBridge(
+      httpBridge({
+        source: {
+          kind: 'table',
+          connectionId: 'c1',
+          table: 'users',
+          filters: [{ column: 'id', operator: 'in', value: [1, 2, 30] }],
+        },
+      }),
+    );
+    expect(d.mode).toBe('selected');
+    expect([...d.selectedKeys.entries()]).toEqual([
+      ['1', 1],
+      ['2', 2],
+      ['30', 30],
+    ]);
+    // absent optional source fields normalize to ''
+    expect(d.database).toBe('');
+    expect(d.schema).toBe('');
+  });
+
+  it('hydrates a watch trigger as a live bridge with its strategy fields', () => {
+    const d = loadBridge(
+      httpBridge({
+        trigger: {
+          kind: 'watch',
+          strategy: { strategy: 'timestamp', column: 'updated_at', lookbackMs: 3000 },
+          pollIntervalMs: 7500,
+          startFrom: 'beginning',
+          maxPerPoll: 500,
+        },
+      }),
+    );
+    expect(d.syncMode).toBe('live');
+    expect(d.triggerKind).toBe('watch');
+    expect(d.watchStrategy).toBe('timestamp');
+    expect(d.watchColumn).toBe('updated_at');
+    expect(d.pollSeconds).toBe(8); // rounded from 7500ms
+    expect(d.watchStartFrom).toBe('beginning');
+  });
+
+  it('leaves the watch column blank for a snapshot strategy', () => {
+    const d = loadBridge(
+      httpBridge({
+        trigger: {
+          kind: 'watch',
+          strategy: { strategy: 'snapshot', maxTracked: 50000 },
+          pollIntervalMs: 5000,
+          startFrom: 'now',
+          maxPerPoll: 500,
+        },
+      }),
+    );
+    expect(d.watchStrategy).toBe('snapshot');
+    expect(d.watchColumn).toBe('');
+  });
+
+  it('hydrates a cdc trigger with its operations', () => {
+    const d = loadBridge(
+      httpBridge({ trigger: { kind: 'cdc', operations: ['insert', 'delete'] } }),
+    );
+    expect(d.syncMode).toBe('live');
+    expect(d.triggerKind).toBe('cdc');
+    expect([...d.cdcOps]).toEqual(['insert', 'delete']);
+  });
+
+  it('hydrates header auth into the separate name/value fields', () => {
+    const d = loadBridge(
+      httpBridge({
+        destination: {
+          kind: 'http',
+          url: 'https://x.test/h',
+          method: 'PUT',
+          auth: { type: 'header', name: 'X-API-Key', value: 'v1' },
+          idempotency: false,
+        },
+      }),
+    );
+    expect(d.dest.authType).toBe('header');
+    expect(d.dest.authHeaderName).toBe('X-API-Key');
+    expect(d.dest.authHeaderValue).toBe('v1');
+    expect(d.dest.authToken).toBe('');
+    expect(d.dest.headers).toEqual([]);
+  });
+
+  it('hydrates database targets, keeping only real renames', () => {
+    const d = loadBridge(
+      httpBridge({
+        destination: {
+          kind: 'database',
+          targets: [
+            {
+              connectionId: 'c2',
+              table: 'users_copy',
+              writeMode: 'upsert',
+              keyColumns: ['id'],
+              mapping: [
+                { source: 'id', target: 'id' },
+                { source: 'email', target: 'mail' },
+              ],
+              createMissingTable: false,
+            },
+          ],
+        },
+      }),
+    );
+    expect(d.destKind).toBe('database');
+    expect(d.dbTargets).toEqual([
+      {
+        connectionId: 'c2',
+        database: '',
+        schema: '',
+        table: 'users_copy',
+        writeMode: 'upsert',
+        keyColumns: ['id'],
+        createMissingTable: false,
+        renames: { email: 'mail' }, // identity pairs dropped
+      },
+    ]);
+    // the http form resets to blank when the bridge writes to databases
+    expect(d.dest.url).toBe('');
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* buildInput: draft → BridgeInputDTO (save payload)                          */
+/* -------------------------------------------------------------------------- */
+
+describe('buildInput', () => {
+  it('builds the exact http payload, with fields omitted when all are included', () => {
+    const d = readyDraft();
+    d.dest = {
+      ...d.dest,
+      method: 'PUT',
+      authType: 'bearer',
+      authToken: 'tok',
+      headers: [
+        { key: ' X-Env ', value: 'prod' },
+        { key: '   ', value: 'dropped' },
+      ],
+      idempotency: true,
+    };
+    d.wrapKey = 'user';
+    expect(buildInput(d, ctx())).toEqual({
+      name: 'Users to CRM',
+      source: {
+        kind: 'table',
+        connectionId: 'c1',
+        database: 'app',
+        schema: 'public',
+        table: 'users',
+        filters: undefined,
+        sort: [{ column: 'id', direction: 'asc' }],
+      },
+      destination: {
+        kind: 'http',
+        url: 'https://api.example.com/webhook',
+        method: 'PUT',
+        headers: { 'X-Env': 'prod' },
+        auth: { type: 'bearer', token: 'tok' },
+        idempotency: true,
+      },
+      transform: { template: '{{$row}}', fields: undefined, wrapKey: 'user' },
+      delivery: {
+        batchSize: 1,
+        maxAttempts: 3,
+        minDelayMs: 0,
+        timeoutMs: 15000,
+        onError: 'continue',
+        backoffMs: 500,
+        backoffMaxMs: 30000,
+        pageSize: 200,
+      },
+      trigger: { kind: 'replay' },
+      enabled: true,
+    });
+  });
+
+  it('pins fields (in table order) when a subset of columns is included', () => {
+    const d = readyDraft();
+    d.included = new Set(['name', 'id']); // insertion order differs from table order
+    const input = buildInput(d, ctx());
+    expect(input.transform.fields).toEqual(['id', 'name']);
+  });
+
+  it('emits an in-filter from the selection in selected mode', () => {
+    const d = readyDraft();
+    d.mode = 'selected';
+    d.selectedKeys = new Map<string, unknown>([
+      ['1', 1],
+      ['2', 2],
+    ]);
+    const input = buildInput(d, ctx());
+    expect(input.source.kind).toBe('table');
+    if (input.source.kind === 'table') {
+      expect(input.source.filters).toEqual([
+        { column: 'id', operator: 'in', value: [1, 2] },
+      ]);
+    }
+  });
+
+  it('omits filters and sort without a single-column primary key', () => {
+    const d = readyDraft();
+    d.mode = 'selected';
+    d.selectedKeys = new Map([['1', 1]]);
+    const input = buildInput(d, ctx({ singlePk: null }));
+    if (input.source.kind === 'table') {
+      expect(input.source.filters).toBeUndefined();
+      expect(input.source.sort).toBeUndefined();
+    }
+  });
+
+  it('normalizes blank optionals: name falls back, empty database/schema/wrapKey become undefined', () => {
+    const d = readyDraft();
+    d.name = '   ';
+    d.database = '';
+    d.schema = '';
+    const input = buildInput(d, ctx());
+    expect(input.name).toBe('Send users');
+    if (input.source.kind === 'table') {
+      expect(input.source.database).toBeUndefined();
+      expect(input.source.schema).toBeUndefined();
+    }
+    expect(input.transform.wrapKey).toBeUndefined();
+    expect(
+      input.destination.kind === 'http' ? input.destination.headers : null,
+    ).toBeUndefined();
+  });
+
+  it('maps header auth and none auth', () => {
+    const d = readyDraft();
+    d.dest = {
+      ...d.dest,
+      authType: 'header',
+      authHeaderName: 'X-API-Key',
+      authHeaderValue: 'v',
+    };
+    let input = buildInput(d, ctx());
+    if (input.destination.kind === 'http') {
+      expect(input.destination.auth).toEqual({
+        type: 'header',
+        name: 'X-API-Key',
+        value: 'v',
+      });
+    }
+    d.dest = { ...d.dest, authType: 'none' };
+    input = buildInput(d, ctx());
+    if (input.destination.kind === 'http') {
+      expect(input.destination.auth).toEqual({ type: 'none' });
+    }
+  });
+
+  it('builds a database destination with the full included projection per target', () => {
+    const d = readyDraft();
+    d.included = new Set(['id', 'email']);
+    d.destKind = 'database';
+    d.dbTargets = [
+      {
+        connectionId: 'c2',
+        database: '',
+        schema: '',
+        table: '  users_copy  ',
+        writeMode: 'upsert',
+        keyColumns: ['id'],
+        createMissingTable: true,
+        renames: { email: ' mail ', name: 'ignored' },
+      },
+    ];
+    const input = buildInput(d, ctx());
+    expect(input.destination).toEqual({
+      kind: 'database',
+      targets: [
+        {
+          connectionId: 'c2',
+          database: undefined,
+          schema: undefined,
+          table: 'users_copy',
+          writeMode: 'upsert',
+          keyColumns: ['id'],
+          mapping: [
+            { source: 'id', target: 'id' },
+            { source: 'email', target: 'mail' }, // rename trimmed
+          ],
+          createMissingTable: true,
+        },
+      ],
+    });
+  });
+
+  it('builds watch triggers per strategy and clamps the poll interval to 1s', () => {
+    const d = readyDraft();
+    d.syncMode = 'live';
+    d.triggerKind = 'watch';
+    d.watchStrategy = 'increment';
+    d.watchColumn = 'id';
+    d.pollSeconds = 0.2;
+    d.watchStartFrom = 'beginning';
+    let input = buildInput(d, ctx());
+    expect(input.trigger).toEqual({
+      kind: 'watch',
+      strategy: { strategy: 'increment', column: 'id' },
+      pollIntervalMs: 1000,
+      startFrom: 'beginning',
+      maxPerPoll: 500,
+    });
+
+    d.watchStrategy = 'timestamp';
+    d.watchColumn = 'updated_at';
+    d.pollSeconds = 5;
+    input = buildInput(d, ctx());
+    expect(input.trigger).toEqual({
+      kind: 'watch',
+      strategy: { strategy: 'timestamp', column: 'updated_at', lookbackMs: 3000 },
+      pollIntervalMs: 5000,
+      startFrom: 'beginning',
+      maxPerPoll: 500,
+    });
+
+    d.watchStrategy = 'snapshot';
+    input = buildInput(d, ctx());
+    expect(input.trigger).toEqual({
+      kind: 'watch',
+      strategy: { strategy: 'snapshot', maxTracked: 50000 },
+      pollIntervalMs: 5000,
+      startFrom: 'beginning',
+      maxPerPoll: 500,
+    });
+  });
+
+  it('builds a cdc trigger from the selected operations', () => {
+    const d = readyDraft();
+    d.syncMode = 'live';
+    d.triggerKind = 'cdc';
+    d.cdcOps = new Set(['update', 'delete']);
+    expect(buildInput(d, ctx()).trigger).toEqual({
+      kind: 'cdc',
+      operations: ['update', 'delete'],
+    });
+  });
+
+  it('round-trips a loaded bridge back into an equivalent save payload', () => {
+    const bridge = httpBridge();
+    const d = loadBridge(bridge);
+    // simulate the columns-loaded effect applying the pinned fields
+    d.included = new Set(['id', 'email']);
+    const input = buildInput(d, ctx({ fallbackName: 'unused' }));
+    expect(input.name).toBe(bridge.name);
+    expect(input.source).toEqual({ ...bridge.source, filters: undefined, sort: [{ column: 'id', direction: 'asc' }] });
+    expect(input.destination).toEqual(bridge.destination);
+    expect(input.transform).toEqual(bridge.transform);
+    expect(input.delivery).toEqual(bridge.delivery);
+    expect(input.trigger).toEqual(bridge.trigger);
+    expect(input.enabled).toBe(bridge.enabled);
+  });
+});

--- a/apps/web/src/components/bridges/builder/mapping.ts
+++ b/apps/web/src/components/bridges/builder/mapping.ts
@@ -1,0 +1,228 @@
+/**
+ * the two pure edges of the builder: an existing bridge → a draft (edit-mode
+ * hydration) and a draft → the input DTO the API expects (save). kept free of
+ * React so they can be unit-tested directly.
+ */
+import type { Bridge, BridgeInputDTO, FilterSpec, SortSpec } from '@syncle/core';
+import {
+  blankDbTarget,
+  blankDestination,
+  initialDraft,
+  type BuilderDraft,
+} from './draft';
+
+/** hydrate a draft from an existing bridge (edit mode) */
+export function loadBridge(h: Bridge): BuilderDraft {
+  const d = initialDraft();
+  d.name = h.name;
+  d.connectionId = h.source.connectionId;
+  d.database = h.source.database ?? '';
+  d.mode = 'all';
+  d.selectedKeys = new Map();
+  if (h.source.kind === 'table') {
+    d.schema = h.source.schema ?? '';
+    d.table = h.source.table;
+    const inFilter = h.source.filters?.find((f) => f.operator === 'in');
+    if (inFilter && Array.isArray(inFilter.value)) {
+      d.mode = 'selected';
+      d.selectedKeys = new Map(
+        (inFilter.value as unknown[]).map((v) => [String(v), v]),
+      );
+    }
+  }
+  // applied when the table's columns load (subset = pinned fields, none = all)
+  d.fieldsPref = h.transform.fields ?? null;
+  d.wrapKey = h.transform.wrapKey ?? '';
+  if (h.trigger.kind === 'watch') {
+    d.syncMode = 'live';
+    d.triggerKind = 'watch';
+    d.watchStrategy = h.trigger.strategy.strategy;
+    d.watchColumn =
+      h.trigger.strategy.strategy === 'snapshot' ? '' : h.trigger.strategy.column;
+    d.pollSeconds = Math.round(h.trigger.pollIntervalMs / 1000);
+    d.watchStartFrom = h.trigger.startFrom;
+  } else if (h.trigger.kind === 'cdc') {
+    d.syncMode = 'live';
+    d.triggerKind = 'cdc';
+    d.cdcOps = new Set(h.trigger.operations);
+  } else {
+    d.syncMode = 'oneTime';
+    d.triggerKind = 'replay';
+  }
+  if (h.destination.kind === 'database') {
+    d.destKind = 'database';
+    d.dbTargets = h.destination.targets.map((t) => ({
+      connectionId: t.connectionId,
+      database: t.database ?? '',
+      schema: t.schema ?? '',
+      table: t.table,
+      writeMode: t.writeMode,
+      keyColumns: t.keyColumns,
+      createMissingTable: t.createMissingTable,
+      renames: Object.fromEntries(
+        t.mapping
+          .filter((m) => m.source !== m.target)
+          .map((m) => [m.source, m.target]),
+      ),
+    }));
+    d.dest = blankDestination();
+  } else {
+    d.destKind = 'http';
+    d.dbTargets = [blankDbTarget()];
+    d.dest = {
+      url: h.destination.url,
+      method: h.destination.method,
+      authType: h.destination.auth.type,
+      authToken:
+        h.destination.auth.type === 'bearer' ? h.destination.auth.token : '',
+      authHeaderName:
+        h.destination.auth.type === 'header' ? h.destination.auth.name : '',
+      authHeaderValue:
+        h.destination.auth.type === 'header' ? h.destination.auth.value : '',
+      headers: Object.entries(h.destination.headers ?? {}).map(
+        ([key, value]) => ({ key, value }),
+      ),
+      idempotency: h.destination.idempotency,
+    };
+  }
+  d.delivery = {
+    batchSize: h.delivery.batchSize,
+    maxAttempts: h.delivery.maxAttempts,
+    minDelayMs: h.delivery.minDelayMs,
+    timeoutMs: h.delivery.timeoutMs,
+    onError: h.delivery.onError,
+  };
+  d.enabled = h.enabled;
+  return d;
+}
+
+/** the bits of live table metadata the save payload depends on */
+export interface BuildInputContext {
+  /** every column name of the source table, in table order */
+  columns: string[];
+  /** the table's single-column primary key, or null */
+  singlePk: string | null;
+  /** localized name used when the draft's name is blank */
+  fallbackName: string;
+}
+
+/** turn the draft into the exact payload the create/update endpoints expect */
+export function buildInput(
+  draft: BuilderDraft,
+  ctx: BuildInputContext,
+): BridgeInputDTO {
+  const includedList = ctx.columns.filter((n) => draft.included.has(n));
+
+  const filters: FilterSpec[] = [];
+  if (draft.mode === 'selected' && ctx.singlePk) {
+    filters.push({
+      column: ctx.singlePk,
+      operator: 'in',
+      value: [...draft.selectedKeys.values()],
+    });
+  }
+  const sort: SortSpec[] | undefined = ctx.singlePk
+    ? [{ column: ctx.singlePk, direction: 'asc' }]
+    : undefined;
+
+  const auth: Extract<
+    BridgeInputDTO['destination'],
+    { kind: 'http' }
+  >['auth'] =
+    draft.dest.authType === 'bearer'
+      ? { type: 'bearer', token: draft.dest.authToken }
+      : draft.dest.authType === 'header'
+        ? {
+            type: 'header',
+            name: draft.dest.authHeaderName,
+            value: draft.dest.authHeaderValue,
+          }
+        : { type: 'none' };
+  const headerEntries = draft.dest.headers
+    .filter((h) => h.key.trim())
+    .map((h) => [h.key.trim(), h.value] as const);
+
+  const allIncluded = includedList.length === ctx.columns.length;
+
+  const destination: BridgeInputDTO['destination'] =
+    draft.destKind === 'database'
+      ? {
+          kind: 'database',
+          targets: draft.dbTargets.map((t) => ({
+            connectionId: t.connectionId,
+            database: t.database || undefined,
+            schema: t.schema || undefined,
+            table: t.table.trim(),
+            writeMode: t.writeMode,
+            keyColumns: t.keyColumns,
+            // always send the full projection so the included-column choice is
+            // honored; renames apply where the target name differs
+            mapping: includedList.map((s) => ({
+              source: s,
+              target: (t.renames[s]?.trim() || s),
+            })),
+            createMissingTable: t.createMissingTable,
+          })),
+        }
+      : {
+          kind: 'http',
+          url: draft.dest.url.trim(),
+          method: draft.dest.method,
+          headers: headerEntries.length
+            ? Object.fromEntries(headerEntries)
+            : undefined,
+          auth,
+          idempotency: draft.dest.idempotency,
+        };
+
+  return {
+    name: draft.name.trim() || ctx.fallbackName,
+    source: {
+      kind: 'table',
+      connectionId: draft.connectionId,
+      database: draft.database || undefined,
+      schema: draft.schema || undefined,
+      table: draft.table,
+      filters: filters.length ? filters : undefined,
+      sort,
+    },
+    destination,
+    transform: {
+      template: '{{$row}}',
+      fields: allIncluded ? undefined : includedList,
+      wrapKey: draft.wrapKey || undefined,
+    },
+    delivery: {
+      batchSize: draft.delivery.batchSize,
+      maxAttempts: draft.delivery.maxAttempts,
+      minDelayMs: draft.delivery.minDelayMs,
+      timeoutMs: draft.delivery.timeoutMs,
+      onError: draft.delivery.onError,
+      backoffMs: 500,
+      backoffMaxMs: 30000,
+      pageSize: 200,
+    },
+    trigger:
+      draft.triggerKind === 'cdc'
+        ? { kind: 'cdc', operations: [...draft.cdcOps] }
+        : draft.triggerKind === 'watch'
+          ? {
+              kind: 'watch',
+              strategy:
+                draft.watchStrategy === 'snapshot'
+                  ? { strategy: 'snapshot', maxTracked: 50000 }
+                  : draft.watchStrategy === 'timestamp'
+                    ? {
+                        strategy: 'timestamp',
+                        column: draft.watchColumn,
+                        lookbackMs: 3000,
+                      }
+                    : { strategy: 'increment', column: draft.watchColumn },
+              pollIntervalMs: Math.max(1000, Math.round(draft.pollSeconds * 1000)),
+              startFrom: draft.watchStartFrom,
+              maxPerPoll: 500,
+            }
+          : { kind: 'replay' },
+    enabled: draft.enabled,
+  };
+}

--- a/apps/web/src/components/bridges/builder/num-field.tsx
+++ b/apps/web/src/components/bridges/builder/num-field.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function NumField({
+  label,
+  value,
+  min,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min?: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <Label className="text-xs">{label}</Label>
+      <Input
+        type="number"
+        min={min}
+        className="h-8"
+        value={value}
+        onChange={(e) => {
+          // a cleared input coerces to 0 — clamp so e.g. batchSize can't be 0
+          const n = Number(e.target.value);
+          const floor = min ?? 0;
+          onChange(Number.isFinite(n) ? Math.max(floor, n) : floor);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/bridges/builder/payload-section.tsx
+++ b/apps/web/src/components/bridges/builder/payload-section.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+/**
+ * "what gets sent": the wrap-key input plus a live preview of the payload —
+ * a schema (field → JS type) and a real sample body rendered with the exact
+ * transform / mapping the runner will use.
+ */
+import { useMemo, type Dispatch } from 'react';
+import { useTranslations } from 'next-intl';
+import { mapRow, renderRow } from '@syncle/core';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { BuilderAction, BuilderDraft } from './draft';
+
+function jsType(v: unknown): string {
+  if (v === null || v === undefined) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v;
+}
+
+export function PayloadSection({
+  draft,
+  dispatch,
+  sampleRow,
+  includedList,
+}: {
+  draft: Pick<BuilderDraft, 'wrapKey' | 'table' | 'destKind' | 'dbTargets'>;
+  dispatch: Dispatch<BuilderAction>;
+  sampleRow: Record<string, unknown> | undefined;
+  includedList: string[];
+}) {
+  const t = useTranslations('bridgeBuilder');
+  const { wrapKey, table, destKind, dbTargets } = draft;
+
+  /* live payload: schema (field → type) + a real sample body */
+  const preview = useMemo(() => {
+    if (!sampleRow || includedList.length === 0) return null;
+    const schemaShape: Record<string, string> = {};
+    for (const c of includedList) schemaShape[c] = jsType(sampleRow[c]);
+    let body: unknown = null;
+    let error: string | null = null;
+    try {
+      if (destKind === 'database') {
+        const renames = dbTargets[0]?.renames ?? {};
+        body = mapRow(
+          sampleRow,
+          includedList.map((s) => ({ source: s, target: renames[s]?.trim() || s })),
+        );
+      } else {
+        body = renderRow(
+          sampleRow,
+          {
+            template: '{{$row}}',
+            fields: includedList,
+            wrapKey: wrapKey || undefined,
+          },
+          { table: table || '(table)', now: new Date().toISOString(), index: 0 },
+        ).body;
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    return {
+      schema: wrapKey ? { [wrapKey]: schemaShape } : schemaShape,
+      body,
+      error,
+    };
+  }, [sampleRow, includedList, wrapKey, table, destKind, dbTargets]);
+
+  return (
+    <section>
+      <h3 className="mb-2 text-sm font-semibold">{t('whatGetsSent')}</h3>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="grid gap-1.5">
+          <Label className="text-xs">{t('wrapKey')}</Label>
+          <Input
+            value={wrapKey}
+            placeholder={t('wrapKeyPlaceholder')}
+            className="h-8"
+            onChange={(e) => dispatch({ type: 'setWrapKey', wrapKey: e.target.value })}
+          />
+        </div>
+      </div>
+      {preview?.error ? (
+        <p className="text-destructive mt-2 text-xs">
+          {preview.error}
+        </p>
+      ) : preview ? (
+        <div className="mt-2 space-y-2">
+          <div>
+            <p className="text-muted-foreground mb-1 text-xs">
+              {t('schemaTypes')}
+            </p>
+            <pre className="bg-muted max-h-40 overflow-auto rounded-md p-2 font-mono text-[11px] leading-relaxed">
+              {JSON.stringify(preview.schema, null, 2)}
+            </pre>
+          </div>
+          <div>
+            <p className="text-muted-foreground mb-1 text-xs">
+              {t('samplePayload')}
+            </p>
+            <pre className="bg-muted max-h-48 overflow-auto rounded-md p-2 font-mono text-[11px] leading-relaxed">
+              {JSON.stringify(preview.body, null, 2)}
+            </pre>
+          </div>
+        </div>
+      ) : (
+        <p className="text-muted-foreground mt-2 text-xs">
+          {t('previewHint')}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/bridges/builder/source-section.tsx
+++ b/apps/web/src/components/bridges/builder/source-section.tsx
@@ -1,0 +1,406 @@
+'use client';
+
+/**
+ * left panel of the builder: source pickers (connection / database / table),
+ * the row/column selection grid, and pagination.
+ */
+import type { Dispatch } from 'react';
+import { Check, Loader2, Pencil, Plus, Radio, RefreshCw } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import type {
+  BrowseResult,
+  ConnectionConfig,
+  QueryColumn,
+  TableSchema,
+} from '@syncle/core';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { PAGE_SIZE, type BuilderAction, type BuilderDraft } from './draft';
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+export function SourceSection({
+  draft,
+  dispatch,
+  connections,
+  databases,
+  tables,
+  columns,
+  rows,
+  pk,
+  singlePk,
+  browse,
+  isFetching,
+  onRefetch,
+  openConnectionDialog,
+}: {
+  draft: Pick<
+    BuilderDraft,
+    | 'connectionId'
+    | 'database'
+    | 'table'
+    | 'mode'
+    | 'selectedKeys'
+    | 'included'
+    | 'offset'
+    | 'syncMode'
+  >;
+  dispatch: Dispatch<BuilderAction>;
+  connections: ConnectionConfig[] | undefined;
+  databases: string[] | undefined;
+  tables: TableSchema[];
+  columns: QueryColumn[];
+  rows: Record<string, unknown>[];
+  pk: string[];
+  singlePk: string | null;
+  browse: BrowseResult | undefined;
+  isFetching: boolean;
+  onRefetch: () => void;
+  openConnectionDialog: (editingId?: string | null) => void;
+}) {
+  const t = useTranslations('bridgeBuilder');
+  const { connectionId, database, table, mode, selectedKeys, included, offset, syncMode } =
+    draft;
+
+  /* ----- selection helpers ----- */
+
+  function toggleRow(row: Record<string, unknown>) {
+    if (!singlePk) return;
+    dispatch({ type: 'toggleRow', key: String(row[singlePk]), value: row[singlePk] });
+  }
+
+  function togglePage() {
+    if (!singlePk) return;
+    dispatch({
+      type: 'togglePage',
+      entries: rows.map((r) => ({ key: String(r[singlePk]), value: r[singlePk] })),
+    });
+  }
+
+  function toggleColumn(name: string) {
+    dispatch({ type: 'toggleColumn', name });
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* source pickers */}
+      <div className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
+        <div className="flex items-center gap-1">
+          <Select
+            value={connectionId}
+            onValueChange={(v) => dispatch({ type: 'selectConnection', connectionId: v })}
+          >
+            <SelectTrigger className="h-8 w-44">
+              <SelectValue placeholder={t('connection')} />
+            </SelectTrigger>
+            <SelectContent>
+              {(connections?.length ?? 0) === 0 && (
+                <div className="text-muted-foreground px-2 py-1.5 text-xs">
+                  {t('noConnections')}
+                </div>
+              )}
+              {connections?.map((c) => (
+                <SelectItem key={c.id} value={c.id}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {connectionId ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              title={t('editConnection')}
+              onClick={() => openConnectionDialog(connectionId)}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              onClick={() => openConnectionDialog()}
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" /> {t('connectDatabase')}
+            </Button>
+          )}
+        </div>
+
+        {(databases?.length ?? 0) > 0 && (
+          <Select
+            value={database || '__default'}
+            onValueChange={(v) =>
+              dispatch({
+                type: 'selectDatabase',
+                database: v === '__default' ? '' : v,
+              })
+            }
+          >
+            <SelectTrigger className="h-8 w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__default">{t('defaultDb')}</SelectItem>
+              {databases?.map((d) => (
+                <SelectItem key={d} value={d}>
+                  {d}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        <Select
+          value={table}
+          onValueChange={(v) => dispatch({ type: 'selectTable', table: v })}
+        >
+          <SelectTrigger className="h-8 w-52">
+            <SelectValue placeholder={t('table')} />
+          </SelectTrigger>
+          <SelectContent>
+            {tables.map((t) => (
+              <SelectItem
+                key={`${t.schema ?? ''}.${t.name}`}
+                value={t.name}
+              >
+                {t.schema ? `${t.schema}.${t.name}` : t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {table && (
+          <>
+            {syncMode === 'oneTime' && (
+              <>
+                <div className="ml-2 flex items-center overflow-hidden rounded-md border text-xs">
+                  {(['selected', 'all'] as const).map((m) => (
+                    <button
+                      key={m}
+                      disabled={m === 'selected' && !singlePk}
+                      onClick={() => dispatch({ type: 'setMode', mode: m })}
+                      className={cn(
+                        'px-2.5 py-1.5 transition-colors disabled:opacity-40',
+                        mode === m
+                          ? 'bg-primary text-primary-foreground'
+                          : 'hover:bg-accent',
+                      )}
+                      title={
+                        m === 'selected' && !singlePk
+                          ? t('needsSinglePk')
+                          : undefined
+                      }
+                    >
+                      {m === 'selected' ? t('selectedRows') : t('allRows')}
+                    </button>
+                  ))}
+                </div>
+                {mode === 'selected' && (
+                  <Badge variant="secondary" className="font-normal">
+                    {t('nSelected', { count: selectedKeys.size })}
+                  </Badge>
+                )}
+              </>
+            )}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="ml-auto h-8 w-8"
+              onClick={() => onRefetch()}
+            >
+              {isFetching ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* live-mode preview banner */}
+      {syncMode === 'live' && table && (
+        <div className="flex items-start gap-2 border-b bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-950/30 dark:text-blue-300">
+          <Radio className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            <strong>{t('columnSelectionOnly')}</strong> {t('liveBannerRest')}
+          </span>
+        </div>
+      )}
+
+      {/* grid */}
+      <div className="scrollbar-thin min-h-0 flex-1 overflow-auto">
+        {!table ? (
+          <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+            {syncMode === 'live'
+              ? t('pickLive')
+              : t('pickOneTime')}
+          </div>
+        ) : (
+          <table className="w-full border-collapse text-sm">
+            <thead className="bg-muted/95 sticky top-0 z-10 backdrop-blur">
+              <tr>
+                {mode === 'selected' && (
+                  <th className="w-8 border-b border-r px-2 py-1.5">
+                    <input
+                      type="checkbox"
+                      className="accent-primary h-3.5 w-3.5 cursor-pointer"
+                      disabled={!singlePk}
+                      checked={
+                        rows.length > 0 &&
+                        !!singlePk &&
+                        rows.every((r) =>
+                          selectedKeys.has(String(r[singlePk])),
+                        )
+                      }
+                      onChange={togglePage}
+                    />
+                  </th>
+                )}
+                {columns.map((col) => {
+                  const on = included.has(col.name);
+                  return (
+                    <th
+                      key={col.name}
+                      className={cn(
+                        'border-b border-r px-3 py-1.5 text-left font-medium',
+                        !on && 'opacity-40',
+                      )}
+                    >
+                      <button
+                        className="flex items-center gap-1.5 whitespace-nowrap"
+                        onClick={() => toggleColumn(col.name)}
+                        title={
+                          on
+                            ? t('includedClickExclude')
+                            : t('excludedClickInclude')
+                        }
+                      >
+                        <span
+                          className={cn(
+                            'flex h-3.5 w-3.5 items-center justify-center rounded border',
+                            on
+                              ? 'bg-primary border-primary text-primary-foreground'
+                              : 'border-muted-foreground/40',
+                          )}
+                        >
+                          {on && <Check className="h-3 w-3" />}
+                        </span>
+                        <span>{col.name}</span>
+                        {pk.includes(col.name) && (
+                          <span className="text-[10px] text-amber-500">
+                            PK
+                          </span>
+                        )}
+                      </button>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => {
+                const isSel =
+                  !!singlePk && selectedKeys.has(String(row[singlePk]));
+                return (
+                  <tr
+                    key={i}
+                    className={cn(
+                      'hover:bg-accent/40',
+                      mode === 'selected' && isSel && 'bg-primary/5',
+                    )}
+                  >
+                    {mode === 'selected' && (
+                      <td className="border-b border-r px-2 text-center">
+                        <input
+                          type="checkbox"
+                          className="accent-primary h-3.5 w-3.5 cursor-pointer"
+                          disabled={!singlePk}
+                          checked={isSel}
+                          onChange={() => toggleRow(row)}
+                        />
+                      </td>
+                    )}
+                    {columns.map((col) => (
+                      <td
+                        key={col.name}
+                        className={cn(
+                          'max-w-[360px] border-b border-r px-3 py-1',
+                          !included.has(col.name) && 'opacity-40',
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            'block truncate font-mono text-xs',
+                            row[col.name] == null &&
+                              'text-muted-foreground/60 italic',
+                          )}
+                          title={formatCell(row[col.name])}
+                        >
+                          {formatCell(row[col.name])}
+                        </span>
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* pagination */}
+      {table && (
+        <div className="text-muted-foreground flex items-center gap-2 border-t px-3 py-1.5 text-xs">
+          <span>
+            {syncMode === 'live' ? t('previewRows') + ' ' : t('rows') + ' '}
+            {rows.length ? offset + 1 : 0}–{offset + rows.length}
+            {syncMode === 'oneTime' && browse?.total != null
+              ? t('ofTotal', {
+                  total: `${browse.estimated ? '~' : ''}${browse.total.toLocaleString()}`,
+                })
+              : ''}
+          </span>
+          <div className="ml-auto flex gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7"
+              disabled={offset === 0}
+              onClick={() =>
+                dispatch({ type: 'setOffset', offset: Math.max(0, offset - PAGE_SIZE) })
+              }
+            >
+              {t('prev')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7"
+              disabled={!browse?.hasMore}
+              onClick={() =>
+                dispatch({ type: 'setOffset', offset: offset + PAGE_SIZE })
+              }
+            >
+              {t('next')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/bridges/builder/trigger-section.tsx
+++ b/apps/web/src/components/bridges/builder/trigger-section.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+/**
+ * "what runs in this bridge" (one-time job vs live) plus, for live bridges,
+ * the trigger config: polling watch or event-based CDC. owns the CDC
+ * readiness probing flow.
+ */
+import type { Dispatch } from 'react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { useTranslations } from 'next-intl';
+import type { QueryColumn } from '@syncle/core';
+import { api, ApiError } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { NumField } from './num-field';
+import type { BuilderAction, BuilderDraft, WatchStrategy } from './draft';
+
+export function TriggerSection({
+  draft,
+  dispatch,
+  columns,
+}: {
+  draft: Pick<
+    BuilderDraft,
+    | 'connectionId'
+    | 'database'
+    | 'schema'
+    | 'table'
+    | 'syncMode'
+    | 'triggerKind'
+    | 'watchStrategy'
+    | 'watchColumn'
+    | 'pollSeconds'
+    | 'watchStartFrom'
+    | 'cdcOps'
+    | 'readiness'
+    | 'checkingCdc'
+  >;
+  dispatch: Dispatch<BuilderAction>;
+  columns: QueryColumn[];
+}) {
+  const t = useTranslations('bridgeBuilder');
+  const {
+    syncMode,
+    triggerKind,
+    watchStrategy,
+    watchColumn,
+    pollSeconds,
+    watchStartFrom,
+    cdcOps,
+    readiness,
+    checkingCdc,
+  } = draft;
+
+  async function checkReadiness() {
+    if (!draft.connectionId || !draft.table) return;
+    dispatch({ type: 'setCheckingCdc', checking: true });
+    try {
+      dispatch({
+        type: 'setReadiness',
+        readiness: await api.cdcReadiness({
+          connectionId: draft.connectionId,
+          database: draft.database || undefined,
+          schema: draft.schema || undefined,
+          table: draft.table,
+        }),
+      });
+    } catch (err) {
+      toast.error(t('readinessFailed'), {
+        description: err instanceof ApiError ? err.message : String(err),
+      });
+    } finally {
+      dispatch({ type: 'setCheckingCdc', checking: false });
+    }
+  }
+
+  return (
+    <>
+      {/* what runs in this bridge: an on-demand job or a live bridge */}
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold">{t('whatRuns')}</h3>
+        <div className="flex overflow-hidden rounded-md border text-xs">
+          {(
+            [
+              ['oneTime', t('modeOneTime')],
+              ['live', t('modeLive')],
+            ] as const
+          ).map(([k, label]) => (
+            <button
+              key={k}
+              onClick={() => dispatch({ type: 'setSyncMode', syncMode: k })}
+              className={cn(
+                'flex-1 px-2.5 py-1.5 transition-colors',
+                syncMode === k
+                  ? 'bg-accent font-medium'
+                  : 'text-muted-foreground hover:bg-accent/50',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <p className="text-muted-foreground text-[11px]">
+          {syncMode === 'oneTime'
+            ? t('oneTimeDesc')
+            : t('liveDesc')}
+        </p>
+      </section>
+
+      {/* trigger, live bridges only. one-time jobs are always a one-shot replay */}
+      {syncMode === 'live' && (
+        <section className="space-y-2">
+          <h3 className="text-sm font-semibold">{t('howItListens')}</h3>
+          <div className="flex overflow-hidden rounded-md border text-xs">
+            {(
+              [
+                ['watch', t('polling')],
+                ['cdc', t('eventBased')],
+              ] as const
+            ).map(([k, label]) => (
+              <button
+                key={k}
+                onClick={() => dispatch({ type: 'setTriggerKind', triggerKind: k })}
+                className={cn(
+                  'flex-1 px-2.5 py-1.5 transition-colors',
+                  triggerKind === k
+                    ? 'bg-accent font-medium'
+                    : 'text-muted-foreground hover:bg-accent/50',
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {triggerKind === 'cdc' && (
+            <div className="grid gap-2 rounded-md border p-2.5">
+            <Label className="text-xs">{t('operationsToDeliver')}</Label>
+            <div className="flex gap-3 text-xs">
+              {(['insert', 'update', 'delete'] as const).map((op) => (
+                <label key={op} className="flex items-center gap-1.5">
+                  <input
+                    type="checkbox"
+                    className="accent-primary h-3.5 w-3.5"
+                    checked={cdcOps.has(op)}
+                    onChange={() => dispatch({ type: 'toggleCdcOp', op })}
+                  />
+                  {op === 'insert'
+                    ? t('opInsert')
+                    : op === 'update'
+                      ? t('opUpdate')
+                      : t('opDelete')}
+                </label>
+              ))}
+            </div>
+
+            {/* readiness / setup */}
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground text-[11px]">
+                {t('cdcDesc')}
+              </span>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7"
+                disabled={!draft.connectionId || !draft.table || checkingCdc}
+                onClick={checkReadiness}
+              >
+                {checkingCdc ? (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                {t('checkReadiness')}
+              </Button>
+            </div>
+
+            {readiness && (
+              <div className="space-y-1.5 rounded-md border p-2 text-[11px]">
+                {!readiness.supported ? (
+                  <p className="text-amber-600">
+                    {readiness.instructions[0]}
+                  </p>
+                ) : (
+                  <>
+                    <p
+                      className={cn(
+                        'font-medium',
+                        readiness.ready ? 'text-emerald-600' : 'text-amber-600',
+                      )}
+                    >
+                      {readiness.ready
+                        ? t('cdcReady')
+                        : t('setupNeeded')}
+                    </p>
+                    {readiness.checks.map((c) => (
+                      <div key={c.label} className="flex items-center gap-1.5">
+                        <span className={c.ok ? 'text-emerald-600' : 'text-destructive'}>
+                          {c.ok ? '✓' : '✗'}
+                        </span>
+                        <span>
+                          {c.label}
+                          {c.detail ? ` (${c.detail})` : ''}
+                        </span>
+                      </div>
+                    ))}
+                    {readiness.instructions.map((ins, i) => (
+                      <p key={i} className="text-muted-foreground pl-1">
+                        • {ins}
+                      </p>
+                    ))}
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {triggerKind === 'watch' && (
+          <div className="grid gap-2 rounded-md border p-2.5">
+            <div className="grid gap-1.5">
+              <Label className="text-xs">{t('detectNewRowsBy')}</Label>
+              <Select
+                value={watchStrategy}
+                onValueChange={(v) =>
+                  dispatch({ type: 'setWatchStrategy', strategy: v as WatchStrategy })
+                }
+              >
+                <SelectTrigger className="h-8">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="increment">
+                    {t('strategyIncrement')}
+                  </SelectItem>
+                  <SelectItem value="timestamp">
+                    {t('strategyTimestamp')}
+                  </SelectItem>
+                  <SelectItem value="snapshot">
+                    {t('strategySnapshot')}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {watchStrategy !== 'snapshot' && (
+              <div className="grid gap-1.5">
+                <Label className="text-xs">
+                  {watchStrategy === 'timestamp'
+                    ? t('timestampColumn')
+                    : t('incrementingColumn')}
+                </Label>
+                <Select
+                  value={watchColumn}
+                  onValueChange={(v) => dispatch({ type: 'setWatchColumn', column: v })}
+                >
+                  <SelectTrigger className="h-8">
+                    <SelectValue placeholder={t('selectColumn')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {columns.map((c) => (
+                      <SelectItem key={c.name} value={c.name}>
+                        {c.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-2">
+              <NumField
+                label={t('pollEvery')}
+                value={pollSeconds}
+                min={1}
+                onChange={(v) => dispatch({ type: 'setPollSeconds', seconds: v })}
+              />
+              <div className="grid gap-1.5">
+                <Label className="text-xs">{t('startFrom')}</Label>
+                <Select
+                  value={watchStartFrom}
+                  onValueChange={(v) =>
+                    dispatch({
+                      type: 'setWatchStartFrom',
+                      startFrom: v as 'now' | 'beginning',
+                    })
+                  }
+                >
+                  <SelectTrigger className="h-8">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="now">{t('fromNow')}</SelectItem>
+                    <SelectItem value="beginning">{t('fromBeginning')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+              <p className="text-muted-foreground text-[11px]">
+                {t('watchDesc')}
+              </p>
+            </div>
+          )}
+        </section>
+      )}
+    </>
+  );
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// node environment is enough: the web tests cover pure functions (no DOM)
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      // mirror the "@/*" path alias from tsconfig.json
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@22.19.19)(terser@5.48.0)
 
   packages/core:
     dependencies:


### PR DESCRIPTION
## What

`bridge-builder.tsx` had grown into a ~1,900-line god-component: one function holding ~27 useState calls across source selection, row/column selection, trigger config (incl. CDC readiness probing), HTTP destination, database targets, delivery tuning, payload preview, and edit-mode hydration. This splits it along the section boundaries the JSX already had, with zero behavior change.

## How

- **`builder/draft.ts`** — one typed `BuilderDraft` + a discriminated-union `BuilderAction` reducer replaces all the scalar useState calls. Every cross-field cascade (connection change resets database/table/columns/rows, table change resets selections + CDC readiness, sync-mode toggle adjusts the trigger kind, database destination seeds the first target's key with the source PK) now lives in one reducer instead of being scattered across onChange closures.
- **`builder/mapping.ts`** — the two pure edges extracted from inline closures: `loadBridge(bridge) -> BuilderDraft` (edit-mode hydration) and `buildInput(draft, ctx) -> BridgeInputDTO` (save payload). Covered by 17 unit tests in `mapping.test.ts`, including a load -> save round-trip.
- **Sections** — `source-section` (pickers + grid + pagination), `trigger-section` (run mode + watch/CDC config, owns the readiness probe flow), `payload-section` (wrap key + live preview), `destination-section` (HTTP form / db targets toggle), `db-targets-editor`, `delivery-section`, shared `num-field`. `bridge-builder.tsx` (304 lines) stays as the orchestrator: queries, derived state, save flow, layout.
- **Testing plumbing** — `apps/web` gets a `test` script (`vitest run --passWithNoTests`) and a minimal node-environment `vitest.config.ts` with the `@` alias; vitest pinned to the same `^2.1.4` the other packages use.

Behavior-preserving: identical rendered tree, labels, i18n keys, and network calls. Verified i18n keys, classNames, and select values are byte-identical between the old monolith and the new files.

## Gates

- `pnpm build:core` ✓
- `pnpm typecheck` ✓
- `pnpm -r test` ✓ (17 new web tests; 75 api + core suites still green)
- `pnpm lint` ✓
- `pnpm --filter @syncle/web build` ✓