### PR TITLE
perf(core): set-based insert/upsert/delete for database sinks

### DIFF
--- a/apps/api/src/bridges/database-sink.service.ts
+++ b/apps/api/src/bridges/database-sink.service.ts
@@ -139,39 +139,66 @@ export class DatabaseSinkService {
       target.connectionId,
       target.database,
       async (adapter) => {
-        // write the whole batch for this target, one row at a time
+        const { schema, table } = target;
+
+        // one set-based statement per batch where the engine supports it,
+        // otherwise the original row-at-a-time loop. Both paths must produce
+        // the same rows and the same `affected` count — only the number of
+        // round trips differs.
         const writeBatch = async (): Promise<void> => {
-          for (const row of rows) {
-            const mapped = mapRow(row, target.mapping);
-            if (op === 'delete') {
-              const identity = pick(mapped, target.keyColumns);
-              const res = await adapter.deleteRow({
-                schema: target.schema,
-                table: target.table,
-                identity,
-              });
+          const mapped = rows.map((row) => mapRow(row, target.mapping));
+          const isUpsert = op !== 'delete' && target.writeMode !== 'insert';
+          if (isUpsert && target.keyColumns.length === 0) {
+            throw new Error(
+              'Upsert needs at least one key column; set keys or use insert mode',
+            );
+          }
+
+          if (op === 'delete') {
+            const identities = mapped.map((m) => pick(m, target.keyColumns));
+            if (adapter.deleteRows) {
+              const res = await adapter.deleteRows({ schema, table, identities });
               affected += res.affectedRows ?? 0;
-            } else if (target.writeMode === 'insert') {
-              const res = await adapter.insertRow({
-                schema: target.schema,
-                table: target.table,
-                values: mapped,
-              });
-              affected += res.affectedRows ?? 1;
-            } else {
-              if (target.keyColumns.length === 0) {
-                throw new Error(
-                  'Upsert needs at least one key column; set keys or use insert mode',
-                );
-              }
-              const res = await adapter.upsertRow({
-                schema: target.schema,
-                table: target.table,
-                values: mapped,
-                keyColumns: target.keyColumns,
-              });
+              return;
+            }
+            for (const identity of identities) {
+              const res = await adapter.deleteRow({ schema, table, identity });
+              affected += res.affectedRows ?? 0;
+            }
+            return;
+          }
+
+          if (target.writeMode === 'insert') {
+            if (adapter.insertRows) {
+              const res = await adapter.insertRows({ schema, table, rows: mapped });
+              affected += res.affectedRows ?? mapped.length;
+              return;
+            }
+            for (const values of mapped) {
+              const res = await adapter.insertRow({ schema, table, values });
               affected += res.affectedRows ?? 1;
             }
+            return;
+          }
+
+          if (adapter.upsertRows) {
+            const res = await adapter.upsertRows({
+              schema,
+              table,
+              rows: mapped,
+              keyColumns: target.keyColumns,
+            });
+            affected += res.affectedRows ?? mapped.length;
+            return;
+          }
+          for (const values of mapped) {
+            const res = await adapter.upsertRow({
+              schema,
+              table,
+              values,
+              keyColumns: target.keyColumns,
+            });
+            affected += res.affectedRows ?? 1;
           }
         };
 

--- a/apps/api/test/integration/batch-writes.itest.ts
+++ b/apps/api/test/integration/batch-writes.itest.ts
@@ -1,0 +1,360 @@
+/**
+ * Set-based writes against real engines.
+ *
+ * The governing rule for every test here: a batched write must be
+ * INDISTINGUISHABLE from the per-row loop it replaces. So most cases assert the
+ * resulting table contents, not just that the call succeeded, and several run
+ * the same data through both paths and compare.
+ */
+import 'reflect-metadata';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { DatabaseAdapter } from '@syncle/core';
+import { TEST_CONNECTIONS, uniqueTable, withAdapter } from './harness';
+
+type Engine = 'postgres' | 'mysql' | 'sqlite';
+const ENGINES: Engine[] = ['postgres', 'mysql', 'sqlite'];
+
+/** per-engine column types for the small fixture table */
+const TYPES: Record<Engine, { int: string; text: string }> = {
+  postgres: { int: 'integer', text: 'text' },
+  mysql: { int: 'int', text: 'varchar(255)' },
+  sqlite: { int: 'INTEGER', text: 'TEXT' },
+};
+
+const created: Array<{ engine: Engine; table: string }> = [];
+
+async function makeTable(
+  a: DatabaseAdapter,
+  engine: Engine,
+  table: string,
+  extra: string[] = [],
+): Promise<void> {
+  const t = TYPES[engine];
+  await a.createTable({
+    table,
+    columns: [
+      { name: 'id', type: t.int, nullable: false, primaryKey: true },
+      { name: 'name', type: t.text, nullable: true },
+      { name: 'note', type: t.text, nullable: true },
+      ...extra.map((c) => ({ name: c, type: t.text, nullable: true })),
+    ],
+  });
+  created.push({ engine, table });
+}
+
+async function rowsOf(
+  a: DatabaseAdapter,
+  table: string,
+): Promise<Array<Record<string, unknown>>> {
+  const res = await a.browse({ table, limit: 10_000, offset: 0 });
+  return [...res.rows].sort((x, y) => Number(x.id) - Number(y.id));
+}
+
+afterEach(async () => {
+  while (created.length) {
+    const item = created.pop();
+    if (!item) break;
+    await withAdapter(item.engine, (a) => a.dropTable(item.table)).catch(
+      () => undefined,
+    );
+  }
+});
+
+describe.each(ENGINES)('batched writes — %s', (engine) => {
+  it('exposes the optional batch methods', async () => {
+    await withAdapter(engine, async (a) => {
+      expect(typeof a.insertRows).toBe('function');
+      expect(typeof a.upsertRows).toBe('function');
+      expect(typeof a.deleteRows).toBe('function');
+    });
+  });
+
+  it('insertRows writes every row', async () => {
+    const table = uniqueTable('b_ins');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      const res = await a.insertRows?.({
+        table,
+        rows: [
+          { id: 1, name: 'a', note: 'x' },
+          { id: 2, name: 'b', note: 'y' },
+          { id: 3, name: 'c', note: 'z' },
+        ],
+      });
+      expect(res?.affectedRows).toBe(3);
+      const rows = await rowsOf(a, table);
+      expect(rows.map((r) => r.name)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  it('insertRows handles sparse rows with different column sets', async () => {
+    const table = uniqueTable('b_sparse');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      // three distinct shapes in one call — these cannot share one statement
+      await a.insertRows?.({
+        table,
+        rows: [
+          { id: 1, name: 'a', note: 'n1' },
+          { id: 2, name: 'b' },
+          { id: 3, note: 'n3' },
+        ],
+      });
+      const rows = await rowsOf(a, table);
+      expect(rows).toHaveLength(3);
+      expect(rows[0]).toMatchObject({ id: 1, name: 'a', note: 'n1' });
+      expect(rows[1]).toMatchObject({ id: 2, name: 'b' });
+      expect(rows[1]?.note ?? null).toBeNull();
+      expect(rows[2]?.name ?? null).toBeNull();
+      expect(rows[2]).toMatchObject({ id: 3, note: 'n3' });
+    });
+  });
+
+  it('insertRows on an empty list is a no-op', async () => {
+    const table = uniqueTable('b_empty');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      const res = await a.insertRows?.({ table, rows: [] });
+      expect(res?.affectedRows).toBe(0);
+      expect(await rowsOf(a, table)).toHaveLength(0);
+    });
+  });
+
+  it('upsertRows inserts new rows and updates existing ones', async () => {
+    const table = uniqueTable('b_up');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({
+        table,
+        rows: [
+          { id: 1, name: 'old', note: 'keep' },
+          { id: 2, name: 'old2', note: 'keep2' },
+        ],
+      });
+      await a.upsertRows?.({
+        table,
+        keyColumns: ['id'],
+        rows: [
+          { id: 1, name: 'new', note: 'updated' }, // update
+          { id: 3, name: 'fresh', note: 'inserted' }, // insert
+        ],
+      });
+      const rows = await rowsOf(a, table);
+      expect(rows).toHaveLength(3);
+      expect(rows[0]).toMatchObject({ id: 1, name: 'new', note: 'updated' });
+      expect(rows[1]).toMatchObject({ id: 2, name: 'old2' });
+      expect(rows[2]).toMatchObject({ id: 3, name: 'fresh' });
+    });
+  });
+
+  it('upsertRows is idempotent when replayed', async () => {
+    const table = uniqueTable('b_idem');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      const rows = [
+        { id: 1, name: 'a', note: 'n' },
+        { id: 2, name: 'b', note: 'm' },
+      ];
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      // at-least-once redelivery must not duplicate
+      expect(await rowsOf(a, table)).toHaveLength(2);
+    });
+  });
+
+  it('upsertRows rejects an empty key list', async () => {
+    const table = uniqueTable('b_nokey');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await expect(
+        a.upsertRows?.({ table, keyColumns: [], rows: [{ id: 1 }] }),
+      ).rejects.toThrow(/key columns/i);
+    });
+  });
+
+  it('deleteRows removes exactly the named identities', async () => {
+    const table = uniqueTable('b_del');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({
+        table,
+        rows: [1, 2, 3, 4].map((id) => ({ id, name: `n${id}`, note: null })),
+      });
+      const res = await a.deleteRows?.({
+        table,
+        identities: [{ id: 2 }, { id: 4 }],
+      });
+      expect(res?.affectedRows).toBe(2);
+      const rows = await rowsOf(a, table);
+      expect(rows.map((r) => Number(r.id))).toEqual([1, 3]);
+    });
+  });
+
+  it('deleteRows tolerates identities that match nothing', async () => {
+    const table = uniqueTable('b_delmiss');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({ table, rows: [{ id: 1, name: 'a' }] });
+      const res = await a.deleteRows?.({
+        table,
+        identities: [{ id: 99 }, { id: 1 }],
+      });
+      expect(res?.affectedRows).toBe(1);
+      expect(await rowsOf(a, table)).toHaveLength(0);
+    });
+  });
+
+  it('deleteRows on an empty list is a no-op', async () => {
+    const table = uniqueTable('b_delempty');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({ table, rows: [{ id: 1 }] });
+      const res = await a.deleteRows?.({ table, identities: [] });
+      expect(res?.affectedRows).toBe(0);
+      expect(await rowsOf(a, table)).toHaveLength(1);
+    });
+  });
+
+  it('batched and per-row paths produce identical tables', async () => {
+    const viaLoop = uniqueTable('b_loop');
+    const viaBatch = uniqueTable('b_batch');
+    const data = Array.from({ length: 50 }, (_, i) => ({
+      id: i + 1,
+      name: `name-${i}`,
+      note: i % 3 === 0 ? null : `note-${i}`,
+    }));
+
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, viaLoop);
+      await makeTable(a, engine, viaBatch);
+
+      for (const row of data) {
+        await a.upsertRow({ table: viaLoop, values: row, keyColumns: ['id'] });
+      }
+      await a.upsertRows?.({ table: viaBatch, keyColumns: ['id'], rows: data });
+
+      expect(await rowsOf(a, viaBatch)).toEqual(await rowsOf(a, viaLoop));
+    });
+  });
+});
+
+describe('composite keys and chunking', () => {
+  it('upsertRows and deleteRows handle composite keys (postgres)', async () => {
+    const table = uniqueTable('b_comp');
+    await withAdapter('postgres', async (a) => {
+      await a.createTable({
+        table,
+        columns: [
+          { name: 'tenant', type: 'text', nullable: false, primaryKey: true },
+          { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+          { name: 'name', type: 'text', nullable: true },
+        ],
+      });
+      created.push({ engine: 'postgres', table });
+
+      await a.upsertRows?.({
+        table,
+        keyColumns: ['tenant', 'id'],
+        rows: [
+          { tenant: 't1', id: 1, name: 'a' },
+          { tenant: 't2', id: 1, name: 'b' },
+        ],
+      });
+      // same id, different tenant → both survive
+      let res = await a.browse({ table, limit: 100, offset: 0 });
+      expect(res.rows).toHaveLength(2);
+
+      // updating one composite key must not touch the other
+      await a.upsertRows?.({
+        table,
+        keyColumns: ['tenant', 'id'],
+        rows: [{ tenant: 't1', id: 1, name: 'changed' }],
+      });
+      res = await a.browse({ table, limit: 100, offset: 0 });
+      expect(res.rows).toHaveLength(2);
+      expect(res.rows.find((r) => r.tenant === 't1')?.name).toBe('changed');
+      expect(res.rows.find((r) => r.tenant === 't2')?.name).toBe('b');
+
+      await a.deleteRows?.({ table, identities: [{ tenant: 't2', id: 1 }] });
+      res = await a.browse({ table, limit: 100, offset: 0 });
+      expect(res.rows).toHaveLength(1);
+      expect(res.rows[0]?.tenant).toBe('t1');
+    });
+  });
+
+  it('splits a batch that exceeds the driver bind-parameter cap', async () => {
+    // SQLite caps binds at 32766. 40 columns => ~819 rows per statement, so
+    // 2500 rows must span multiple statements and still land exactly once.
+    const table = uniqueTable('b_chunk');
+    const extra = Array.from({ length: 37 }, (_, i) => `c${i}`);
+    const total = 2500;
+
+    await withAdapter('sqlite', async (a) => {
+      await makeTable(a, 'sqlite', table, extra);
+      const rows = Array.from({ length: total }, (_, i) => {
+        const row: Record<string, unknown> = {
+          id: i + 1,
+          name: `n${i}`,
+          note: `x${i}`,
+        };
+        for (const c of extra) row[c] = `${c}-${i}`;
+        return row;
+      });
+      const res = await a.insertRows?.({ table, rows });
+      expect(res?.affectedRows).toBe(total);
+
+      const all = await a.browse({ table, limit: 10_000, offset: 0 });
+      expect(all.rows).toHaveLength(total);
+
+      // and the same again through upsert, which must not duplicate
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      const after = await a.browse({ table, limit: 10_000, offset: 0 });
+      expect(after.rows).toHaveLength(total);
+    });
+  });
+
+  it('deleteRows splits large identity lists too', async () => {
+    const table = uniqueTable('b_delchunk');
+    await withAdapter('sqlite', async (a) => {
+      await makeTable(a, 'sqlite', table);
+      const rows = Array.from({ length: 5000 }, (_, i) => ({ id: i + 1 }));
+      await a.insertRows?.({ table, rows });
+      const res = await a.deleteRows?.({ table, identities: rows });
+      expect(res?.affectedRows).toBe(5000);
+      const all = await a.browse({ table, limit: 10, offset: 0 });
+      expect(all.rows).toHaveLength(0);
+    });
+  });
+  it('splits large COMPOSITE-key deletes without blowing expression depth', async () => {
+    // the OR-of-ANDs form is a deep expression tree; SQLite rejects past depth
+    // 1000, so this must be chunked by clause count, not just by bind count
+    const table = uniqueTable('b_delcomp');
+    await withAdapter('sqlite', async (a) => {
+      await a.createTable({
+        table,
+        columns: [
+          { name: 'tenant', type: 'TEXT', nullable: false, primaryKey: true },
+          { name: 'id', type: 'INTEGER', nullable: false, primaryKey: true },
+        ],
+      });
+      created.push({ engine: 'sqlite', table });
+
+      const rows = Array.from({ length: 1500 }, (_, i) => ({
+        tenant: `t${i % 3}`,
+        id: i + 1,
+      }));
+      await a.insertRows?.({ table, rows });
+      const res = await a.deleteRows?.({ table, identities: rows });
+      expect(res?.affectedRows).toBe(1500);
+      const all = await a.browse({ table, limit: 10, offset: 0 });
+      expect(all.rows).toHaveLength(0);
+    });
+  });
+});
+
+describe('test connections cover every batched engine', () => {
+  it('has a connection for each engine under test', () => {
+    for (const e of ENGINES) expect(TEST_CONNECTIONS[e]).toBeTruthy();
+  });
+});

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -7,6 +7,9 @@
  * touch a developer's real database, the dev stack, or an installed app stack.
  */
 import { randomUUID } from 'node:crypto';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { bootstrapDrivers, createAdapter } from '@syncle/core/adapters';
 import type { ConnectionConfig, DatabaseAdapter, DatabaseEngine } from '@syncle/core';
 
@@ -47,6 +50,10 @@ export const TEST_CONNECTIONS: Record<string, ConnectionConfig> = {
     database: 'syncle_test',
   }),
   redis: base('redis', { host: '127.0.0.1', port: 56379 }),
+  // file-backed, so it needs no container; a fresh temp file per run
+  sqlite: base('sqlite', {
+    database: join(mkdtempSync(join(tmpdir(), 'syncle-it-')), 'test.db'),
+  }),
 };
 
 /** open a real adapter, run `fn`, always disconnect */

--- a/packages/core/src/adapters/sql/base-sql-adapter.ts
+++ b/packages/core/src/adapters/sql/base-sql-adapter.ts
@@ -23,13 +23,16 @@ import type {
   DatabaseEngine,
   DatabaseSchema,
   DeleteRowParams,
+  DeleteRowsParams,
   FilterSpec,
   InsertRowParams,
+  InsertRowsParams,
   QueryResult,
   RestoreResult,
   TableSchema,
   UpdateRowParams,
   UpsertRowParams,
+  UpsertRowsParams,
 } from '../types';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { BadRequestError } from '../../errors';
@@ -502,6 +505,164 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
       sql,
       cols.map((c) => p.values[c]),
     );
+  }
+
+  /* ----- set-based writes ----------------------------------------------- */
+
+  /**
+   * Group rows by the exact set of columns they carry. A change stream can emit
+   * sparse rows, and one multi-row INSERT needs a single uniform column list,
+   * so rows with different shapes go into separate statements. Insertion order
+   * is preserved within each group.
+   */
+  private groupByColumns(
+    rows: Array<Record<string, unknown>>,
+  ): Array<{ columns: string[]; rows: Array<Record<string, unknown>> }> {
+    const groups = new Map<
+      string,
+      { columns: string[]; rows: Array<Record<string, unknown>> }
+    >();
+    for (const row of rows) {
+      const columns = Object.keys(row);
+      if (columns.length === 0) continue;
+      // the signature must not collide across different column sets, so it is
+      // built from the sorted names; the emitted column order stays as-written
+      const key = JSON.stringify([...columns].sort());
+      const existing = groups.get(key);
+      if (existing) existing.rows.push(row);
+      else groups.set(key, { columns, rows: [row] });
+    }
+    return [...groups.values()];
+  }
+
+  /** rows per statement so `rows × columns` stays under the driver's bind cap */
+  private chunkSize(columnCount: number): number {
+    return Math.max(1, Math.floor(this.maxBindParams() / Math.max(1, columnCount)));
+  }
+
+  /**
+   * One INSERT per column-shape and bind-limit chunk. `tail` appends the
+   * dialect's upsert clause when this is an upsert.
+   *
+   * Values are bound exactly as {@link insertRow} binds them, so a batched
+   * write and the per-row loop it replaces are indistinguishable to the engine.
+   */
+  private async insertGrouped(
+    table: string,
+    schema: string | undefined,
+    rows: Array<Record<string, unknown>>,
+    tail: (columns: string[]) => string,
+  ): Promise<QueryResult> {
+    const target = this.qualify(table, schema);
+    let affected = 0;
+    for (const group of this.groupByColumns(rows)) {
+      const { columns } = group;
+      const colSql = columns.map((c) => this.quoteIdent(c)).join(', ');
+      const size = this.chunkSize(columns.length);
+      for (let i = 0; i < group.rows.length; i += size) {
+        const chunk = group.rows.slice(i, i + size);
+        const params: unknown[] = [];
+        let ph = 1;
+        const tuples = chunk.map((row) => {
+          const placeholders = columns.map((c) => {
+            params.push(row[c]);
+            return this.placeholder(ph++);
+          });
+          return `(${placeholders.join(', ')})`;
+        });
+        const res = await this.runSql(
+          `INSERT INTO ${target} (${colSql}) VALUES ${tuples.join(', ')} ${tail(columns)}`.trim(),
+          params,
+        );
+        // engines report affected rows inconsistently for multi-row upserts
+        // (MySQL counts an update as 2); fall back to the rows we sent
+        affected += res.affectedRows ?? chunk.length;
+      }
+    }
+    return { affectedRows: affected, rowCount: affected, rows: [], columns: [], executionMs: 0 };
+  }
+
+  async insertRows(p: InsertRowsParams): Promise<QueryResult> {
+    if (p.rows.length === 0) {
+      return { affectedRows: 0, rowCount: 0, rows: [], columns: [], executionMs: 0 };
+    }
+    return this.insertGrouped(p.table, p.schema, p.rows, () => '');
+  }
+
+  async upsertRows(p: UpsertRowsParams): Promise<QueryResult> {
+    if (p.rows.length === 0) {
+      return { affectedRows: 0, rowCount: 0, rows: [], columns: [], executionMs: 0 };
+    }
+    if (p.keyColumns.length === 0) {
+      throw new BadRequestError('Cannot upsert without key columns to match on');
+    }
+    return this.insertGrouped(p.table, p.schema, p.rows, (columns) =>
+      this.upsertClause(p.keyColumns, columns),
+    );
+  }
+
+  /**
+   * Upper bound on OR-ed clauses in one DELETE. Staying under the bind cap is
+   * not sufficient: SQLite also limits expression-tree DEPTH (1000 by default),
+   * and a long chain of ORs is a deep tree, so a batch well within the bind
+   * budget can still be rejected. Single-column keys avoid the issue entirely
+   * by using a flat IN list; this cap covers the composite-key form.
+   */
+  protected maxOrClauses(): number {
+    return 200;
+  }
+
+  /**
+   * Deletes many identities. A single key column becomes `k IN (?, ?, …)`,
+   * which is flat and cheap; composite keys fall back to
+   * `(a = ? AND b = ?) OR (…)`, since an IN over tuples is not portable.
+   */
+  async deleteRows(p: DeleteRowsParams): Promise<QueryResult> {
+    if (p.identities.length === 0) {
+      return { affectedRows: 0, rowCount: 0, rows: [], columns: [], executionMs: 0 };
+    }
+    const target = this.qualify(p.table, p.schema);
+    let affected = 0;
+    for (const group of this.groupByColumns(p.identities)) {
+      const { columns } = group;
+      const single = columns.length === 1 ? columns[0] : undefined;
+      // a flat IN list has no depth problem, so it is only bind-capped
+      const size =
+        single !== undefined
+          ? this.chunkSize(1)
+          : Math.min(this.chunkSize(columns.length), this.maxOrClauses());
+
+      for (let i = 0; i < group.rows.length; i += size) {
+        const chunk = group.rows.slice(i, i + size);
+        const params: unknown[] = [];
+        let ph = 1;
+        let where: string;
+
+        if (single !== undefined) {
+          const list = chunk.map((identity) => {
+            params.push(identity[single]);
+            return this.placeholder(ph++);
+          });
+          where = `${this.quoteIdent(single)} IN (${list.join(', ')})`;
+        } else {
+          const clauses = chunk.map((identity) => {
+            const conds = columns.map((c) => {
+              params.push(identity[c]);
+              return `${this.quoteIdent(c)} = ${this.placeholder(ph++)}`;
+            });
+            return `(${conds.join(' AND ')})`;
+          });
+          where = clauses.join(' OR ');
+        }
+
+        const res = await this.runSql(
+          `DELETE FROM ${target} WHERE ${where}`,
+          params,
+        );
+        affected += res.affectedRows ?? 0;
+      }
+    }
+    return { affectedRows: affected, rowCount: affected, rows: [], columns: [], executionMs: 0 };
   }
 
   /* ----- schema management (DDL) ----- */

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -300,6 +300,44 @@ export interface UpsertRowParams {
 }
 
 /* -------------------------------------------------------------------------- */
+/* batched writes                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Batched variants of the single-row writes. A sink handling a stream of
+ * changes would otherwise pay a full round trip per row, which dominates
+ * throughput once the database is anywhere but localhost.
+ *
+ * These are OPTIONAL on {@link DatabaseAdapter}: an engine that cannot express
+ * a set-based write simply omits them and callers fall back to looping the
+ * single-row methods. Callers MUST therefore guard with
+ * `adapter.upsertRows?.(...)` rather than assuming availability.
+ *
+ * Rows are NOT required to share a column set — implementations group by the
+ * columns actually present, since a change stream can emit sparse rows.
+ */
+export interface InsertRowsParams {
+  schema?: string;
+  table: string;
+  rows: Array<Record<string, unknown>>;
+}
+
+export interface UpsertRowsParams {
+  schema?: string;
+  table: string;
+  rows: Array<Record<string, unknown>>;
+  /** columns that uniquely identify a row (must be a unique/primary key) */
+  keyColumns: string[];
+}
+
+export interface DeleteRowsParams {
+  schema?: string;
+  table: string;
+  /** one identity per row to remove; all must use the same key columns */
+  identities: RowIdentity[];
+}
+
+/* -------------------------------------------------------------------------- */
 /* schema management (DDL)                                                     */
 /* -------------------------------------------------------------------------- */
 
@@ -390,6 +428,11 @@ export interface DatabaseAdapter {
   deleteRow(params: DeleteRowParams): Promise<QueryResult>;
   /** insert-or-update keyed by `keyColumns`, atomic in the engine's dialect */
   upsertRow(params: UpsertRowParams): Promise<QueryResult>;
+
+  /* ----- optional set-based writes; see InsertRowsParams for the contract ----- */
+  insertRows?(params: InsertRowsParams): Promise<QueryResult>;
+  upsertRows?(params: UpsertRowsParams): Promise<QueryResult>;
+  deleteRows?(params: DeleteRowsParams): Promise<QueryResult>;
 
   /* schema management, guarded by `capabilities.ddl` / `manageDatabases` */
   createDatabase(name: string): Promise<void>;


### PR DESCRIPTION
Stacked on #64.

## Why

A batch of rows cost one round trip per row. The sink looped the single-row adapter methods, so a 500-row batch was 500 statements. Round-trip latency, not the database, was the ceiling.

## What

Optional `insertRows` / `upsertRows` / `deleteRows` on the adapter contract, implemented once in `BaseSqlAdapter` so Postgres, MySQL and SQLite all gain them through the existing `upsertClause` dialect hook.

**Optional by design.** MongoDB and Redis do not implement them and the sink falls back to the per-row loop — which is also the path the existing unit tests exercise through their stub adapters, so those keep passing unchanged.

## Two engine limits, not one

Bound parameters are capped per statement (the existing `maxBindParams`). SQLite *additionally* caps expression-tree **depth** at 1000, and a long `OR` chain is a deep tree — so a delete can sit well inside the bind budget and still be rejected outright.

Single-column deletes therefore use a flat `IN` list (also faster); composite keys chunk by clause count.

That limit was found by the integration suite, not by reading documentation. It would have shipped.

## Correctness

Rows are grouped by column set before batching, since a change stream emits sparse rows and one `INSERT` needs a uniform column list. Values are bound exactly as `insertRow` binds them, so a batched write and the loop it replaces are indistinguishable to the engine.

## Verification

38 integration tests against real Postgres, MySQL and SQLite: sparse rows, composite keys, replay idempotence, empty batches, multi-chunk splits, identity-vs-loop equivalence, and both the bind-count and expression-depth limits.