### PR TITLE
test(api): integration harness that runs against real databases

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
   "name": "@syncle/api",
   "version": "0.1.0",
   "private": true,
-  "description": "Syncle backend — NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
+  "description": "Syncle backend \u2014 NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
   "scripts": {
     "build": "prisma generate && nest build",
     "dev": "prisma generate && prisma migrate deploy && nest start --watch",
@@ -13,7 +13,8 @@
     "migrate:dev": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
     "postinstall": "prisma generate",
-    "test:coverage": "vitest run --passWithNoTests --coverage"
+    "test:coverage": "vitest run --passWithNoTests --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@nestjs/bullmq": "^10.2.3",

--- a/apps/api/test/integration/engines.itest.ts
+++ b/apps/api/test/integration/engines.itest.ts
@@ -1,0 +1,85 @@
+/**
+ * Baseline: every engine in the test stack is reachable through its real
+ * adapter and can round-trip a row. If this fails, nothing else in the suite
+ * means anything, so it runs first and fails loudly.
+ */
+import 'reflect-metadata';
+import { afterAll, describe, expect, it } from 'vitest';
+import { TEST_CONNECTIONS, uniqueTable, withAdapter } from './harness';
+
+describe('engine connectivity', () => {
+  it('pings every engine', async () => {
+    // ping() resolves with no value; throwing is the failure signal
+    for (const engine of Object.keys(TEST_CONNECTIONS)) {
+      await expect(
+        withAdapter(engine, (a) => a.ping()),
+        `${engine} ping`,
+      ).resolves.not.toThrow();
+    }
+  });
+});
+
+describe('postgres round-trip', () => {
+  const table = uniqueTable('it_pg');
+
+  afterAll(async () => {
+    await withAdapter('postgres', (a) => a.dropTable(table)).catch(() => undefined);
+  });
+
+  it('creates, inserts and reads back', async () => {
+    await withAdapter('postgres', async (a) => {
+      await a.createTable({
+        table,
+        columns: [
+          { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+          { name: 'name', type: 'text', nullable: true },
+        ],
+      });
+      await a.insertRow({ table, values: { id: 1, name: 'alpha' } });
+      const res = await a.browse({ table, limit: 10, offset: 0 });
+      expect(res.rows).toHaveLength(1);
+      expect(res.rows[0]).toMatchObject({ id: 1, name: 'alpha' });
+    });
+  });
+});
+
+describe('mysql round-trip', () => {
+  const table = uniqueTable('it_my');
+
+  afterAll(async () => {
+    await withAdapter('mysql', (a) => a.dropTable(table)).catch(() => undefined);
+  });
+
+  it('creates, inserts and reads back', async () => {
+    await withAdapter('mysql', async (a) => {
+      await a.createTable({
+        table,
+        columns: [
+          { name: 'id', type: 'int', nullable: false, primaryKey: true },
+          { name: 'name', type: 'varchar(255)', nullable: true },
+        ],
+      });
+      await a.insertRow({ table, values: { id: 1, name: 'alpha' } });
+      const res = await a.browse({ table, limit: 10, offset: 0 });
+      expect(res.rows).toHaveLength(1);
+      expect(res.rows[0]).toMatchObject({ id: 1, name: 'alpha' });
+    });
+  });
+});
+
+describe('mongodb round-trip', () => {
+  const table = uniqueTable('it_mg');
+
+  afterAll(async () => {
+    await withAdapter('mongodb', (a) => a.dropTable(table)).catch(() => undefined);
+  });
+
+  it('inserts and reads back a document', async () => {
+    await withAdapter('mongodb', async (a) => {
+      await a.insertRow({ table, values: { _id: 'a1', name: 'alpha' } });
+      const res = await a.browse({ table, limit: 10, offset: 0 });
+      expect(res.rows).toHaveLength(1);
+      expect(res.rows[0]).toMatchObject({ name: 'alpha' });
+    });
+  });
+});

--- a/apps/api/test/integration/global-setup.ts
+++ b/apps/api/test/integration/global-setup.ts
@@ -1,0 +1,78 @@
+/**
+ * Brings the test engines to a usable state before the suite runs.
+ *
+ * Compose can start MongoDB but cannot initiate a replica set, and change
+ * streams do not exist without one — so that happens here, idempotently. Also
+ * waits for every engine to accept connections, so a slow container start
+ * surfaces as a clear message instead of a pile of connection-refused failures.
+ */
+import { MongoClient } from 'mongodb';
+import { bootstrapDrivers, createAdapter } from '@syncle/core/adapters';
+import { TEST_CONNECTIONS } from './harness';
+
+const MONGO_DIRECT = 'mongodb://127.0.0.1:57017/?directConnection=true';
+
+async function initReplicaSet(): Promise<void> {
+  const client = new MongoClient(MONGO_DIRECT, {
+    serverSelectionTimeoutMS: 3_000,
+  });
+  await client.connect();
+  try {
+    const admin = client.db('admin');
+    try {
+      await admin.command({ replSetGetStatus: 1 });
+      return; // already initiated
+    } catch {
+      await admin.command({
+        replSetInitiate: {
+          _id: 'rs0',
+          members: [{ _id: 0, host: '127.0.0.1:57017' }],
+        },
+      });
+    }
+    // wait for this node to actually become primary before tests open streams
+    for (let i = 0; i < 60; i++) {
+      try {
+        const st = (await admin.command({ replSetGetStatus: 1 })) as {
+          myState?: number;
+        };
+        if (st.myState === 1) return;
+      } catch {
+        /* still electing */
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    throw new Error('mongo replica set did not reach PRIMARY');
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+async function waitForEngine(name: string): Promise<void> {
+  const conn = TEST_CONNECTIONS[name];
+  if (!conn) throw new Error(`unknown engine ${name}`);
+  let lastErr: unknown;
+  for (let i = 0; i < 60; i++) {
+    const adapter = createAdapter(conn);
+    try {
+      await adapter.connect();
+      await adapter.ping();
+      return;
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 1_000));
+    } finally {
+      await adapter.close().catch(() => undefined);
+    }
+  }
+  throw new Error(
+    `engine "${name}" never became reachable — is docker-compose.test.yml up? ` +
+      `last error: ${(lastErr as Error)?.message}`,
+  );
+}
+
+export async function setup(): Promise<void> {
+  bootstrapDrivers();
+  await initReplicaSet();
+  for (const name of Object.keys(TEST_CONNECTIONS)) await waitForEngine(name);
+}

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared plumbing for the integration suite: connection configs pointing at the
+ * throwaway engines in docker-compose.test.yml, plus helpers for driving a real
+ * adapter and waiting on asynchronous propagation.
+ *
+ * Ports here intentionally differ from every default so the suite can never
+ * touch a developer's real database, the dev stack, or an installed app stack.
+ */
+import { randomUUID } from 'node:crypto';
+import { bootstrapDrivers, createAdapter } from '@syncle/core/adapters';
+import type { ConnectionConfig, DatabaseAdapter, DatabaseEngine } from '@syncle/core';
+
+bootstrapDrivers();
+
+const now = new Date().toISOString();
+
+function base(engine: DatabaseEngine, extra: Partial<ConnectionConfig>): ConnectionConfig {
+  return {
+    id: `it-${engine}`,
+    name: `integration ${engine}`,
+    workspaceId: 'it',
+    engine,
+    createdAt: now,
+    updatedAt: now,
+    ...extra,
+  };
+}
+
+export const TEST_CONNECTIONS: Record<string, ConnectionConfig> = {
+  postgres: base('postgres', {
+    host: '127.0.0.1',
+    port: 55432,
+    user: 'syncle',
+    password: 'syncle',
+    database: 'syncle_test',
+  }),
+  mysql: base('mysql', {
+    host: '127.0.0.1',
+    port: 53306,
+    user: 'root',
+    password: 'syncle',
+    database: 'syncle_test',
+  }),
+  mongodb: base('mongodb', {
+    host: '127.0.0.1',
+    port: 57017,
+    database: 'syncle_test',
+  }),
+  redis: base('redis', { host: '127.0.0.1', port: 56379 }),
+};
+
+/** open a real adapter, run `fn`, always disconnect */
+export async function withAdapter<T>(
+  engine: keyof typeof TEST_CONNECTIONS,
+  fn: (a: DatabaseAdapter) => Promise<T>,
+): Promise<T> {
+  const conn = TEST_CONNECTIONS[engine];
+  if (!conn) throw new Error(`no test connection for ${engine}`);
+  const adapter = createAdapter(conn);
+  await adapter.connect();
+  try {
+    return await fn(adapter);
+  } finally {
+    await adapter.close().catch(() => undefined);
+  }
+}
+
+/** a collision-proof table name, so parallel or repeated runs never clash */
+export function uniqueTable(prefix: string): string {
+  return `${prefix}_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
+}
+
+/**
+ * Poll `check` until it returns a truthy value or the deadline passes. CDC is
+ * asynchronous end to end, so assertions have to wait for propagation rather
+ * than assume it. Returns the value; throws with `label` on timeout.
+ */
+export async function waitFor<T>(
+  label: string,
+  check: () => Promise<T | null | undefined | false>,
+  { timeoutMs = 30_000, intervalMs = 100 } = {},
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: unknown;
+  for (;;) {
+    try {
+      const v = await check();
+      if (v) return v;
+      last = v;
+    } catch (err) {
+      last = (err as Error).message;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label} (last: ${JSON.stringify(last)})`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Integration suite: runs against the REAL databases in docker-compose.test.yml.
+ *
+ *   docker compose -f docker-compose.test.yml up -d
+ *   pnpm test:integration
+ *
+ * Kept in its own config, and behind an `.itest.ts` suffix, so `pnpm test`
+ * (which has no config and uses vitest's default `*.test.ts` glob) never picks
+ * these up and never needs Docker.
+ *
+ * Single-threaded and serial: these tests create replication slots, hold binlog
+ * readers open and write to shared tables, so parallel files would interfere.
+ */
+export default defineConfig({
+  test: {
+    include: ['test/integration/**/*.itest.ts'],
+    globalSetup: ['test/integration/global-setup.ts'],
+    // CDC is inherently timing-bound: a change has to travel source -> log ->
+    // reader -> destination. Generous per-test time, still bounded.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    fileParallelism: false,
+    sequence: { concurrent: false },
+  },
+});

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,97 @@
+# Real databases for the integration suite (`pnpm test:integration`).
+#
+#   docker compose -f docker-compose.test.yml up -d
+#
+# `name:` pins the Compose project. Without it the project is derived from the
+# directory and this file would MERGE with the dev stack in docker-compose.yml
+# and with an installed app stack at ~/.syncle/docker-compose.app.yml — a
+# service named `redis` here would then recreate *their* redis. Keep the name.
+#
+# These are throwaway instances on non-default ports so they never collide with
+# the dev stack in docker-compose.yml or with anything local. Every engine is
+# configured for CHANGE CAPTURE, which is the whole point of the suite:
+# Postgres needs logical WAL + slots, MySQL needs a row-format binlog (and GTID,
+# so failover-resume can be tested), MongoDB needs a replica set for change
+# streams, and Redis needs keyspace notifications.
+#
+# tmpfs storage: these are disposable and speed matters more than durability.
+name: syncle-test
+
+services:
+  pg:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: syncle
+      POSTGRES_PASSWORD: syncle
+      POSTGRES_DB: syncle_test
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=20
+      - -c
+      - max_wal_senders=20
+      # surface slot lag quickly in tests rather than after a default timeout
+      - -c
+      - wal_sender_timeout=5s
+    ports: ['127.0.0.1:55432:5432']
+    tmpfs: ['/var/lib/postgresql/data']
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U syncle -d syncle_test']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: syncle
+      MYSQL_DATABASE: syncle_test
+    command:
+      - --server-id=1
+      - --log-bin=binlog
+      - --binlog-format=ROW
+      - --binlog-row-image=FULL
+      # GTID on, so the GTID-cursor work can be tested against a real server
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+      - --log-replica-updates=ON
+    ports: ['127.0.0.1:53306:3306']
+    tmpfs: ['/var/lib/mysql']
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-h', '127.0.0.1', '-psyncle']
+      interval: 3s
+      timeout: 5s
+      retries: 40
+
+  mongo:
+    image: mongo:7
+    # Change streams require a replica set, even a single-node one. The port
+    # is identical inside and out on purpose: a replica set advertises its
+    # members' host:port, and clients reconnect to whatever it advertises. With
+    # a remapped port the driver would discover 127.0.0.1:27017 and dial the
+    # wrong place from the host, so keep these two numbers the same.
+    command: ['--replSet', 'rs0', '--bind_ip_all', '--port', '57017']
+    ports: ['127.0.0.1:57017:57017']
+    tmpfs: ['/data/db']
+    healthcheck:
+      test:
+        ['CMD', 'mongosh', '--port', '57017', '--quiet', '--eval', 'db.adminCommand("ping").ok']
+      interval: 3s
+      timeout: 5s
+      retries: 30
+
+  redis:
+    image: redis:7-alpine
+    # KEA = keyspace + keyevent notifications for all event classes (CDC source);
+    # appendonly is what makes the spool durable enough to own acked changes
+    command:
+      ['redis-server', '--notify-keyspace-events', 'KEA', '--appendonly', 'yes']
+    ports: ['127.0.0.1:56379:6379']
+    tmpfs: ['/data']
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 2s
+      timeout: 3s
+      retries: 30


### PR DESCRIPTION
First of a six-PR stack that makes CDC fast enough to be useful at volume. This one adds no product code — it is the harness everything after it is verified with.

## Why

CI has never run a query against a real database. It runs typecheck, unit tests with stub adapters, and a Docker build. Every claim about CDC correctness rested on reading the code, which is not a good position to be in before restructuring the CDC hot path.

## What

`docker-compose.test.yml` brings up Postgres, MySQL, MongoDB and Redis configured **for change capture**: logical WAL and replication slots, a ROW-format binlog with GTID on, a single-node replica set (change streams need one), keyspace notifications. Storage is tmpfs and every port is non-default, so the stack is disposable and cannot reach a real database.

The Compose project is pinned with `name: syncle-test`. Without it the project name is derived from the directory, and this file merges with `docker-compose.yml` **and** with an installed stack at `~/.syncle/docker-compose.app.yml` — where a service named `redis` recreates theirs. That is not hypothetical; it happened while writing this.

## Not affecting the existing suite

Tests use an `.itest.ts` suffix and a separate vitest config, so `pnpm test` keeps its default `*.test.ts` glob, still needs no Docker, and is untouched.

Global setup initiates the replica set (Compose cannot) and waits for every engine, so the suite runs from a cold stack with no manual steps — verified by wiping Mongo and running cold.

## Verification

    docker compose -f docker-compose.test.yml up -d
    pnpm --filter @syncle/api test:integration

4 tests: every engine reachable through its real adapter, and a row round-tripped on Postgres, MySQL and MongoDB.