### PR TITLE
Say the things the product already does

### DIFF
--- a/website/app/docs/troubleshooting/page.tsx
+++ b/website/app/docs/troubleshooting/page.tsx
@@ -1,0 +1,172 @@
+import { CodeBlock } from '@/components/docs/code-block';
+import { DocArticle, docMetadata } from '@/components/docs/doc-article';
+import { Note } from '@/components/docs/note';
+
+export const metadata = docMetadata('troubleshooting');
+
+export default function Page() {
+  return (
+    <DocArticle slug="troubleshooting">
+      <p>
+        The failures people actually hit, and what each one means. Most of them
+        are a database setting rather than a bug in Syncle — CDC in particular
+        needs the source server configured for it, and no tool can turn that on
+        from the outside.
+      </p>
+
+      <h2 id="syncle-up-does-nothing">syncle up exits without starting</h2>
+      <p>
+        Two known causes. If the message mentions resolving a reference, you are
+        on an install older than 1.2.0, where the installer asked for the image
+        by its release tag (<code>v1.2.0</code>) while images publish without
+        the prefix (<code>1.2.0</code>). Reinstalling picks up the fixed script.
+      </p>
+      <p>
+        If the machine is offline, upgrade to 1.2.0 or later. Before it, a
+        failed image pull aborted the whole start, so a host with the images
+        already cached could not run Syncle at all; the pull is now best-effort.
+      </p>
+      <p>
+        Otherwise it is usually the port. Syncle publishes one, 3002, and
+        refuses to start if something already holds it:
+      </p>
+      <CodeBlock>{`lsof -i :3002`}</CodeBlock>
+
+      <h2 id="lost-the-setup-token">The setup form wants a token</h2>
+      <p>
+        <code>syncle up</code> normally reads the first-run token off the server
+        and opens the interface with it already accepted. Opening Syncle from a
+        different device skips that, because the token is only readable by
+        something with access to the container. Print it and paste it in:
+      </p>
+      <CodeBlock>{`syncle logs api`}</CodeBlock>
+      <p>
+        If the account already exists, there is no token to find — the API
+        deletes it the moment setup succeeds, and clears it at boot when an
+        account is present. Use the login form instead.
+      </p>
+
+      <h2 id="cdc-never-fires">A CDC bridge never delivers anything</h2>
+      <p>
+        Almost always the source server is not configured for change data
+        capture. The builder checks this before it lets you save, and names the
+        setting that is missing — if you skipped past that, re-open the bridge
+        and look at the trigger step. What each engine needs:
+      </p>
+
+      <h3 id="cdc-postgres">PostgreSQL</h3>
+      <p>
+        <code>wal_level=logical</code>, set in <code>postgresql.conf</code> or
+        your provider&apos;s parameter group, followed by a server restart. This
+        is the one prerequisite that cannot be automated, because it needs the
+        restart.
+      </p>
+
+      <h3 id="cdc-mysql">MySQL and MariaDB</h3>
+      <p>
+        Row-based binary logging, in <code>my.cnf</code>:{' '}
+        <code>log_bin=ON</code>, <code>binlog_format=ROW</code>,{' '}
+        <code>binlog_row_image=FULL</code>, and a unique{' '}
+        <code>server_id</code>. It needs a server restart. On managed MySQL —
+        RDS, Aurora, Cloud SQL — set these in the parameter group and reboot.
+      </p>
+
+      <h3 id="cdc-mongodb">MongoDB</h3>
+      <p>
+        Change streams require a replica set. A single-node replica set is fine
+        for development: start <code>mongod</code> with{' '}
+        <code>--replSet rs0</code> and run <code>rs.initiate()</code> once.
+        Atlas already satisfies this.
+      </p>
+
+      <h3 id="cdc-redis">Redis</h3>
+      <p>
+        Keyspace notifications, which Syncle tries to enable itself on start:
+      </p>
+      <CodeBlock>{`CONFIG SET notify-keyspace-events EA`}</CodeBlock>
+      <p>
+        Managed Redis usually refuses that and wants it enabled in the provider
+        console instead. It can also be set permanently in{' '}
+        <code>redis.conf</code>.
+      </p>
+
+      <Note>
+        Redis keyspace notifications are fire-and-forget. If Syncle is not
+        running at the moment a key changes, that event is gone — it is not
+        replayed on reconnect. A Redis CDC bridge is therefore not a
+        completeness guarantee, and a periodic replay job is the way to close
+        the gap. See <a href="/docs/cdc">CDC setup</a>.
+      </Note>
+
+      <h2 id="watch-delivers-nothing">A watch bridge delivers nothing</h2>
+      <p>
+        A new watch bridge starts from <strong>now</strong> by default, so it
+        ignores everything already in the table and only delivers rows that
+        appear after it started. If you wanted the existing rows too, either set
+        it to start from the beginning, or run a replay job once to backfill and
+        leave the watch running for what follows.
+      </p>
+      <p>
+        If it delivers nothing even for new rows, check the cursor matches the
+        table. A timestamp cursor on a column the application does not update
+        will never advance; a table whose primary keys are UUIDs needs the
+        primary-key diff strategy rather than an incrementing id. A cursor
+        column holding future timestamps parks the bridge until real time
+        catches up.
+      </p>
+
+      <h2 id="deletes-missing">Deletes are not crossing the bridge</h2>
+      <p>
+        Expected on a watch bridge. Watch polls for rows that exist, so it sees
+        inserts, and updates when the cursor is a timestamp, but a deleted row
+        is simply absent from the next poll and indistinguishable from one that
+        was never there. Deletes need a CDC trigger, which reads them from the
+        change log.
+      </p>
+
+      <h2 id="cannot-connect">A connection will not test</h2>
+      <p>
+        An error beginning <code>SSH:</code> comes from the tunnel, not the
+        database — the jump host refused the key, the user, or the forward.
+        Check the SSH credentials on their own before looking at the database.
+      </p>
+      <p>
+        Without a tunnel, the usual causes are the database not listening on an
+        interface Syncle can reach, or TLS. Syncle connects out to your
+        database, so the database has to accept a connection from the Docker
+        host. On the same machine, that is generally{' '}
+        <code>host.docker.internal</code> rather than{' '}
+        <code>localhost</code>, which inside a container means the container.
+      </p>
+
+      <h2 id="deliveries-failing">Rows are failing rather than syncing</h2>
+      <p>
+        Click a failed delivery on the timeline: it shows the row that was sent
+        and the error that came back. Failed rows can be retried in place
+        without rerunning the whole job.
+      </p>
+      <p>
+        A bridge that fails everything usually has a destination mismatch — key
+        columns that are not unique in the target, or a type the target will not
+        accept. A bridge that fails intermittently against an HTTP endpoint is
+        usually being rate limited; raise the minimum delay between requests, or
+        lower the batch size, in the bridge&apos;s delivery settings.
+      </p>
+
+      <h2 id="still-stuck">Still stuck</h2>
+      <p>
+        <code>syncle logs api</code> carries the server side of anything the
+        interface could not explain. If it looks like a bug, open an issue with
+        the engine, the trigger type, and that log; if you are unsure whether it
+        is a bug,{' '}
+        <a
+          href="https://github.com/osmanahmadxai/SYNCLE/discussions"
+          rel="noopener"
+        >
+          Discussions
+        </a>{' '}
+        is the better place to start.
+      </p>
+    </DocArticle>
+  );
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { CopyCommand } from '@/components/copy-command';
 import { CodeBlock } from '@/components/docs/code-block';
+import { formatReleaseDate, latestRelease } from '@/lib/release';
 import { InstallTranscript } from '@/components/install-transcript';
 import { SiteFooter } from '@/components/site-footer';
 import { SiteHeader } from '@/components/site-header';
@@ -92,6 +93,8 @@ function Section({
 }
 
 export default function Home() {
+  const release = latestRelease();
+
   return (
     <>
       <SiteHeader />
@@ -182,7 +185,10 @@ export default function Home() {
             A bridge is a saved sync path: a source table or query, the columns
             and mapping, the destinations, and a trigger. The trigger is how it
             notices that something changed — there are three, and you pick per
-            bridge. The rest of the pipeline is identical.
+            bridge. The rest of the pipeline is identical. The destination table
+            does not have to exist first: unless you turn it off, Syncle creates
+            it from the source schema on the first write, with the types
+            translated for whichever engine is receiving them.
           </p>
           <div className="mt-5 space-y-4">
             {TRIGGERS.map((t) => (
@@ -196,6 +202,15 @@ export default function Home() {
             alt="The Syncle bridge builder: source table with selectable columns, a live preview of real rows, trigger configuration, the inferred schema and a sample payload"
             caption="Picking the trigger in the builder, with a live preview of what will be sent."
           />
+
+          <p className="mt-5">
+            Choosing CDC checks the source before it lets you continue: whether
+            logical replication is on for Postgres, the binlog is set to row
+            format for MySQL, the Mongo deployment is a replica set, or Redis
+            has keyspace notifications enabled — and when something is missing,
+            it says which setting and what to change it to. You find out at the
+            builder rather than from a bridge that silently never fires.
+          </p>
 
           <p className="mt-5 text-[15px] text-muted-foreground">
             The honest edges: SQLite has no change log, so it syncs by watch
@@ -426,9 +441,18 @@ export default function Home() {
         <Section title="Under the hood">
           <p className="mt-4">
             The first stable release, 1.0.0, shipped on 23 July 2026, after
-            the project grew up under its working name, Data Bridge; there have
-            been releases since — the link below always points at the current
-            one. It is TypeScript throughout: a NestJS API and a Next.js
+            the project grew up under its working name, Data Bridge.{' '}
+            {/* the sentence already names 1.0.0; only add the clause once
+                the changelog has something newer to report */}
+            {release && release.version !== '1.0.0' ? (
+              <>
+                The current release is {release.version}, from{' '}
+                {formatReleaseDate(release.date)}.
+              </>
+            ) : (
+              <>The link below always points at the current release.</>
+            )}{' '}
+            It is TypeScript throughout: a NestJS API and a Next.js
             interface, running as four containers behind one published port,
             keeping their own state in a bundled PostgreSQL and Redis. The
             interface speaks English and Chinese, and the whole thing is MIT

--- a/website/lib/content.ts
+++ b/website/lib/content.ts
@@ -29,7 +29,7 @@ export const FAQ: { q: string; a: string }[] = [
   },
   {
     q: 'Does it sync in real time, or on a schedule?',
-    a: 'You choose per bridge. CDC reads the database change log directly — Postgres logical replication, MySQL binlog, MongoDB change streams, Redis keyspace notifications — so changes arrive without polling. Watch polls a cursor instead, which works on every engine, including SQLite, which has no change log to read. Replay is a one-shot pass for the initial backfill.',
+    a: 'You choose per bridge. CDC reads the database change log directly — Postgres logical replication, MySQL binlog, MongoDB change streams, Redis keyspace notifications — so changes arrive without polling. Watch polls a cursor instead, which works on every engine, including SQLite, which has no change log to read. The cursor can be an auto-increment id, a timestamp column, or a diff of the primary keys — so a table with no updated_at column can still be watched. Replay is a one-shot pass for the initial backfill.',
   },
   {
     q: 'Can it duplicate or lose rows?',

--- a/website/lib/docs.ts
+++ b/website/lib/docs.ts
@@ -60,6 +60,12 @@ export const DOC_PAGES: DocPage[] = [
       'The REST API under /api: authentication, response envelopes, and every endpoint for connections, bridges and jobs.',
   },
   {
+    slug: 'troubleshooting',
+    title: 'Troubleshooting',
+    description:
+      'The failures people actually hit: CDC that never fires, watch bridges that deliver nothing, connections that will not test, and rows that fail.',
+  },
+  {
     slug: 'self-hosting',
     title: 'Self-hosting & security',
     description:

--- a/website/lib/release.ts
+++ b/website/lib/release.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The newest shipped version, read out of the repository's CHANGELOG at build
+ * time. The site lives in the same repo as the code it describes, so this can
+ * be a fact rather than a number someone has to remember to update — which is
+ * exactly how the changelog itself fell two releases behind.
+ *
+ * Server-side only: this runs during `next build`, never in the browser.
+ */
+export interface Release {
+  version: string;
+  /** the date as written in the changelog, ISO */
+  date: string;
+}
+
+/** `## [1.2.0] - 2026-08-21`, first match wins — the changelog is newest-first */
+const ENTRY = /^##\s*\[(\d+\.\d+\.\d+)\]\s*-\s*(\d{4}-\d{2}-\d{2})\s*$/m;
+
+export function latestRelease(): Release | null {
+  try {
+    const text = readFileSync(join(process.cwd(), '..', 'CHANGELOG.md'), 'utf8');
+    const m = ENTRY.exec(text);
+    return m ? { version: m[1], date: m[2] } : null;
+  } catch {
+    // building the site outside the monorepo: fall back to saying nothing
+    return null;
+  }
+}
+
+/** `2026-08-21` → `21 August 2026`, to match how the page writes dates */
+export function formatReleaseDate(iso: string): string {
+  return new Date(`${iso}T00:00:00Z`).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}


### PR DESCRIPTION
Three capabilities are implemented, documented under `/docs`, and absent from the homepage — the page that has to sell them.

## The claims

| Capability | Where it lives | Homepage said |
|---|---|---|
| The destination table is created from the source schema on first write | `createMissingTable`, on by default | nothing — the demo video shows it, the copy never claimed it |
| Choosing CDC pre-flights the source server and names what is misconfigured | `POST /bridges/cdc/readiness`, drives the builder panel | nothing |
| A watch cursor can be a primary-key diff | `watchStrategySchema` | the FAQ said "polls a cursor", which reads as though an `updated_at` column is required |

The homepage body copy was already correct about the third — it names all three strategies. Only the FAQ answer was vague, so only that changed.

## Troubleshooting page

New at `/docs/troubleshooting`, written from the providers rather than from imagination. The remediation text is what the readiness checks actually return:

- `wal_level=logical` and a restart (PostgreSQL)
- `log_bin=ON`, `binlog_format=ROW`, `binlog_row_image=FULL`, unique `server_id` (MySQL)
- replica set, `--replSet rs0` + `rs.initiate()` for local dev (MongoDB)
- `CONFIG SET notify-keyspace-events EA` (Redis)

Plus the failures that are behaviour rather than bugs: a watch bridge starting from `now` and so ignoring existing rows, deletes not crossing a watch bridge, and the `SSH:` error prefix meaning the tunnel rather than the database.

## Release version

`lib/release.ts` reads the newest version out of `CHANGELOG.md` at build time, replacing the hedge *"there have been releases since — the link below always points at the current one"*. Now that the site is in the same repository as the code, that can be a fact rather than a number someone has to remember to update.

**Ordering:** this reads whatever `CHANGELOG.md` currently says, so it is worth merging #58 first. It is safe either way — while the newest entry is still 1.0.0, which the sentence already names, the clause is suppressed and the old wording shows instead.

## Verification

`npm run build` and `npm run typecheck` pass; `/docs/troubleshooting` prerenders. (`npm run lint` has never been configured in this project and still prompts — untouched here.)