### PR TITLE
test(api): end-to-end CDC syncing against real databases

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
   "name": "@syncle/api",
   "version": "0.1.0",
   "private": true,
-  "description": "Syncle backend \u2014 NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
+  "description": "Syncle backend — NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
   "scripts": {
     "build": "prisma generate && nest build",
     "dev": "prisma generate && prisma migrate deploy && nest start --watch",
@@ -39,11 +39,13 @@
   "devDependencies": {
     "@nestjs/cli": "^10.4.7",
     "@nestjs/schematics": "^10.2.3",
+    "@swc/core": "^1.16.2",
     "@types/express": "^5.0.0",
     "@types/node": "^22.9.0",
     "@types/ssh2": "^1.15.5",
     "@vitest/coverage-v8": "^2.1.4",
     "typescript": "^5.6.3",
+    "unplugin-swc": "^1.5.11",
     "vitest": "^2.1.4"
   }
 }

--- a/apps/api/test/integration/cdc-sync.itest.ts
+++ b/apps/api/test/integration/cdc-sync.itest.ts
@@ -1,0 +1,244 @@
+/**
+ * End-to-end change data capture: a row written to a real source database must
+ * appear in a real destination database, through the actual application.
+ *
+ * This boots the real Nest DI container against the real metadata store and
+ * drives the real services — no stubs anywhere. It is the test that gives the
+ * CDC pipeline's correctness claims any weight, and the safety net for the
+ * throughput work that restructures that pipeline.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { INestApplicationContext } from '@nestjs/common';
+import { applyTestEnv } from './env';
+import { TEST_CONNECTIONS, uniqueTable, waitFor, withAdapter } from './harness';
+
+// env must be in place before the app module is evaluated: runtimeConfig reads
+// process.env at import time, so a static import would bind the real .env
+applyTestEnv();
+
+let ctx: INestApplicationContext;
+let connections: any;
+let bridges: any;
+let cdc: any;
+
+/** ids of things to tear down, newest first */
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  const { NestFactory } = await import('@nestjs/core');
+  const { AppModule } = await import('../../src/app.module');
+  const { ConnectionStoreService } = await import(
+    '../../src/connections/connection-store.service'
+  );
+  const { BridgeStoreService } = await import(
+    '../../src/bridges/bridge-store.service'
+  );
+  const { BridgeCdcService } = await import(
+    '../../src/bridges/bridge-cdc.service'
+  );
+
+  ctx = await NestFactory.createApplicationContext(AppModule, { logger: false });
+  connections = ctx.get(ConnectionStoreService);
+  bridges = ctx.get(BridgeStoreService);
+  cdc = ctx.get(BridgeCdcService);
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await ctx?.close().catch(() => undefined);
+});
+
+/** register a source connection in the app for one of the test engines */
+async function connectionFor(engine: 'postgres' | 'mysql'): Promise<string> {
+  const t = TEST_CONNECTIONS[engine]!;
+  const conn = await connections.create({
+    name: `it-${engine}-${Date.now()}`,
+    engine,
+    host: t.host,
+    port: t.port,
+    user: t.user,
+    password: t.password,
+    database: t.database,
+  });
+  return conn.id;
+}
+
+interface SyncSetup {
+  bridgeId: string;
+  sourceTable: string;
+  destTable: string;
+}
+
+/**
+ * Build a live CDC bridge from a fresh Postgres table into a destination table
+ * on `destEngine`, and start it. Returns once the stream is running.
+ */
+async function startBridge(
+  destEngine: 'postgres' | 'mysql',
+  sourceConnId: string,
+  destConnId: string,
+): Promise<SyncSetup> {
+  const sourceTable = uniqueTable('src');
+  const destTable = uniqueTable('dst');
+
+  await withAdapter('postgres', async (a) => {
+    await a.createTable({
+      table: sourceTable,
+      columns: [
+        { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+        { name: 'name', type: 'text', nullable: true },
+      ],
+    });
+  });
+  cleanups.push(async () => {
+    await withAdapter('postgres', (a) => a.dropTable(sourceTable)).catch(
+      () => undefined,
+    );
+  });
+  cleanups.push(async () => {
+    await withAdapter(destEngine, (a) => a.dropTable(destTable)).catch(
+      () => undefined,
+    );
+  });
+
+  // parse through the real schema so defaults (delivery, transform, write
+  // modes) are applied exactly as the HTTP layer applies them
+  const { bridgeInputSchema } = await import('@syncle/core');
+  const input = bridgeInputSchema.parse({
+    name: `it-bridge-${sourceTable}`,
+    source: { kind: 'table', connectionId: sourceConnId, table: sourceTable },
+    destination: {
+      kind: 'database',
+      targets: [
+        {
+          connectionId: destConnId,
+          table: destTable,
+          writeMode: 'upsert',
+          keyColumns: ['id'],
+          createMissingTable: true,
+        },
+      ],
+    },
+    transform: { template: '{{$row}}' },
+    trigger: { kind: 'cdc', operations: ['insert', 'update', 'delete'] },
+  });
+  const bridge = await bridges.create(input);
+
+  await cdc.start(bridge.id);
+  cleanups.push(async () => {
+    await cdc.stop(bridge.id).catch(() => undefined);
+    await cdc.cleanup(bridge.id).catch(() => undefined);
+  });
+
+  return { bridgeId: bridge.id, sourceTable, destTable };
+}
+
+/** rows currently in the destination table, sorted by id */
+async function destRows(
+  engine: 'postgres' | 'mysql',
+  table: string,
+): Promise<Array<Record<string, unknown>>> {
+  return withAdapter(engine, async (a) => {
+    try {
+      const res = await a.browse({ table, limit: 1000, offset: 0 });
+      return [...res.rows].sort((x, y) => Number(x.id) - Number(y.id));
+    } catch {
+      return []; // table not created yet — the sink creates it on first write
+    }
+  });
+}
+
+describe('postgres -> postgres CDC', () => {
+  let setup: SyncSetup;
+
+  beforeAll(async () => {
+    const src = await connectionFor('postgres');
+    const dst = await connectionFor('postgres');
+    setup = await startBridge('postgres', src, dst);
+  }, 120_000);
+
+  it('propagates an insert', async () => {
+    await withAdapter('postgres', (a) =>
+      a.insertRow({ table: setup.sourceTable, values: { id: 1, name: 'alpha' } }),
+    );
+    const rows = await waitFor('insert to arrive', async () => {
+      const r = await destRows('postgres', setup.destTable);
+      return r.length === 1 ? r : null;
+    });
+    expect(rows[0]).toMatchObject({ id: 1, name: 'alpha' });
+  });
+
+  it('propagates an update', async () => {
+    await withAdapter('postgres', (a) =>
+      a.updateRow({
+        table: setup.sourceTable,
+        identity: { id: 1 },
+        changes: { name: 'alpha-updated' },
+      }),
+    );
+    const rows = await waitFor('update to arrive', async () => {
+      const r = await destRows('postgres', setup.destTable);
+      return r[0]?.name === 'alpha-updated' ? r : null;
+    });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('propagates a delete', async () => {
+    await withAdapter('postgres', (a) =>
+      a.deleteRow({ table: setup.sourceTable, identity: { id: 1 } }),
+    );
+    await waitFor('delete to arrive', async () => {
+      const r = await destRows('postgres', setup.destTable);
+      return r.length === 0 ? true : null;
+    });
+    expect(await destRows('postgres', setup.destTable)).toHaveLength(0);
+  });
+
+  it('propagates a burst of rows, exactly once each', async () => {
+    const total = 200;
+    await withAdapter('postgres', async (a) => {
+      await a.insertRows?.({
+        table: setup.sourceTable,
+        rows: Array.from({ length: total }, (_, i) => ({
+          id: i + 100,
+          name: `burst-${i}`,
+        })),
+      });
+    });
+    const rows = await waitFor(
+      `all ${total} burst rows`,
+      async () => {
+        const r = await destRows('postgres', setup.destTable);
+        return r.length === total ? r : null;
+      },
+      { timeoutMs: 90_000 },
+    );
+    // no duplicates: ids must be unique and complete
+    const ids = rows.map((r) => Number(r.id)).sort((a, b) => a - b);
+    expect(new Set(ids).size).toBe(total);
+    expect(ids[0]).toBe(100);
+    expect(ids[total - 1]).toBe(100 + total - 1);
+  });
+});
+
+describe('postgres -> mysql CDC (cross engine)', () => {
+  let setup: SyncSetup;
+
+  beforeAll(async () => {
+    const src = await connectionFor('postgres');
+    const dst = await connectionFor('mysql');
+    setup = await startBridge('mysql', src, dst);
+  }, 120_000);
+
+  it('moves rows across engines', async () => {
+    await withAdapter('postgres', (a) =>
+      a.insertRow({ table: setup.sourceTable, values: { id: 7, name: 'cross' } }),
+    );
+    const rows = await waitFor('cross-engine row', async () => {
+      const r = await destRows('mysql', setup.destTable);
+      return r.length === 1 ? r : null;
+    });
+    expect(rows[0]).toMatchObject({ id: 7, name: 'cross' });
+  });
+});

--- a/apps/api/test/integration/env.ts
+++ b/apps/api/test/integration/env.ts
@@ -1,0 +1,27 @@
+/**
+ * Environment for the end-to-end tests.
+ *
+ * `runtimeConfig` reads process.env at module-evaluation time, so these must be
+ * set BEFORE anything imports the app. Test files therefore call
+ * `applyTestEnv()` and only then `await import()` the Nest module — a static
+ * import would be hoisted above the assignment and pick up the real .env.
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** metadata store for the app under test — separate from the synced databases */
+export const META_DB_URL =
+  'postgresql://syncle:syncle@127.0.0.1:55432/syncle_meta?schema=public';
+
+export const TEST_REDIS_URL = 'redis://127.0.0.1:56379';
+
+export function applyTestEnv(): void {
+  process.env.DATABASE_URL = META_DB_URL;
+  process.env.REDIS_URL = TEST_REDIS_URL;
+  process.env.SYNCLE_DATA_DIR ??= mkdtempSync(join(tmpdir(), 'syncle-data-'));
+  // a fixed, base64-encoded 32-byte key: deterministic so encrypted
+  // connection secrets round-trip within a run. Test-only value.
+  process.env.SYNCLE_MASTER_KEY ??= 'BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=';
+  process.env.NODE_ENV = 'test';
+}

--- a/apps/api/test/integration/global-setup.ts
+++ b/apps/api/test/integration/global-setup.ts
@@ -6,9 +6,12 @@
  * waits for every engine to accept connections, so a slow container start
  * surfaces as a clear message instead of a pile of connection-refused failures.
  */
+import { execFileSync } from 'node:child_process';
+import { Client } from 'pg';
 import { MongoClient } from 'mongodb';
 import { bootstrapDrivers, createAdapter } from '@syncle/core/adapters';
 import { TEST_CONNECTIONS } from './harness';
+import { META_DB_URL, applyTestEnv } from './env';
 
 const MONGO_DIRECT = 'mongodb://127.0.0.1:57017/?directConnection=true';
 
@@ -71,8 +74,41 @@ async function waitForEngine(name: string): Promise<void> {
   );
 }
 
+/**
+ * The app's own metadata store. Created here rather than by compose so the
+ * schema is migrated with the real Prisma migrations — the same ones production
+ * runs — instead of a hand-written approximation.
+ */
+async function prepareMetadataDatabase(): Promise<void> {
+  const admin = new Client({
+    host: '127.0.0.1',
+    port: 55432,
+    user: 'syncle',
+    password: 'syncle',
+    database: 'syncle_test',
+  });
+  await admin.connect();
+  try {
+    const exists = await admin.query(
+      'select 1 from pg_database where datname = $1',
+      ['syncle_meta'],
+    );
+    if (exists.rowCount === 0) await admin.query('create database syncle_meta');
+  } finally {
+    await admin.end().catch(() => undefined);
+  }
+
+  execFileSync('npx', ['prisma', 'migrate', 'deploy'], {
+    cwd: new URL('../..', import.meta.url).pathname,
+    env: { ...process.env, DATABASE_URL: META_DB_URL },
+    stdio: 'pipe',
+  });
+}
+
 export async function setup(): Promise<void> {
+  applyTestEnv();
   bootstrapDrivers();
   await initReplicaSet();
   for (const name of Object.keys(TEST_CONNECTIONS)) await waitForEngine(name);
+  await prepareMetadataDatabase();
 }

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config';
+import swc from 'unplugin-swc';
 
 /**
  * Integration suite: runs against the REAL databases in docker-compose.test.yml.
@@ -10,10 +11,15 @@ import { defineConfig } from 'vitest/config';
  * (which has no config and uses vitest's default `*.test.ts` glob) never picks
  * these up and never needs Docker.
  *
+ * Compiled with SWC rather than vitest's default esbuild: Nest resolves
+ * constructor dependencies from `emitDecoratorMetadata`, which esbuild does
+ * not emit. Without this every injected dependency arrives as undefined.
+ *
  * Single-threaded and serial: these tests create replication slots, hold binlog
  * readers open and write to shared tables, so parallel files would interfere.
  */
 export default defineConfig({
+  plugins: [swc.vite({ module: { type: 'es6' } })],
   test: {
     include: ['test/integration/**/*.itest.ts'],
     globalSetup: ['test/integration/global-setup.ts'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,10 +80,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.4.7
-        version: 10.4.9(@swc/core@1.15.46)
+        version: 10.4.9(@swc/core@1.16.2)(esbuild@0.21.5)
       '@nestjs/schematics':
         specifier: ^10.2.3
         version: 10.2.3(chokidar@3.6.0)(typescript@5.9.3)
+      '@swc/core':
+        specifier: ^1.16.2
+        version: 1.16.2
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -99,6 +102,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      unplugin-swc:
+        specifier: ^1.5.11
+        version: 1.5.11(@swc/core@1.16.2)(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
       vitest:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@22.19.19)(terser@5.48.0)
@@ -736,6 +742,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -1510,6 +1519,15 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.61.0':
     resolution: {integrity: sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==}
     cpu: [arm]
@@ -1663,8 +1681,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@swc/core-darwin-arm64@1.16.2':
+    resolution: {integrity: sha512-i/j0HNbnn79qnTVPicvay92Nark8fW8NQqn1e2mGERjUXNpBV0+SwQxlRpk2zBhn6laJ8PDI6Kn1nHZhnz3LCA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@swc/core-darwin-x64@1.15.46':
     resolution: {integrity: sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.16.2':
+    resolution: {integrity: sha512-HrwqHyEyHVXO3qTk8EkNK7/b6sOZSEoNh+pot6RdE5x0LbNqfo8LtJUvi3UTXr+5ja/o5HbJdW80eCXo+NjbiA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -1675,8 +1705,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@swc/core-linux-arm-gnueabihf@1.16.2':
+    resolution: {integrity: sha512-MdXi83Z/gGp1LIrg+h7HKxiul/z/Bty/ZJSvYAFqDl9zteC1XLSAZdScquKtXPp50rdyXqritTDCqQBhwVfZKA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
   '@swc/core-linux-arm64-gnu@1.15.46':
     resolution: {integrity: sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-gnu@1.16.2':
+    resolution: {integrity: sha512-/jcTmK6Ktz3owM3YtiKvjofV6p3VpHnYzTIrOGwDIOsDigRAAVuZ8east33wYO/7UTdKYFlyHNnJNT0WJqOA3Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1689,8 +1732,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@swc/core-linux-arm64-musl@1.16.2':
+    resolution: {integrity: sha512-4gFarKaFnlJTSlJYKmMhV4u+3YE4uYfiydpBoYjmgQhCf9lAieOq+WilZaK9vVSHeqLuQpTEiGULZqAdsRX5Dw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@swc/core-linux-ppc64-gnu@1.15.46':
     resolution: {integrity: sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-ppc64-gnu@1.16.2':
+    resolution: {integrity: sha512-syqSLGd6KlZ1PciNzs6bIUlhOuFztZufebOHaERjc4N4SqNZxyqYd4I+jj/EfOYnpe0kNjccn9HJLN1p5dz3+w==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
@@ -1703,8 +1760,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@swc/core-linux-s390x-gnu@1.16.2':
+    resolution: {integrity: sha512-ZBBLK+ewGyXLzWeMS7wbKtWBdnif6etn7xvPY/iOfbdsjX/+bgkp1pQt2lWF2wlu2hXYZuhJ/tHZE/QR8/apzg==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@swc/core-linux-x64-gnu@1.15.46':
     resolution: {integrity: sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.16.2':
+    resolution: {integrity: sha512-LyHJgxCA4Tje0ysBMbEb0tt/ie8kgUKoFE3JAKFhpevmTmhYEoC0H9s47WuDsqiFckF1ITUguZIXJG6K5e0dvg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1717,8 +1788,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@swc/core-linux-x64-musl@1.16.2':
+    resolution: {integrity: sha512-PghXJlVM1cgtLfNUR1vxFo1z+PDRAe8cWAJlZZ7spmeiN7BospGXg/MHUg7oNSgwSX7Zo//YKv9P5yD9apsFJQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@swc/core-win32-arm64-msvc@1.15.46':
     resolution: {integrity: sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-arm64-msvc@1.16.2':
+    resolution: {integrity: sha512-StTOSefYBxemvNYYUI3UmO1a8y+hSPjjfHogC2TEHL+Z1PlEBim/XtLas5rS04jAzT9RrNmbtX911SZ42H9jSQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -1729,14 +1813,35 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@swc/core-win32-ia32-msvc@1.16.2':
+    resolution: {integrity: sha512-fycER209DYIzsibpTMC+chND05OfOjgztWL9U8OE6/uUlsOUZH3eh98isBLEnOymYUhlJLEt5++W1+KL/FOh5Q==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
   '@swc/core-win32-x64-msvc@1.15.46':
     resolution: {integrity: sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
+  '@swc/core-win32-x64-msvc@1.16.2':
+    resolution: {integrity: sha512-cSd1z6ivSrJPVr+moVwOHWjeKy6TpO4/Shwcv5KCrKYXCccxwh4pRy1C3fDioNx2PF1jPZWHKZjtXt+Be9VbaQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
   '@swc/core@1.15.46':
     resolution: {integrity: sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/core@1.16.2':
+    resolution: {integrity: sha512-95I4kiSMeveI/Mhi+tE4fiWcWLUMfzfKrk0jtr8LRMqHgOgq+xHS+zExkDqoO4b5OeeuXHMWVdD5MeP3X6sULw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'
@@ -1752,6 +1857,9 @@ packages:
 
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tanstack/query-core@5.100.14':
     resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
@@ -2969,6 +3077,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -3528,6 +3639,10 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
@@ -4896,6 +5011,44 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin-swc@1.5.11:
+    resolution: {integrity: sha512-R7U4GbfrESPnYLn3nXREZrwhKQk3BAmTBoKJ5lmo7btTc/yJpNsDzavBWo+XpQTjDSIogiZEAxC5ig/vfMWxWg==}
+    peerDependencies:
+      '@swc/core': ^1.2.108
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -5031,6 +5184,9 @@ packages:
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   webpack@5.97.1:
     resolution: {integrity: sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==}
@@ -5510,6 +5666,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.11':
@@ -5584,7 +5745,7 @@ snapshots:
       bullmq: 5.78.0
       tslib: 2.8.1
 
-  '@nestjs/cli@10.4.9(@swc/core@1.15.46)':
+  '@nestjs/cli@10.4.9(@swc/core@1.16.2)(esbuild@0.21.5)':
     dependencies:
       '@angular-devkit/core': 17.3.11(chokidar@3.6.0)
       '@angular-devkit/schematics': 17.3.11(chokidar@3.6.0)
@@ -5594,7 +5755,7 @@ snapshots:
       chokidar: 3.6.0
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.15.46))
+      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
       glob: 10.4.5
       inquirer: 8.2.6
       node-emoji: 1.11.0
@@ -5603,10 +5764,10 @@ snapshots:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.7.2
-      webpack: 5.97.1(@swc/core@1.15.46)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/core': 1.15.46
+      '@swc/core': 1.16.2
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -6271,6 +6432,14 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rollup/pluginutils@5.4.0(rollup@4.61.0)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.61.0
+
   '@rollup/rollup-android-arm-eabi@4.61.0':
     optional: true
 
@@ -6355,37 +6524,73 @@ snapshots:
   '@swc/core-darwin-arm64@1.15.46':
     optional: true
 
+  '@swc/core-darwin-arm64@1.16.2':
+    optional: true
+
   '@swc/core-darwin-x64@1.15.46':
+    optional: true
+
+  '@swc/core-darwin-x64@1.16.2':
     optional: true
 
   '@swc/core-linux-arm-gnueabihf@1.15.46':
     optional: true
 
+  '@swc/core-linux-arm-gnueabihf@1.16.2':
+    optional: true
+
   '@swc/core-linux-arm64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.16.2':
     optional: true
 
   '@swc/core-linux-arm64-musl@1.15.46':
     optional: true
 
+  '@swc/core-linux-arm64-musl@1.16.2':
+    optional: true
+
   '@swc/core-linux-ppc64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.16.2':
     optional: true
 
   '@swc/core-linux-s390x-gnu@1.15.46':
     optional: true
 
+  '@swc/core-linux-s390x-gnu@1.16.2':
+    optional: true
+
   '@swc/core-linux-x64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.16.2':
     optional: true
 
   '@swc/core-linux-x64-musl@1.15.46':
     optional: true
 
+  '@swc/core-linux-x64-musl@1.16.2':
+    optional: true
+
   '@swc/core-win32-arm64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.16.2':
     optional: true
 
   '@swc/core-win32-ia32-msvc@1.15.46':
     optional: true
 
+  '@swc/core-win32-ia32-msvc@1.16.2':
+    optional: true
+
   '@swc/core-win32-x64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.16.2':
     optional: true
 
   '@swc/core@1.15.46':
@@ -6406,6 +6611,24 @@ snapshots:
       '@swc/core-win32-ia32-msvc': 1.15.46
       '@swc/core-win32-x64-msvc': 1.15.46
 
+  '@swc/core@1.16.2':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.16.2
+      '@swc/core-darwin-x64': 1.16.2
+      '@swc/core-linux-arm-gnueabihf': 1.16.2
+      '@swc/core-linux-arm64-gnu': 1.16.2
+      '@swc/core-linux-arm64-musl': 1.16.2
+      '@swc/core-linux-ppc64-gnu': 1.16.2
+      '@swc/core-linux-s390x-gnu': 1.16.2
+      '@swc/core-linux-x64-gnu': 1.16.2
+      '@swc/core-linux-x64-musl': 1.16.2
+      '@swc/core-win32-arm64-msvc': 1.16.2
+      '@swc/core-win32-ia32-msvc': 1.16.2
+      '@swc/core-win32-x64-msvc': 1.16.2
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -6413,6 +6636,10 @@ snapshots:
       tslib: 2.8.1
 
   '@swc/types@0.1.27':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  '@swc/types@0.1.28':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -7858,6 +8085,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -8008,7 +8237,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.15.46)):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -8023,7 +8252,7 @@ snapshots:
       semver: 7.8.1
       tapable: 2.3.3
       typescript: 5.7.2
-      webpack: 5.97.1(@swc/core@1.15.46)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
 
   forwarded@0.2.0: {}
 
@@ -8504,6 +8733,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.2: {}
 
@@ -9689,15 +9920,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.46)(webpack@5.97.1(@swc/core@1.15.46)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.16.2)(esbuild@0.21.5)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.97.1(@swc/core@1.15.46)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
     optionalDependencies:
-      '@swc/core': 1.15.46
+      '@swc/core': 1.16.2
+      esbuild: 0.21.5
 
   terser@5.48.0:
     dependencies:
@@ -9866,6 +10098,34 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-swc@1.5.11(@swc/core@1.16.2)(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
+      '@swc/core': 1.16.2
+      load-tsconfig: 0.2.5
+      unplugin: 3.3.0(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  unplugin@3.3.0(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.21.5
+      rollup: 4.61.0
+      vite: 5.4.21(@types/node@22.19.19)(terser@5.48.0)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -10016,7 +10276,9 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.97.1(@swc/core@1.15.46):
+  webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -10038,7 +10300,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.46)(webpack@5.97.1(@swc/core@1.15.46))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.16.2)(esbuild@0.21.5)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
Stacked on #65. Still no product code — this is the safety net for the CDC restructure that follows.

## What

The test that actually proves syncing works. It boots the real Nest DI container against a migrated metadata store, creates real connections and a real CDC bridge, writes to a real Postgres table, and waits for the rows to land in a real destination. No stubs in the path.

Covers insert, update and delete propagation, a 200-row burst arriving exactly once (no duplicates, no gaps), and a cross-engine Postgres → MySQL sync.

## Two things this needed

**SWC instead of esbuild** for the integration config. Nest resolves constructor dependencies from `emitDecoratorMetadata`, which esbuild does not emit — every injected dependency arrives as `undefined`. That is why the existing unit tests construct their services by hand rather than through DI.

**Bridge input parsed through the real `bridgeInputSchema`**, so schema defaults are applied exactly as the HTTP layer applies them.

The metadata database is created and migrated with the production Prisma migrations in global setup, so the schema under test is the shipped one rather than a hand-written approximation.