### PR TITLE
feat(web): derive the UI languages from the message files

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 import { Providers } from '@/components/providers';
+import { LocaleListProvider } from '@/i18n/locale-list';
+import { locales } from '@/i18n/locales';
 import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
 
@@ -22,8 +24,10 @@ export default async function RootLayout({
     <html lang={locale} suppressHydrationWarning>
       <body className="bg-background text-foreground h-screen overflow-hidden antialiased">
         <NextIntlClientProvider messages={messages}>
-          <Providers>{children}</Providers>
-          <Toaster position="bottom-right" richColors />
+          <LocaleListProvider locales={locales}>
+            <Providers>{children}</Providers>
+            <Toaster position="bottom-right" richColors />
+          </LocaleListProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/apps/web/src/components/lang-toggle.tsx
+++ b/apps/web/src/components/lang-toggle.tsx
@@ -3,22 +3,41 @@
 import { useLocale, useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { useLocaleList } from '@/i18n/locale-list';
+
+/** what a language calls itself — "中文", "italiano" — falling back to the code */
+function endonym(locale: string): string {
+  try {
+    return (
+      new Intl.DisplayNames([locale], { type: 'language' }).of(locale) ?? locale
+    );
+  } catch {
+    return locale;
+  }
+}
 
 /**
- * Flips the UI language by writing the `NEXT_LOCALE` cookie that
- * src/i18n/request.ts reads on the server, then refreshing server components
- * so the new messages load. The label shows the CURRENT language.
+ * Cycles the UI language by writing the `NEXT_LOCALE` cookie that
+ * src/i18n/request.ts reads on the server, then refreshing server components so
+ * the new messages load. The languages on offer come from the message files
+ * themselves, so adding one needs no change here. The label shows the CURRENT
+ * language; the tooltip names the one a click switches to.
  */
 export function LangToggle() {
   const locale = useLocale();
+  const locales = useLocaleList();
   const t = useTranslations('lang');
   const router = useRouter();
-  const next = locale === 'zh' ? 'en' : 'zh';
+
+  const next = locales[(locales.indexOf(locale) + 1) % locales.length] ?? locale;
 
   function switchLocale() {
     document.cookie = `NEXT_LOCALE=${next};path=/;max-age=31536000;samesite=lax`;
     router.refresh();
   }
+
+  // one language shipped means nothing to switch to
+  if (locales.length < 2) return null;
 
   return (
     <Button
@@ -26,10 +45,10 @@ export function LangToggle() {
       size="icon"
       className="h-8 w-8"
       aria-label={t('ariaLabel')}
-      title={t('ariaLabel')}
+      title={`${t('ariaLabel')} — ${endonym(next)}`}
       onClick={switchLocale}
     >
-      <span className="text-xs font-medium">{locale === 'zh' ? '中' : 'EN'}</span>
+      <span className="text-xs font-medium uppercase">{locale}</span>
     </Button>
   );
 }

--- a/apps/web/src/i18n/locale-list.tsx
+++ b/apps/web/src/i18n/locale-list.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+const LocaleListContext = createContext<readonly string[]>([]);
+
+/**
+ * Carries the build-time locale list to client components. It comes down from
+ * the server because deriving it in the browser would mean bundling every
+ * message file into the client — next-intl ships only the active one today.
+ */
+export function LocaleListProvider({
+  locales,
+  children,
+}: {
+  locales: readonly string[];
+  children: ReactNode;
+}) {
+  return (
+    <LocaleListContext.Provider value={locales}>
+      {children}
+    </LocaleListContext.Provider>
+  );
+}
+
+export function useLocaleList(): readonly string[] {
+  return useContext(LocaleListContext);
+}

--- a/apps/web/src/i18n/locales.ts
+++ b/apps/web/src/i18n/locales.ts
@@ -1,0 +1,34 @@
+/**
+ * The set of UI locales IS the set of message files: adding a language means
+ * dropping `<code>.json` into src/messages/, and nothing in here changes.
+ *
+ * The listing is resolved by the bundler at build time rather than by reading
+ * the directory at runtime. The Docker image ships Next's standalone output,
+ * which carries the compiled bundle but not `src/`, so a `readdirSync` here
+ * would work in dev and come back empty in the container. `require.context`
+ * compiles the directory listing into the bundle instead.
+ */
+
+/** webpack's context API — `@types/node` types `require` without it */
+type RequireContext = (
+  dir: string,
+  useSubdirectories: boolean,
+  regExp: RegExp,
+) => { keys(): string[] };
+
+const messageFiles = (
+  require as unknown as { context: RequireContext }
+).context('../messages', false, /\.json$/);
+
+/** e.g. ['en', 'it', 'zh'] — sorted so the toggle cycles in a stable order */
+export const locales: readonly string[] = messageFiles
+  .keys()
+  .map((key) => key.replace(/^\.\//, '').replace(/\.json$/, ''))
+  .sort();
+
+/** the fallback when the cookie is absent or names a language we don't ship */
+export const defaultLocale = 'en';
+
+export function isLocale(value: string | undefined): boolean {
+  return value !== undefined && locales.includes(value);
+}

--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -1,19 +1,15 @@
 import { cookies } from 'next/headers';
 import { getRequestConfig } from 'next-intl/server';
+import { defaultLocale, isLocale, locales } from './locales';
 
-// Supported UI locales. Chinese is the default so the app shows 中文 out of the
-// box; the language toggle writes a `NEXT_LOCALE` cookie to switch.
-export const locales = ['zh', 'en'] as const;
-export type Locale = (typeof locales)[number];
-export const defaultLocale: Locale = 'en';
+// Which locales exist is derived from src/messages/ — see ./locales.ts. The
+// language toggle writes a `NEXT_LOCALE` cookie to switch between them.
+export { defaultLocale, locales };
 
 export default getRequestConfig(async () => {
   const store = await cookies();
   const cookieLocale = store.get('NEXT_LOCALE')?.value;
-  const locale: Locale =
-    cookieLocale && (locales as readonly string[]).includes(cookieLocale)
-      ? (cookieLocale as Locale)
-      : defaultLocale;
+  const locale = isLocale(cookieLocale) ? (cookieLocale as string) : defaultLocale;
 
   return {
     locale,

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -10,9 +10,7 @@
     "test": "Test"
   },
   "lang": {
-    "ariaLabel": "Switch language",
-    "en": "EN",
-    "zh": "中文"
+    "ariaLabel": "Switch language"
   },
   "theme": {
     "toggle": "Toggle theme"

--- a/apps/web/src/messages/it.json
+++ b/apps/web/src/messages/it.json
@@ -10,9 +10,7 @@
     "test": "Test"
   },
   "lang": {
-    "ariaLabel": "Cambia lingua",
-    "en": "EN",
-    "zh": "中文"
+    "ariaLabel": "Cambia lingua"
   },
   "theme": {
     "toggle": "Cambia tema"

--- a/apps/web/src/messages/zh.json
+++ b/apps/web/src/messages/zh.json
@@ -10,9 +10,7 @@
     "test": "测试"
   },
   "lang": {
-    "ariaLabel": "切换语言",
-    "en": "EN",
-    "zh": "中文"
+    "ariaLabel": "切换语言"
   },
   "theme": {
     "toggle": "切换主题"


### PR DESCRIPTION
Follow-up to #61. @albanobattistella's Italian translation is already on `main`; this makes the app actually able to load it, and makes the next language a one-file change.

## The problem

`locales` in `src/i18n/request.ts` was a hardcoded allowlist, so a message file that wasn't listed there was unreachable — the `NEXT_LOCALE` cookie failed the `includes` check and fell back to English. `it.json` rendered nothing, not even with the cookie set by hand. The toggle was a fixed `zh`/`en` flip on top of that, so there was no UI path either.

## What changed

- `src/i18n/locales.ts` derives the locale list from `src/messages/` — adding `<code>.json` is now the whole job.
- `LangToggle` cycles that list instead of flipping between two fixed languages, and labels itself from `Intl.DisplayNames`. That removed the per-language `lang.en` / `lang.zh` keys, which nothing referenced.
- The list reaches client components through a small context provided in the root layout, so the browser gets an array of codes rather than every message file.

## Why `require.context` and not `readdirSync`

The listing is resolved by the bundler at build time on purpose. The Docker image copies only `.next/standalone`, `.next/static` and `public`, so `src/messages/` does not exist on disk in the container — a runtime directory read would work in dev and come back empty in production.

## Verification

`en` / `it` / `zh` all render, and an unknown code falls back to English, under both `next start` and a standalone build served from a tree with no `src/`:

| cookie | `<html lang>` | renders |
| --- | --- | --- |
| `it` | `it` | Accedi |
| `zh` | `zh` | 登录 |
| `en` | `en` | Sign in |
| `xx` | `en` | Sign in |

Typecheck, lint and the full test suite (75 tests) pass.