### PR TITLE
fix(install): drop the "v" prefix when deriving the image tag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,8 +43,11 @@ if [ -z "$REF" ]; then
   [ -n "$REF" ] || REF=main
 fi
 
+# The git tag carries a "v" prefix; the image tag does not. docker/metadata-action
+# renders {{version}} from the semver in the tag, so v1.1.0 publishes as 1.1.0 —
+# asking for :v1.1.0 gets "not found".
 case "$REF" in
-  v*) IMAGE_TAG="$REF" ;;
+  v*) IMAGE_TAG="${REF#v}" ;;
   *)  IMAGE_TAG="latest" ;;
 esac
 IMAGE="${SYNCLE_IMAGE:-$IMAGE_REPO:$IMAGE_TAG}"


### PR DESCRIPTION
The one-command install is broken on `main`. A fresh install fails with:

```
failed to resolve reference "ghcr.io/osmanahmadxai/syncle:v1.1.0": not found
```

The installer resolves the newest release — a git tag, `v1.1.0` — and used it verbatim as the image tag. But `docker/metadata-action` renders `{{version}}` from the semver *inside* the tag, so a release publishes as `:1.1.0`, `:1.1` and `:latest`, never `:v1.1.0`.

One character. Verified by running the fixed installer end to end: pulls `ghcr.io/osmanahmadxai/syncle:1.1.0`, all four containers healthy, web GUI serving, `/api` proxied, setup token printed.

No new release is needed — `install.sh` is fetched from `main`, so this goes live on merge. The v1.1.0 images are already correct.