### PR TITLE
feat(setup): prefill the first-run token instead of making it be looked up

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ opens it at **http://localhost:3002**. Docker is the only requirement — Node,
 Postgres and Redis all run in containers, and the app image is pulled prebuilt,
 so nothing is compiled on your machine.
 
-On first run the API prints a **setup token** to the console; enter it in the
-web UI to create your admin account. Grab it with `syncle logs api` if you miss
-it.
+On first run it opens the setup form with a one-time **setup token** already
+filled in, so all you do is pick a username and password. The token proves you
+are the operator of this machine — it is read off the server by `syncle up`,
+never typed. If you're setting up from another device, `syncle logs api` prints
+it and the form accepts it by hand.
 
 After that, the `syncle` command manages the stack:
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -11,6 +11,7 @@ import {
   scrypt as scryptCb,
   timingSafeEqual,
 } from 'node:crypto';
+import { rmSync, writeFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import type { Request, Response } from 'express';
@@ -25,6 +26,7 @@ import { AttemptLimiter } from '../common/attempt-limiter';
 import type { AppUser } from '@prisma/client';
 import { CryptoService } from '../common/crypto.service';
 import { PrismaService } from '../common/prisma.service';
+import { runtimeConfig } from '../common/runtime-config';
 import { SettingsStoreService } from '../settings/settings-store.service';
 
 const scrypt = promisify(scryptCb);
@@ -89,7 +91,12 @@ export class AuthService implements OnModuleInit {
    */
   async onModuleInit(): Promise<void> {
     try {
-      if (await this.hasAccount()) return;
+      if (await this.hasAccount()) {
+        // an account already exists — clear any token file left behind by an
+        // earlier boot (e.g. the process was killed mid-setup)
+        this.clearSetupTokenFile();
+        return;
+      }
     } catch (err) {
       // DB not up yet — the token is minted lazily on the first setup attempt
       this.logger.warn(`Skipped setup-token mint: ${(err as Error).message}`);
@@ -132,6 +139,7 @@ export class AuthService implements OnModuleInit {
       },
     });
     this.setupToken = null;
+    this.clearSetupTokenFile();
     this.setupLimiter.succeed(`setup:${ip}`);
     return user;
   }
@@ -167,7 +175,38 @@ export class AuthService implements OnModuleInit {
 
   private mintSetupToken(): string {
     this.setupToken = randomBytes(9).toString('base64url');
+    this.persistSetupToken(this.setupToken);
     return this.setupToken;
+  }
+
+  /**
+   * Mirror the token to the data dir so `syncle up` can read it back and open
+   * the browser with the setup form already filled in. Reading that file needs
+   * host or container access — the same thing the token is proof of — so this
+   * changes how the operator receives it, not who can.
+   *
+   * Written 0600, and removed as soon as an account exists so a stale file can
+   * never hand out a token that no longer works.
+   */
+  private persistSetupToken(token: string): void {
+    try {
+      writeFileSync(runtimeConfig.setupTokenFile, `${token}\n`, { mode: 0o600 });
+    } catch (err) {
+      // non-fatal: the token is still printed to the console
+      this.logger.warn(
+        `Could not write the setup-token file: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  private clearSetupTokenFile(): void {
+    try {
+      rmSync(runtimeConfig.setupTokenFile, { force: true });
+    } catch (err) {
+      this.logger.warn(
+        `Could not remove the setup-token file: ${(err as Error).message}`,
+      );
+    }
   }
 
   /**

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -17,6 +17,12 @@ export const runtimeConfig = {
   dataDir,
   storeFile: resolve(dataDir, 'syncle.db'),
   keyFile: resolve(dataDir, 'master.key'),
+  /**
+   * first-run setup token, mirrored to disk so the launcher can hand it to the
+   * browser instead of making the operator dig it out of the container logs.
+   * exists only while the instance has no account.
+   */
+  setupTokenFile: resolve(dataDir, 'setup-token'),
   masterKey: process.env.SYNCLE_MASTER_KEY ?? null,
   maxQueryRows: Number(process.env.SYNCLE_MAX_QUERY_ROWS ?? 5000),
   poolIdleMs: Number(process.env.SYNCLE_POOL_IDLE_MS ?? 300_000),

--- a/apps/web/src/components/auth/setup-screen.tsx
+++ b/apps/web/src/components/auth/setup-screen.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { Loader2, ShieldCheck } from 'lucide-react';
 import { toast } from 'sonner';
 import { ApiError } from '@/lib/api';
 import { useSetup } from '@/lib/queries';
+import { readSetupTokenFromHash } from '@/lib/setup-token';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -26,7 +27,25 @@ export function SetupScreen() {
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [setupToken, setSetupToken] = useState('');
+  const [tokenFromServer, setTokenFromServer] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  /**
+   * `syncle up` opens this page with the first-run token in the URL fragment,
+   * so the operator never copies it by hand. Stripped from the address bar as
+   * soon as it is read, to keep it out of browser history.
+   */
+  useEffect(() => {
+    const token = readSetupTokenFromHash(window.location.hash);
+    if (!token) return;
+    setSetupToken(token);
+    setTokenFromServer(true);
+    window.history.replaceState(
+      null,
+      '',
+      window.location.pathname + window.location.search,
+    );
+  }, []);
 
   async function handleSubmit() {
     // the Enter-key handler bypasses the button's disabled state
@@ -126,16 +145,23 @@ export function SetupScreen() {
                 onChange={(e) => setConfirm(e.target.value)}
               />
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="setup-token">{t('token')}</Label>
-              <Input
-                id="setup-token"
-                autoComplete="off"
-                value={setupToken}
-                onChange={(e) => setSetupToken(e.target.value)}
-              />
-              <p className="text-muted-foreground text-xs">{t('tokenHint')}</p>
-            </div>
+            {tokenFromServer ? (
+              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-400">
+                <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
+                {t('tokenAuto')}
+              </div>
+            ) : (
+              <div className="grid gap-2">
+                <Label htmlFor="setup-token">{t('token')}</Label>
+                <Input
+                  id="setup-token"
+                  autoComplete="off"
+                  value={setupToken}
+                  onChange={(e) => setSetupToken(e.target.value)}
+                />
+                <p className="text-muted-foreground text-xs">{t('tokenHint')}</p>
+              </div>
+            )}
             {error && <p className="text-destructive text-sm">{error}</p>}
             <Button type="submit" className="w-full" disabled={setup.isPending}>
               {setup.isPending ? (

--- a/apps/web/src/lib/setup-token.test.ts
+++ b/apps/web/src/lib/setup-token.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { readSetupTokenFromHash, setupUrl } from './setup-token';
+
+describe('readSetupTokenFromHash', () => {
+  it('reads the token the launcher writes', () => {
+    expect(readSetupTokenFromHash('#setup-token=4_jtNf95xrP5')).toBe(
+      '4_jtNf95xrP5',
+    );
+  });
+
+  it('works without the leading hash', () => {
+    expect(readSetupTokenFromHash('setup-token=abc123')).toBe('abc123');
+  });
+
+  it('finds the token alongside other fragment params', () => {
+    expect(readSetupTokenFromHash('#foo=1&setup-token=abc&bar=2')).toBe('abc');
+    expect(readSetupTokenFromHash('#setup-token=abc&bar=2')).toBe('abc');
+  });
+
+  it('decodes percent-escapes', () => {
+    // base64url never produces these, but the value is URL-encoded on the way in
+    expect(readSetupTokenFromHash('#setup-token=a%2Bb%2Fc')).toBe('a+b/c');
+  });
+
+  it('survives a malformed escape instead of throwing', () => {
+    // decodeURIComponent('%E0%A4%A') throws — the screen must still render
+    expect(readSetupTokenFromHash('#setup-token=%E0%A4%A')).toBe('%E0%A4%A');
+  });
+
+  it('returns null when there is no token', () => {
+    expect(readSetupTokenFromHash('')).toBeNull();
+    expect(readSetupTokenFromHash('#')).toBeNull();
+    expect(readSetupTokenFromHash('#other=1')).toBeNull();
+    expect(readSetupTokenFromHash('#setup-token=')).toBeNull();
+  });
+
+  it('does not match a key that merely ends with the param name', () => {
+    expect(readSetupTokenFromHash('#not-setup-token=abc')).toBeNull();
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(readSetupTokenFromHash('#setup-token=%20abc%20')).toBe('abc');
+    expect(readSetupTokenFromHash('#setup-token=%20')).toBeNull();
+  });
+});
+
+describe('setupUrl', () => {
+  it('builds the URL the launcher opens', () => {
+    expect(setupUrl('http://localhost:3002', 'abc')).toBe(
+      'http://localhost:3002/#setup-token=abc',
+    );
+  });
+
+  it('does not double the slash', () => {
+    expect(setupUrl('http://localhost:3002/', 'abc')).toBe(
+      'http://localhost:3002/#setup-token=abc',
+    );
+  });
+
+  it('round-trips a token through the fragment', () => {
+    const token = 'a+b/c=';
+    const url = setupUrl('http://localhost:3002', token);
+    expect(readSetupTokenFromHash(new URL(url).hash)).toBe(token);
+  });
+});

--- a/apps/web/src/lib/setup-token.ts
+++ b/apps/web/src/lib/setup-token.ts
@@ -1,0 +1,42 @@
+/**
+ * `syncle up` reads the first-run token off the server and opens the GUI with
+ * it in the URL fragment, so the operator never types it by hand.
+ *
+ * A fragment rather than a query string on purpose: fragments are not sent to
+ * the server, so the token stays out of access logs and Referer headers. The
+ * setup screen strips it from the address bar as soon as it is read, to keep
+ * it out of browser history too.
+ */
+const TOKEN_PARAM = 'setup-token';
+
+/**
+ * Pull the setup token out of a location hash, or null when it isn't there.
+ * Accepts the token in any position so the fragment can carry other params.
+ */
+export function readSetupTokenFromHash(hash: string): string | null {
+  if (!hash) return null;
+  // a hash may or may not include the leading '#', depending on the caller
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  for (const part of raw.split('&')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq) !== TOKEN_PARAM) continue;
+    const value = part.slice(eq + 1);
+    if (!value) return null;
+    try {
+      const decoded = decodeURIComponent(value).trim();
+      return decoded === '' ? null : decoded;
+    } catch {
+      // a malformed percent-escape shouldn't take the setup screen down —
+      // fall back to the raw value and let the API reject it if it's wrong
+      const trimmed = value.trim();
+      return trimmed === '' ? null : trimmed;
+    }
+  }
+  return null;
+}
+
+/** the URL a launcher should open to prefill the setup form */
+export function setupUrl(baseUrl: string, token: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}/#${TOKEN_PARAM}=${encodeURIComponent(token)}`;
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -44,7 +44,8 @@
       "couldNotCreate": "Could not create account",
       "token": "Setup token",
       "tokenHint": "Printed in the server logs when Syncle starts — it proves you operate this server.",
-      "tokenMissing": "Enter the setup token from the server logs."
+      "tokenMissing": "Enter the setup token from the server logs.",
+      "tokenAuto": "Verified as this server's operator — the setup token came from the machine running Syncle."
     }
   },
   "userMenu": {

--- a/apps/web/src/messages/zh.json
+++ b/apps/web/src/messages/zh.json
@@ -44,7 +44,8 @@
       "couldNotCreate": "无法创建账号",
       "token": "初始化令牌",
       "tokenHint": "Syncle 启动时打印在服务器日志中——用于证明你是这台服务器的运维者。",
-      "tokenMissing": "请输入服务器日志中的初始化令牌。"
+      "tokenMissing": "请输入服务器日志中的初始化令牌。",
+      "tokenAuto": "已验证为本服务器的操作者 — 设置令牌来自运行 Syncle 的主机。"
     }
   },
   "userMenu": {

--- a/bin/syncle
+++ b/bin/syncle
@@ -37,6 +37,16 @@ open_url() {
   else printf 'Open %s in your browser.\n' "$1"; fi
 }
 
+# The API writes its first-run token into the data dir, and removes it as soon
+# as an account exists. Reading it needs container access on this host — the
+# very thing the token is proof of — so handing it to the browser changes how
+# the operator receives it, not who is able to.
+setup_token() {
+  compose exec -T api \
+    sh -c 'cat "${SYNCLE_DATA_DIR:-.syncle}/setup-token" 2>/dev/null' 2>/dev/null \
+    | tr -d '\r\n'
+}
+
 wait_for_web() {
   printf 'Waiting for the web GUI'
   for _ in $(seq 1 60); do
@@ -72,19 +82,40 @@ EOF
 cmd="${1:-up}"
 case "$cmd" in
   up)
-    # pull first so a slow download isn't mistaken for a hung startup
+    # pull first so a slow download isn't mistaken for a hung startup.
+    # best-effort: a pull failure must not stop a start that could still work
+    # from cached images (offline, or a locally built SYNCLE_IMAGE). If an
+    # image really is missing, `up` fails next with a clearer message.
     printf 'Downloading images (first run takes a minute)...\n'
-    compose pull --quiet
+    compose pull --quiet 2>/dev/null || printf 'Could not refresh images — using what is already downloaded.\n'
     compose up -d
     wait_for_web
-    open_url "$WEB_URL"
+    # a token only exists on a first run; the fragment prefills the setup form
+    # so it never has to be typed, and never reaches the server or the logs
+    token=$(setup_token || true)
+    if [ -n "$token" ]; then
+      open_url "$WEB_URL/#setup-token=$token"
+      printf '\nFirst run — the setup form is prefilled in your browser.\n'
+      printf 'If it did not open, go to:\n  %s/#setup-token=%s\n\n' "$WEB_URL" "$token"
+    else
+      open_url "$WEB_URL"
+    fi
     printf 'Syncle is running at %s\n' "$WEB_URL"
     ;;
   down)    compose down ;;
   restart) compose restart ;;
   status|ps) compose ps ;;
   logs)    shift || true; compose logs -f "$@" ;;
-  open)    open_url "$WEB_URL" ;;
+  open)
+    # carry the token through here too, so `syncle open` before setup is done
+    # lands on a prefilled form rather than an empty token field
+    token=$(setup_token || true)
+    if [ -n "$token" ]; then
+      open_url "$WEB_URL/#setup-token=$token"
+    else
+      open_url "$WEB_URL"
+    fi
+    ;;
   update)
     # re-runs the installer, which refreshes the compose file and launcher and
     # re-pins the image to the newest release. the encryption key is preserved.


### PR DESCRIPTION
Creating the admin account meant digging the setup token out of the container logs and pasting it into a form field — the worst part of an otherwise one-command install.

`syncle up` now reads the token off the server and opens the GUI with it in the URL fragment. The setup screen shows **"Verified as this server's operator"** instead of an empty field, and the operator only picks a username and password.

## Ownership proof is unchanged

The API mirrors the token to a `0600` file in its data dir, so reading it still requires container access on that host — exactly what the token attests. Anyone reaching the instance over the network still gets an empty token field. The manual field remains for setting up from another device (`syncle logs api` prints it).

A **fragment**, not a query string: fragments are never sent to the server, so the token stays out of access logs and `Referer` headers. The screen strips it from the address bar on read, so it misses browser history too.

## Lifecycle

| State | Behaviour |
|---|---|
| Fresh instance, no account | file written `-rw-------`, matches the console banner |
| Setup succeeds | file removed |
| Boot with an account present | stale file cleared |

That last rule matters: a file left behind by a killed process would otherwise keep offering a token the server no longer honors.

## Also

`compose pull` is now best-effort in the launcher. Under `set -e` a failed pull aborted the whole start, so an offline machine with images already cached could not run `syncle up` at all. A genuinely missing image now fails at `up` with a clearer message.

## Verified

Against a real container stack built from this branch:

- `syncle up` on a fresh install prints the prefilled URL and opens it
- that token is accepted (`201`), and the file is gone afterwards
- `syncle open` after setup uses the plain URL, no token
- stale-file cleanup confirmed by planting one and rebooting the API

11 new unit tests cover the fragment parsing — including a malformed percent-escape, which the first draft crashed on (bare `decodeURIComponent` throws, white-screening the setup page).

Full suite: 174 tests green.