### PR TITLE
Make the changelog match the tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,89 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-08-20
+## [1.2.0] - 2026-08-21
 
-First stable release: visual bridges between any supported engines
-(PostgreSQL, MySQL/MariaDB, SQLite, MongoDB, Redis) and HTTP endpoints, fired
-by one-shot replay, cursor polling, or change-data-capture — with idempotent
-multi-target delivery, a live timeline, and the database workbench.
+Setup no longer sends you to the container logs.
+
+### Changed
+
+- `syncle up` reads the first-run setup token off the server and opens the GUI
+  with it already accepted, so creating the admin account is a username and a
+  password rather than a hunt through `syncle logs api`. The token is mirrored
+  to a `0600` file in the API's data directory, so reading it still requires
+  container access on that host — which is exactly what the token attests.
+  Anyone reaching the instance over the network still faces an empty token
+  field. The token travels in the URL *fragment*, which browsers never send
+  upstream, is stripped from the address bar on read, is deleted the moment
+  setup succeeds, and is cleared at boot if an account already exists.
+
+### Fixed
+
+- `syncle up` works offline. A failed image pull aborted the whole start, so a
+  machine with the images already cached could not run Syncle at all. The pull
+  is now best-effort, and a genuinely missing image fails at `up` with a
+  clearer message.
+- The installer resolves the right image tag. It used the release tag verbatim
+  (`v1.2.0`) where images publish without the prefix (`1.2.0`), so a fresh
+  install died with `failed to resolve reference … not found`.
+
+## [1.1.0] - 2026-08-21
+
+One command to install, SSH tunnels, and hooks renamed to bridges.
 
 ### Added
 
-- Database-to-database bridges: sync data across engines directly, with HTTP
+- One-command Docker install (`install.sh`) and the `syncle` launcher CLI —
+  `up`, `down`, `logs`, `update`, `uninstall`. The app image is pulled prebuilt
+  from GHCR, so nothing is compiled locally and the repository is never cloned.
+- **SSH tunnels**, for databases that only listen on a private network and have
+  to be reached through a bastion host.
+- Chinese (zh) localization for the web app, via `next-intl`. Thanks to
+  @250shiwo.
+- Delivered rows can be read as a table with columns derived from the payloads,
+  or as a newest-first feed. The original cell grid remains as **Map**, where
+  queued sequences can be skipped.
+- A **setup token** guarding first-run account creation, so an exposed instance
+  cannot be claimed by whoever reaches it first.
+- Rate limiting on login and setup attempts, and an SSRF guard on outbound HTTP
+  destinations.
+
+### Changed
+
+- **Breaking.** A *hook* is now a **bridge** and a *run* is now a **job**,
+  throughout. `/api/hooks` is now `/api/bridges`; anything scripting against
+  the API needs updating. The web UI is unaffected and the database migrates
+  itself on upgrade.
+- The bridge builder was split into sections backed by a single draft reducer.
+
+### Fixed
+
+- **CDC** — closed data-loss and ordering gaps in event-based bridges.
+- **Watch triggers** — ordering, a livelock, lookback handling, filters and
+  cancellation; the lookback dedupe now stays stable across truncated pages.
+- **Delivery retries and database sinks** — integrity fixes so a retry or a
+  write cannot double-apply or drop rows.
+- **Lifecycle and resume** — one lifecycle owner, dialect hooks, abort signals
+  actually honoured, and exact keyset resume.
+- Master key and signing key hygiene.
+
+## [1.0.0] - 2026-07-23
+
+First stable release: visual hooks between any supported engines (PostgreSQL,
+MySQL/MariaDB, SQLite, MongoDB, Redis) and HTTP endpoints, fired by one-shot
+replay, cursor polling, or change-data-capture — with idempotent multi-target
+delivery, a live timeline, and the database workbench.
+
+### Added
+
+- Database-to-database sync: rows move across engines directly, with HTTP
   endpoints as an extra destination rather than the only one.
-- Workspaces, with hooks reframed as bridges and a live workspace map.
+- Workspaces, and a live workspace map.
 - Event-based (CDC) delivery for **MySQL** (binlog), **MongoDB** (change
   streams), and **Redis** (keyspace notifications), alongside the existing
   PostgreSQL logical-replication support. Each engine sits behind a shared
   `CdcProvider` interface.
 - A login system and a settings section.
-- One-command Docker install (`install.sh`) and the `syncle` launcher CLI.
-- Chinese (zh) localization for the web app.
 - The `{{$op}}` payload token, exposing the change operation
   (`insert` / `update` / `delete`) for CDC and watch hooks.
 - README visuals: animated banner, badges, diagrams, and a how-to guide.
@@ -38,9 +102,9 @@ multi-target delivery, a live timeline, and the database workbench.
 
 ### Fixed
 
-- Crash, data-loss, and injection paths across the API layer, bridge engine,
-  and core adapters; multi-target bridge writes are atomic and backup memory
-  is bounded.
+- Crash, data-loss, and injection paths across the API layer, the sync engine,
+  and core adapters; multi-target writes are atomic and backup memory is
+  bounded.
 - Stale-state bugs in the studio, which now updates instantly.
 - Delivery timeline now uses the run's snapshot `batchSize`, keeping cells
   aligned even after a hook is edited mid-run.


### PR DESCRIPTION
The changelog had drifted from what was actually released.

## What was wrong

| | Changelog said | Reality |
|---|---|---|
| 1.0.0 date | `2026-08-20` | tag and release both say **2026-07-23** |
| 1.1.0 | *no entry* | released 2026-08-21, 39 commits |
| 1.2.0 | *no entry* | released 2026-08-21, 4 commits |
| hooks → bridges rename | credited to 1.0.0 | shipped in **1.1.0** |
| `install.sh` + `syncle` CLI | credited to 1.0.0 | shipped in **1.1.0** |
| Chinese (zh) localization | credited to 1.0.0 | shipped in **1.1.0** |

## How the attribution was checked

Against the trees at each tag, not from memory:

```
v1.0.0   bridges=0  hooks=19  install.sh=0  ssh=0  zh=0
v1.1.0   bridges=26 hooks=0   install.sh=1  ssh=2  zh=1
v1.2.0   bridges=26 hooks=0   install.sh=1  ssh=2  zh=1
```

So v1.0.0 is the hooks-era release, and the rename, the installer, the SSH tunnel and the localization all belong to 1.1.0. The 1.0.0 entry keeps what it genuinely shipped — multi-engine CDC, workspaces, auth and settings, the `{{$op}}` token, the Postgres metadata store — with its wording moved back to *hooks*, which is what that version called them.

1.1.0 and 1.2.0 are written from their release notes, with the `/api/hooks` → `/api/bridges` break flagged as **Breaking**.

Content only — no code changes.