### PR TITLE
docs: actually show the product media

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ when you need them.
 
 <br>
 
-<img src="docs/assets/syncle-bridge-animation.svg" width="100%" alt="Animated: rows flowing live from a PostgreSQL source across a Syncle bridge into MongoDB, Redis and MySQL — insert, update and delete operations riding the lanes">
+<img src="docs/assets/media/syncle-live-sync.gif" width="100%" alt="A CDC bridge running in Syncle: rows inserted into PostgreSQL arrive in MongoDB while the delivered counter climbs, each row listed with the time it took">
+
+<sub>A real bridge, running. Rows are inserted into Postgres from outside the browser while the page is open — the counter is the bridge doing the work. <a href="docs/assets/media/syncle-demo.mp4">Full 46-second run</a> · <a href="docs/assets/media">more screenshots</a></sub>
 
 </div>
 
@@ -113,6 +115,14 @@ The rest is the same whichever destination and trigger you pick:
 - **Stay in control.** Jobs survive restarts, resume where they stopped, and can
   be cancelled. Skip rows by range or selection, or retry only the failed ones in
   place — failed cells flip green.
+
+<img src="docs/assets/media/screenshots/01-bridge-live-cdc.png" width="100%" alt="A live CDC bridge in Syncle: running since 6:31pm, 2,580 delivered, 0 failed, 0 skipped, 100% success, and a table of the customer rows that crossed it with the time each took">
+
+<sub>A CDC bridge mid-flight, and every row that crossed it — what was written, when, and how long it took.</sub>
+
+<img src="docs/assets/media/screenshots/03-bridge-backfill.png" width="100%" alt="A completed replay job in Syncle: 5,690 rows total, 6,050 delivered, 0 failed, 100% success, listing each customer row with its delivery time">
+
+<sub>A finished backfill. Deliveries can exceed the total because rows kept changing at the source while the replay ran — the upserts are idempotent, so they land once.</sub>
 
 ---
 
@@ -300,6 +310,12 @@ for shaping a source and for inspecting what landed in a destination:
 
 Every table view has a one-click "Create bridge" that drops you into the builder
 pre-seeded with that table as the source.
+
+<img src="docs/assets/media/screenshots/06-workbench-data.png" width="100%" alt="The Syncle workbench browsing a customers table: connection list, schema tree with row counts, and a paginated grid of 5,060 rows">
+
+<img src="docs/assets/media/screenshots/09-workbench-diagram.png" width="100%" alt="The interactive ER diagram in Syncle showing customers, orders, order_items and products with their columns, types and foreign-key relationships">
+
+<sub>Browsing a source table, and the same database as an ER diagram. <a href="docs/assets/media">The query editor and structure views are here too.</a></sub>
 
 ---
 

--- a/docs/assets/media/README.md
+++ b/docs/assets/media/README.md
@@ -12,45 +12,96 @@ screen is a real delivery count from that run.
 Nothing here is anyone's data. Names are assembled from common name parts and
 every address is on `example.com`, the reserved domain.
 
-Images are 1600px wide — twice the width they are usually displayed at, so
-they stay sharp on high-density screens without carrying 3200px files in git.
+Images are 1600px wide — twice the width they are usually displayed at, so they
+stay sharp on high-density screens without carrying 3200px files in git.
 
-## Stills
-
-| File | What it shows | Where it earns its place |
-| --- | --- | --- |
-| `01-bridge-live-cdc.png` | A CDC bridge running at 100% success, and the rows that crossed it | **The hero.** README, above the fold |
-| `02-bridge-feed.png` | The same deliveries as a newest-first stream | Alternate hero; docs |
-| `03-bridge-backfill.png` | A completed replay — 5,690 rows, zero failures, per-row timings | README, on delivery guarantees |
-| `04-workspace-map.png` | One source fanning out to four bridges and four destinations | **Website.** Explains the product in one image |
-| `05-bridge-builder.png` | Column selection, live preview, trigger config, sample payload | Website, "build it visually"; docs/bridges |
-| `06-workbench-data.png` | Browsing 5,060 rows with the schema tree beside them | Website, workbench section |
-| `07-workbench-structure.png` | Column types, defaults, keys and indexes | docs/workbench |
-| `08-workbench-query.png` | The SQL editor with a real result set, 11 ms | Website, workbench section |
-| `09-workbench-diagram.png` | The ER diagram with foreign keys drawn | Website, workbench section |
+---
 
 ## Motion
 
-| File | Length | Use |
-| --- | --- | --- |
-| `syncle-demo.mp4` | 46 s · 1600×1000 · 2.8 MB | The full run: the workspace map, opening a live CDC bridge, rows inserted into Postgres arriving while you watch, the feed, then those same rows sitting in MongoDB. For the website, a Show HN post, or social. |
-| `syncle-live-sync.gif` | 12 s · 900px · 2.2 MB | The moment that matters, on a loop: the delivered counter climbing as rows land. For the README, where a GIF plays and an MP4 does not. |
+**`syncle-live-sync.gif`** — 12 s · 900px · 2.2 MB. The moment that matters, on
+a loop: the delivered counter climbing as rows land. Used at the top of the
+project README, where a GIF plays and an MP4 does not.
 
-The inserts in the video are fired from outside the browser while the page is
-open, so the counter moving on screen is the bridge actually working. There are
-no cuts and nothing is sped up.
+<img src="syncle-live-sync.gif" width="100%" alt="A CDC bridge in Syncle delivering rows as they are inserted into Postgres">
 
-## One caveat
+**`syncle-demo.mp4`** — 46 s · 1600×1000 · 2.8 MB. [The full run](syncle-demo.mp4):
+the workspace map, opening a live CDC bridge, rows inserted into Postgres
+arriving while you watch, the feed, then those same rows sitting in MongoDB.
+For the website, a Show HN post, or social. The inserts are fired from outside
+the browser while the page is open, so the counter moving on screen is the
+bridge actually working — no cuts, nothing sped up.
 
-The map and diagram shots include the fix from #51 (React Flow's controls
-render as a white block with invisible icons in dark mode). The published 1.2.0
-image still has that bug, so those two images match the app **once #51 merges**.
-Everything else is stock 1.2.0.
+---
+
+## Stills
+
+### `01-bridge-live-cdc.png` — a live CDC bridge
+
+The hero. Running, 100% success, and the rows that crossed it. **In the README.**
+
+<img src="screenshots/01-bridge-live-cdc.png" width="100%" alt="A live CDC bridge with 2,580 delivered and the rows that crossed it">
+
+### `02-bridge-feed.png` — the same deliveries as a stream
+
+Newest first, one line per row. An alternate hero, and good for the docs.
+
+<img src="screenshots/02-bridge-feed.png" width="100%" alt="The delivery feed, newest first">
+
+### `03-bridge-backfill.png` — a completed replay
+
+5,690 rows, zero failures, per-row timings. **In the README**, next to the
+delivery guarantees.
+
+<img src="screenshots/03-bridge-backfill.png" width="100%" alt="A completed replay job with 5,690 rows and no failures">
+
+### `04-workspace-map.png` — the whole product in one image
+
+One source fanning out to four bridges and four destinations. The best single
+image for the website.
+
+<img src="screenshots/04-workspace-map.png" width="100%" alt="The workspace map: one Postgres source feeding four bridges into MySQL, MongoDB and Redis">
+
+### `05-bridge-builder.png` — building a bridge
+
+Column selection, a live preview of the source rows, trigger configuration, the
+inferred schema and a sample payload. For the website's "build it visually"
+section and `docs/bridges`.
+
+<img src="screenshots/05-bridge-builder.png" width="100%" alt="The bridge builder: column checkboxes, row preview, polling configuration and sample payload">
+
+### `06-workbench-data.png` — browsing a table
+
+5,060 rows with the schema tree beside them. **In the README**, in the workbench
+section.
+
+<img src="screenshots/06-workbench-data.png" width="100%" alt="The workbench browsing a customers table with the schema tree">
+
+### `07-workbench-structure.png` — columns, keys and indexes
+
+For `docs/workbench`.
+
+<img src="screenshots/07-workbench-structure.png" width="100%" alt="The structure view: column types, defaults, primary key and indexes">
+
+### `08-workbench-query.png` — the SQL editor
+
+A real result set in 11 ms. For the website's workbench section.
+
+<img src="screenshots/08-workbench-query.png" width="100%" alt="The query editor running a grouped aggregate over the customers table">
+
+### `09-workbench-diagram.png` — the ER diagram
+
+Foreign keys drawn between the four tables. **In the README**, and good for the
+website.
+
+<img src="screenshots/09-workbench-diagram.png" width="100%" alt="The interactive ER diagram with foreign keys drawn">
+
+---
 
 ## Re-shooting after a UI change
 
 The capture is scripted — a compose file for the four databases and a separate
 Syncle instance, a seed SQL file, and Playwright scripts that drive the real UI
-and wait on real text before each frame. They live outside this repo today; say
-the word and they can land under `scripts/demo/` so this is one command to
-repeat.
+and wait on real text before each frame, so a slow render cannot produce an
+empty screenshot. They live outside this repo today; say the word and they can
+land under `scripts/demo/` so re-shooting is one command.


### PR DESCRIPTION
#52 added the screenshots and the video, but nothing displayed them. The project README never referenced the files, and the manifest sitting beside them was a table of filenames rather than the pictures — so opening either one showed prose *about* screenshots instead of screenshots. This wires them in.

**In the project README:**

- The live-sync GIF replaces the abstract bridge animation at the top, so the first thing a visitor sees is the real app moving rows between databases, with a link to the full 46-second run.
- The live CDC bridge and the completed backfill sit directly under the delivery guarantees they evidence — "no duplicates", "watch it happen" and "jobs resume" now have a picture of exactly that next to them.
- The workbench grid and the ER diagram sit in the "Source data, when you need it" section.

Four images and one GIF in total, each with real alt text describing what is on screen.

**In `docs/assets/media/README.md`:** every still and the GIF now render inline, each with a line on what it shows and where it belongs, instead of a filename table.

The bridge-animation SVG stays in the repo — it is just no longer the header image. The first thing on the page should be the product working rather than a diagram of it; if you would rather keep it up top, that is a one-line revert and both can coexist.

Every path was checked to resolve to a real file before pushing.
