### PR TITLE
fix(web): theme the React Flow controls for dark mode

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -81,3 +81,39 @@
     background: transparent;
   }
 }
+
+@layer components {
+  /*
+   * React Flow ships its controls with a hard-coded white background, so on
+   * the workspace map and the ER diagram they render as a white block against
+   * the dark canvas. Theme them from the app's own tokens instead.
+   */
+  .react-flow__controls {
+    box-shadow: none;
+  }
+
+  .react-flow__controls-button {
+    background-color: hsl(var(--card));
+    border-bottom: 1px solid hsl(var(--border));
+    color: hsl(var(--foreground));
+  }
+
+  .react-flow__controls-button:first-child {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+  }
+
+  .react-flow__controls-button:last-child {
+    border-bottom: 0;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+  }
+
+  .react-flow__controls-button:hover {
+    background-color: hsl(var(--accent));
+  }
+
+  .react-flow__controls-button svg {
+    fill: currentColor;
+  }
+}


### PR DESCRIPTION
The workspace map and the ER diagram both render React Flow's `<Controls />`, which ships with a hard-coded white background.

In dark mode this shows as a white block in the bottom-left of the canvas. Worse than ugly: the computed styles are `background-color: rgb(254, 254, 254)` with `color: rgb(250, 250, 250)`, so the zoom-in, zoom-out, fit-view and lock buttons are white on white — invisible, not just mis-themed.

This styles them from the app's existing tokens (`--card`, `--border`, `--foreground`, `--accent`) so they read correctly in both themes, and rounds the ends of the button stack.

Found while capturing product screenshots — it appears in every shot of the map and the diagram.