### PR TITLE
Drop decorative shadows from in-flow surfaces

### DIFF
--- a/apps/web/src/components/bridges/delivery-log.tsx
+++ b/apps/web/src/components/bridges/delivery-log.tsx
@@ -435,7 +435,7 @@ export function DeliveryMonitor({
                 className={cn(
                   'flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors',
                   view === id
-                    ? 'bg-background text-foreground shadow-sm'
+                    ? 'bg-background text-foreground'
                     : 'text-muted-foreground hover:text-foreground',
                 )}
               >
@@ -502,7 +502,7 @@ export function DeliveryMonitor({
                     className={cn(
                       'rounded px-2 py-0.5 text-[11px] font-medium transition-colors',
                       filter === f.value
-                        ? 'bg-background text-foreground shadow-sm'
+                        ? 'bg-background text-foreground'
                         : 'text-muted-foreground hover:text-foreground',
                     )}
                   >
@@ -662,8 +662,8 @@ export function DeliveryMonitor({
                       ].filter(Boolean).join(' · ')}
                       className={cn(
                         'flex h-[32px] items-center justify-center rounded border text-[10px] font-semibold tabular-nums',
-                        'transition-[transform,box-shadow] duration-100',
-                        'hover:scale-110 hover:z-10 hover:shadow-sm',
+                        'transition-transform duration-100',
+                        'hover:scale-110 hover:z-10',
                         CELL_STYLES[state],
                         openDelivery?.sequence === seq && 'ring-foreground z-10 ring-2 scale-110',
                         isSel && 'ring-primary z-10 ring-2 scale-110',

--- a/apps/web/src/components/bridges/workspace-map.tsx
+++ b/apps/web/src/components/bridges/workspace-map.tsx
@@ -55,7 +55,7 @@ type DestNodeData = { label: string; kind: 'http' | 'database' };
 
 function ConnectionNode({ data }: NodeProps<Node<ConnNodeData>>) {
   return (
-    <div className="bg-card flex min-w-[150px] items-center gap-2 rounded-md border px-3 py-2 shadow-sm">
+    <div className="bg-card flex min-w-[150px] items-center gap-2 rounded-md border px-3 py-2">
       <Database className="text-primary h-4 w-4 shrink-0" />
       <div className="min-w-0">
         <div className="truncate text-xs font-semibold">{data.label}</div>
@@ -72,7 +72,7 @@ function BridgeNode({ data }: NodeProps<Node<BridgeNodeData>>) {
   return (
     <div
       className={cn(
-        'bg-card min-w-[170px] cursor-pointer rounded-md border px-3 py-2 shadow-sm transition-shadow hover:shadow-md',
+        'bg-card min-w-[170px] cursor-pointer rounded-md border px-3 py-2',
         data.selected ? 'ring-primary ring-2' : '',
       )}
     >
@@ -102,7 +102,7 @@ function BridgeNode({ data }: NodeProps<Node<BridgeNodeData>>) {
 
 function DestinationNode({ data }: NodeProps<Node<DestNodeData>>) {
   return (
-    <div className="bg-card flex min-w-[150px] items-center gap-2 rounded-md border px-3 py-2 shadow-sm">
+    <div className="bg-card flex min-w-[150px] items-center gap-2 rounded-md border px-3 py-2">
       <Handle type="target" position={Position.Left} className="!bg-primary" />
       {data.kind === 'database' ? (
         <Database className="h-4 w-4 shrink-0 text-emerald-500" />

--- a/apps/web/src/components/diagram/er-diagram.tsx
+++ b/apps/web/src/components/diagram/er-diagram.tsx
@@ -22,7 +22,7 @@ type TableNodeData = { table: TableSchema };
 function TableNode({ data }: NodeProps<Node<TableNodeData>>) {
   const { table } = data;
   return (
-    <div className="border-border bg-card min-w-[200px] overflow-hidden rounded-md border shadow-sm">
+    <div className="border-border bg-card min-w-[200px] overflow-hidden rounded-md border">
       <Handle type="target" position={Position.Left} className="!bg-primary" />
       <div className="bg-muted/60 border-b px-3 py-1.5 text-xs font-semibold">
         {table.name}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -9,11 +9,11 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
       },
     },

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -10,13 +10,13 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      "rounded-xl border bg-card text-card-foreground",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
       className
     )}
     {...props}
@@ -19,7 +19,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-4 w-4 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
       )}
     />
   </SwitchPrimitives.Root>

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}


### PR DESCRIPTION
Cards, badges, buttons, inputs, textareas, select triggers, switches, tabs, the ER diagram nodes and the workspace map nodes all carried a shadcn default shadow. None of them float, so the shadow was doing no work beyond softening edges the border already draws.

**Kept** on the eight things that genuinely float: `dialog`, `alert-dialog`, `sheet`, `popover`, `dropdown-menu` (both content variants), `select` content, and the toaster. Without elevation there, a menu opened over a card reads as one surface rather than two.

21 shadows removed, 8 deliberately left. Class-only changes — no logic touched.

## Checks
`tsc --noEmit` clean, `vitest` 28/28 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)