### PR TITLE
chore: syncle.dev is the install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The rest is the same whichever destination and trigger you pick:
 ### Install and run — one command
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/osmanahmadxai/SYNCLE/main/install.sh | sh -s -- up
+curl -fsSL https://syncle.dev/install | sh -s -- up
 ```
 
 That's the whole thing. It downloads the newest release, starts Syncle, and

--- a/bin/syncle
+++ b/bin/syncle
@@ -12,7 +12,7 @@ set -euo pipefail
 export SYNCLE_HOME="${SYNCLE_HOME:-$HOME/.syncle}"
 COMPOSE_FILE="$SYNCLE_HOME/docker-compose.app.yml"
 ENV_FILE="$SYNCLE_HOME/.env"
-INSTALLER="https://raw.githubusercontent.com/osmanahmadxai/SYNCLE/main/install.sh"
+INSTALLER="https://syncle.dev/install"
 WEB_URL="http://localhost:${SYNCLE_PORT:-3002}"
 
 die() { printf 'syncle: %s\n' "$1" >&2; exit 1; }

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 # Syncle one-command installer.
 #
-#   curl -fsSL https://raw.githubusercontent.com/osmanahmadxai/SYNCLE/main/install.sh | sh
+#   curl -fsSL https://syncle.dev/install | sh
 #
 # Add `-s -- up` to start it right away:
 #
-#   curl -fsSL https://raw.githubusercontent.com/osmanahmadxai/SYNCLE/main/install.sh | sh -s -- up
+#   curl -fsSL https://syncle.dev/install | sh -s -- up
 #
 # Requires Docker (with Compose v2) and curl. Nothing else — Node, Postgres and
 # Redis all run in containers, and the app image is downloaded prebuilt, so


### PR DESCRIPTION
## What changed

- **README.md** — the one-command install is now `curl -fsSL https://syncle.dev/install | sh -s -- up`.
- **bin/syncle** — `INSTALLER` now points at `https://syncle.dev/install`, so `syncle update` re-runs the installer through the new domain.
- **install.sh** — only the header comments showing the recommended command were updated. `REPO_RAW`/`REPO_API` are untouched: they must keep fetching real release files from GitHub.

The "Prefer plain Docker Compose?" section in the README still downloads `docker-compose.app.yml` from raw.githubusercontent — that's a file download, not the installer entry point.

## Why old installs keep working

`https://syncle.dev/install` is a redirect to the installer script; the old `raw.githubusercontent.com/.../install.sh` URL remains valid, so existing docs, scripts, and previously installed copies of `syncle` that reference the old URL continue to work unchanged.

## Note

The `bin/syncle` change only reaches users at the next release — installed copies keep their old `INSTALLER` URL until they update, which is fine since that URL still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)