### PR TITLE
chore: point questions at Discussions instead of the issue tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+# Issues are for defects and concrete feature requests. Everything else —
+# questions, "is this supposed to work like this?", setup help — belongs in
+# Discussions, where the answer stays searchable for the next person who asks.
+blank_issues_enabled: false
+contact_links:
+  - name: Question or setup help
+    url: https://github.com/osmanahmadxai/SYNCLE/discussions/categories/q-a
+    about: Ask how something works, or read the answers other people have already had.
+  - name: Documentation
+    url: https://syncle.dev/docs
+    about: Installation, bridges, CDC prerequisites, configuration and the HTTP API.
+  - name: Share what you built
+    url: https://github.com/osmanahmadxai/SYNCLE/discussions/categories/show-and-tell
+    about: Tell us which engines you are bridging, and what you pointed Syncle at.
+  - name: Report a security problem
+    url: https://syncle.dev/docs/self-hosting#reporting
+    about: Security issues go by email, never into a public issue.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ when you need them.
 <br>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Discussions](https://img.shields.io/badge/Discussions-ask%20a%20question-5865F2?logo=github&logoColor=white)](https://github.com/osmanahmadxai/SYNCLE/discussions)
 ![Node](https://img.shields.io/badge/Node-%E2%89%A5%2022-339933?logo=node.js&logoColor=white)
 ![pnpm](https://img.shields.io/badge/pnpm-10-F69220?logo=pnpm&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)
@@ -443,6 +444,23 @@ React Flow · Zod · Vitest.
   further, complete first-run setup before the port is reachable, put it behind
   TLS, and restrict which destinations (database connections / endpoint URLs)
   a bridge may write to.
+
+## Questions, ideas and contributions
+
+- **Questions and setup help** belong in
+  [Discussions](https://github.com/osmanahmadxai/SYNCLE/discussions/categories/q-a),
+  not the issue tracker — an answer there stays searchable for whoever asks next.
+- **Ideas** for where Syncle should go next are welcome in
+  [Ideas](https://github.com/osmanahmadxai/SYNCLE/discussions/categories/ideas),
+  and what you pointed it at belongs in
+  [Show and tell](https://github.com/osmanahmadxai/SYNCLE/discussions/categories/show-and-tell).
+- **Bugs** go in the [issue tracker](https://github.com/osmanahmadxai/SYNCLE/issues) —
+  including places where the documentation and the software disagree, which
+  counts as a bug here.
+- **Code** is welcome too: [CONTRIBUTING.md](CONTRIBUTING.md) covers the whole
+  setup, which is three commands once you have Node 22, pnpm 10 and Docker.
+- **Security problems** go by email rather than into a public issue. The
+  [self-hosting page](https://syncle.dev/docs/self-hosting#reporting) explains how.
 
 ## License
 


### PR DESCRIPTION
Discussions is now open on this repo, with Q&A, Ideas, Show and tell and Announcements. Three seed threads are already posted (#47, #48, #49), because nobody posts first into an empty forum.

This adds the plumbing that keeps questions out of the issue tracker:

- `.github/ISSUE_TEMPLATE/config.yml` puts Q&A, the docs and the security address on the New Issue page, and turns off blank issues so a question cannot arrive as an untriaged bug report.
- README gets a Discussions badge and a short section saying which of the four places — Discussions, issues, CONTRIBUTING, the security email — takes what.

The reasoning: an answer in Discussions is indexed and searchable, so it deflects the same question forever. An answer buried in a closed issue is found by nobody.