### PR TITLE
feat(web): add a Docs link to the header

### DIFF
--- a/apps/web/src/components/studio.tsx
+++ b/apps/web/src/components/studio.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from 'react';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
-import { Database } from 'lucide-react';
+import { BookOpen, Database } from 'lucide-react';
 import { useStudio } from '@/lib/store';
 import {
   ResizableHandle,
@@ -99,6 +99,17 @@ export function Studio() {
                   onClick={openDataSources}
                 >
                   <Database className="h-4 w-4" />
+                </Button>
+                <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
+                  <a
+                    href="https://syncle.dev/docs"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    title={t('docs')}
+                    aria-label={t('docs')}
+                  >
+                    <BookOpen className="h-4 w-4" />
+                  </a>
                 </Button>
                 <ThemeToggle />
                 <LangToggle />

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -18,7 +18,8 @@
     "toggle": "Toggle theme"
   },
   "nav": {
-    "dataSources": "Data sources"
+    "dataSources": "Data sources",
+    "docs": "Docs"
   },
   "auth": {
     "login": {

--- a/apps/web/src/messages/it.json
+++ b/apps/web/src/messages/it.json
@@ -18,7 +18,8 @@
     "toggle": "Cambia tema"
   },
   "nav": {
-    "dataSources": "Origini dati"
+    "dataSources": "Origini dati",
+    "docs": "Documentazione"
   },
   "auth": {
     "login": {

--- a/apps/web/src/messages/zh.json
+++ b/apps/web/src/messages/zh.json
@@ -18,7 +18,8 @@
     "toggle": "切换主题"
   },
   "nav": {
-    "dataSources": "数据源"
+    "dataSources": "数据源",
+    "docs": "文档"
   },
   "auth": {
     "login": {


### PR DESCRIPTION
Nothing in the app linked to the documentation — the only way there was already knowing the URL. This adds a Docs button in the header, beside the theme and language toggles, opening https://syncle.dev/docs in a new tab.

Rendered as an `<a>` through the button's `asChild` prop rather than an `onClick`, so it keeps the icon-button styling while staying a real link: middle-click, open-in-new-tab and copy-link-address all behave as expected. `rel="noreferrer noopener"` on the external target.

The label is translated in all three message files (`Docs` / `文档` / `Documentazione`), keeping key parity at 223 across en, zh and it.

Typecheck, lint and build pass.