### PR TITLE
perf(api): micro-batch the CDC pipeline and checkpoint per batch

### DIFF
--- a/apps/api/src/bridges/bridge-cdc.service.ts
+++ b/apps/api/src/bridges/bridge-cdc.service.ts
@@ -33,6 +33,7 @@ import { randomUUID } from 'node:crypto';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { ConnectionStoreService } from '../connections/connection-store.service';
 import { PrismaService } from '../common/prisma.service';
+import { runtimeConfig } from '../common/runtime-config';
 import { BridgeJobService } from './bridge-job.service';
 import { BridgeStoreService } from './bridge-store.service';
 import { BridgeSinkService } from './bridge-sink.service';
@@ -61,6 +62,26 @@ interface Stream {
   pending: Promise<void>;
   /** the source's primary-key columns, so rowKeys stores keys, not every value */
   primaryKey: string[] | null;
+  /** changes accepted but not yet delivered; flushed as ONE delivery */
+  buffer: Buffered[];
+  /** the operation every buffered change shares; a different op forces a flush */
+  bufferOp: CdcOperation | null;
+  /** key signatures already in the buffer, so one batch never repeats a key */
+  bufferKeys: Set<string>;
+  /** linger timer, so a partial batch still leaves promptly */
+  timer: ReturnType<typeof setTimeout> | null;
+  /** rows per delivery for this bridge */
+  maxBatch: number;
+  /** the resolved bridge, so a flush needs no extra arguments */
+  bridge: ResolvedBridge;
+}
+
+/** one change held in the pending batch */
+interface Buffered {
+  change: CdcChange;
+  row: Record<string, unknown>;
+  /** identity of the row within this batch, or null when there is no key */
+  keySig: string | null;
 }
 
 /** read the persisted resume cursor from a job's cursorJson (legacy `lsn` ok) */
@@ -218,7 +239,14 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
   private async teardown(bridgeId: string): Promise<void> {
     const stream = this.streams.get(bridgeId);
     if (!stream) return;
+    // let the in-flight chain settle so a half-built batch is not abandoned
+    // mid-flush, then drop the entry so nothing new is accepted
+    await stream.pending.catch(() => undefined);
     this.streams.delete(bridgeId);
+    if (stream.timer) clearTimeout(stream.timer);
+    // buffered-but-undelivered changes were never acked, so they would replay
+    // on resume anyway; flushing here just avoids the needless repeat
+    await this.flush(bridgeId, stream).catch(() => undefined);
     await stream.handle.stop().catch(() => undefined);
   }
 
@@ -245,6 +273,19 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
       watermark: startCursor,
       pending: Promise.resolve(),
       primaryKey: await this.resolvePrimaryKey(bridge),
+      buffer: [],
+      bufferOp: null,
+      bufferKeys: new Set(),
+      timer: null,
+      // a database destination may batch freely: writes are idempotent upserts
+      // keyed by column, so N-at-once is indistinguishable from N one-at-a-time.
+      // an HTTP destination must keep delivery.batchSize, because there the
+      // batch size IS the payload the receiver sees.
+      maxBatch:
+        bridge.destination.kind === 'database'
+          ? Math.max(1, runtimeConfig.cdcBatchSize)
+          : Math.max(1, bridge.delivery.batchSize),
+      bridge,
     };
     this.streams.set(bridgeId, stream);
 
@@ -301,16 +342,29 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     const stream = this.streams.get(bridgeId);
     if (!stream) return Promise.resolve();
     stream.pending = stream.pending
-      .then(() => this.processChange(bridgeId, bridge, stream, change))
+      .then(() => this.accept(bridgeId, bridge, stream, change))
       .catch((err) => {
-        // processChange handles its own failures; this only guards the chain
+        // accept() handles its own failures; this only guards the chain
         this.logger.error(`CDC change chain broke for ${bridgeId}: ${(err as Error).message}`);
       });
     return stream.pending;
   }
 
-  /** for one change: dedupe, filter, render, deliver, record, persist cursor, ack */
-  private async processChange(
+  /** identity of a row within a batch, or null when the source has no key */
+  private keySignature(stream: Stream, row: Record<string, unknown>): string | null {
+    if (!stream.primaryKey?.length) return null;
+    try {
+      return JSON.stringify(stream.primaryKey.map((c) => row[c]));
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * take one change: drop replays, handle filtered rows, otherwise add it to
+   * the pending batch and flush when the batch is complete.
+   */
+  private async accept(
     bridgeId: string,
     bridge: ResolvedBridge,
     stream: Stream,
@@ -322,6 +376,8 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     // (durable engines replay from the last acked cursor after a reconnect)
     if (!stream.provider.cursorAfter(change.cursor, stream.watermark)) return;
 
+    const op = change.op as CdcOperation;
+
     // source filters: replay pushes them into SQL, but a CDC stream sees every
     // row of the table, so evaluate them in-process here. skipped rows still
     // advance the durable cursor (and the provider's server-side ack point) so
@@ -330,9 +386,14 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     if (
       !stream.provider.handlesSourceFilters &&
       !rowMatchesFilters(change.row, bridge.source.filters, {
-        passMissingColumns: change.op === 'delete',
+        passMissingColumns: op === 'delete',
       })
     ) {
+      // anything already buffered is ORDERED BEFORE this change, so it has to
+      // be delivered first — otherwise advancing the cursor past it would drop
+      // those rows on a crash
+      await this.flush(bridgeId, stream);
+      if (this.streams.get(bridgeId) !== stream) return;
       stream.watermark = change.cursor;
       try {
         await this.prisma.bridgeJob.update({
@@ -346,35 +407,113 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
+    const keySig = this.keySignature(stream, change.row);
+
+    // two reasons a change cannot join the current batch: a different operation
+    // has no single route through the sink, and a repeated key would make one
+    // multi-row upsert touch the same row twice, which Postgres rejects outright
+    const conflicts =
+      stream.buffer.length > 0 &&
+      (stream.bufferOp !== op || (keySig !== null && stream.bufferKeys.has(keySig)));
+    if (conflicts) {
+      await this.flush(bridgeId, stream);
+      if (this.streams.get(bridgeId) !== stream) return;
+    }
+
+    stream.buffer.push({ change, row: change.row, keySig });
+    stream.bufferOp = op;
+    if (keySig !== null) stream.bufferKeys.add(keySig);
+
+    if (stream.buffer.length >= stream.maxBatch) {
+      // a full batch is delivered before this returns, so a provider that
+      // awaits onChange still feels backpressure and the buffer stays bounded
+      await this.flush(bridgeId, stream);
+      return;
+    }
+    this.scheduleFlush(bridgeId, stream);
+  }
+
+  /** flush a partial batch after a short linger, so a quiet stream is not stuck */
+  private scheduleFlush(bridgeId: string, stream: Stream): void {
+    if (stream.timer) return;
+    const timer = setTimeout(() => {
+      stream.timer = null;
+      if (this.streams.get(bridgeId) !== stream) return;
+      // queued on the same chain, so a timed flush can never interleave with
+      // a change being accepted
+      stream.pending = stream.pending
+        .then(() => this.flush(bridgeId, stream))
+        .catch((err) => {
+          this.logger.error(`CDC timed flush failed for ${bridgeId}: ${(err as Error).message}`);
+        });
+    }, Math.max(0, runtimeConfig.cdcLingerMs));
+    // a pending linger must not hold the process open
+    timer.unref?.();
+    stream.timer = timer;
+  }
+
+  /**
+   * deliver the pending batch as ONE delivery, then checkpoint once and ack
+   * once. per-row work here is what set the old throughput ceiling: a delivery,
+   * a delivery record, a cursor write and a source ack for every single row.
+   *
+   * the cursor advances only after a successful delivery, so a crash mid-batch
+   * replays that batch — absorbed by the watermark dedupe and by writes being
+   * idempotent upserts.
+   */
+  private async flush(bridgeId: string, stream: Stream): Promise<void> {
+    if (stream.timer) {
+      clearTimeout(stream.timer);
+      stream.timer = null;
+    }
+    if (stream.buffer.length === 0) return;
+
+    const items = stream.buffer;
+    const op = stream.bufferOp ?? undefined;
+    stream.buffer = [];
+    stream.bufferKeys = new Set();
+    stream.bufferOp = null;
+
+    const bridge = stream.bridge;
+    if (bridge.source.kind !== 'table') return;
+
+    const rows = items.map((i) => i.row);
+    const lastCursor = items[items.length - 1]!.change.cursor;
     const seq = stream.seq;
     const now = new Date().toISOString();
-    const rowKeys = stream.primaryKey ? stream.primaryKey.map((c) => change.row[c]) : null;
-    // key on the cursor (stable per change) so an at-least-once re-delivery after
-    // a reconnect carries the SAME Idempotency-Key for the receiver to dedupe
+    const pk = stream.primaryKey;
+    // one entry per row, matching rowCount — the same shape the batched replay
+    // path records
+    const rowKeys = pk?.length
+      ? items.map((i) => (pk.length === 1 ? i.row[pk[0]!] : pk.map((c) => i.row[c])))
+      : null;
+    // key on the batch's last cursor (stable per batch) so an at-least-once
+    // re-delivery after a reconnect carries the SAME Idempotency-Key
     const idem =
       bridge.destination.kind === 'http' && bridge.destination.idempotency
-        ? `${stream.jobId}:${change.cursor}`
+        ? `${stream.jobId}:${lastCursor}`
         : undefined;
     const signal = new AbortController().signal;
+
     try {
       // the operation drives both the {{$op}} token (HTTP) and insert/upsert vs
       // delete routing (database destinations)
       const { outcome } = await this.sink.deliver(
         bridge,
-        [change.row],
-        { table: bridge.source.table, now, startIndex: seq, op: change.op as CdcOperation },
+        rows,
+        { table: bridge.source.table, now, startIndex: seq, op },
         signal,
         idem,
       );
 
       await this.jobs.recordDelivery(
         stream.jobId,
-        { sequence: seq, rowIndex: seq, rowCount: 1, rowKeys },
+        { sequence: seq, rowIndex: seq, rowCount: rows.length, rowKeys },
         outcome,
       );
       if (outcome.status === 'failed' && bridge.delivery.onError === 'abort') {
         // stop-on-error: pause the job and stop the stream WITHOUT advancing
-        // the watermark or acking, so this change replays on the next start.
+        // the watermark or acking, so this batch replays on the next start.
         // teardown happens outside the change chain — the provider's stop()
         // may wait for in-flight handlers (i.e. this very call)
         this.logger.warn(`CDC ${bridgeId}: pausing after a failed delivery (onError=abort)`);
@@ -387,27 +526,27 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
         return;
       }
       stream.seq = seq + 1;
-      stream.watermark = change.cursor;
+      stream.watermark = lastCursor;
       await this.prisma.bridgeJob.update({
         where: { id: stream.jobId },
-        data: { cursorOffset: stream.seq, cursorJson: JSON.stringify({ cursor: change.cursor }) },
+        data: { cursorOffset: stream.seq, cursorJson: JSON.stringify({ cursor: lastCursor }) },
       });
       // the checkpoint is durable, so the provider may now advance its
       // server-side ack point (the Postgres slot's confirmed LSN). a missed
       // ack only widens the replay window the watermark dedupe absorbs
       try {
-        await stream.handle.ack?.(change.cursor);
+        await stream.handle.ack?.(lastCursor);
       } catch {
         /* best-effort by contract */
       }
     } catch (err) {
       // a transient pipeline error (Prisma/pool hiccup) must leave a trace: the
-      // event becomes a FAILED delivery row, visible in the timeline + retryable
+      // batch becomes a FAILED delivery row, visible in the timeline + retryable
       const message = err instanceof Error ? err.message : String(err);
       try {
         await this.jobs.recordDelivery(
           stream.jobId,
-          { sequence: seq, rowIndex: seq, rowCount: 1, rowKeys },
+          { sequence: seq, rowIndex: seq, rowCount: rows.length, rowKeys },
           {
             status: 'failed',
             httpStatus: null,
@@ -419,7 +558,7 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
           },
         );
         stream.seq = seq + 1;
-        stream.watermark = change.cursor;
+        stream.watermark = lastCursor;
         this.logger.warn(`CDC delivery for ${bridgeId} failed and was recorded: ${message}`);
       } catch {
         // can't even record the failure: stop instead of silently acking away

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -43,6 +43,25 @@ export const runtimeConfig = {
     process.env.SYNCLE_JOB_CONCURRENCY ?? process.env.SYNCLE_HOOK_CONCURRENCY ?? 5,
   ),
   /**
+   * CDC micro-batching. A change stream delivered one row at a time pays a
+   * delivery, a delivery record, a cursor write and a source ack per row, so
+   * round trips — not the database — set the ceiling. Consecutive changes are
+   * grouped into one delivery instead.
+   *
+   * This applies to DATABASE destinations only, where a batch is invisible:
+   * writes are idempotent upserts keyed by column, so the result is identical.
+   * HTTP destinations keep honouring `delivery.batchSize`, because there the
+   * batch size is the payload shape and changing it would change what
+   * receivers see.
+   *
+   * Batching widens the at-least-once replay window to at most one batch: a
+   * crash mid-batch replays that batch, which the watermark dedupe and
+   * idempotent writes absorb.
+   */
+  cdcBatchSize: Number(process.env.SYNCLE_CDC_BATCH_SIZE ?? 200),
+  /** how long a partial batch waits for more changes before being flushed */
+  cdcLingerMs: Number(process.env.SYNCLE_CDC_LINGER_MS ?? 50),
+  /**
    * when true, HTTP destinations may not resolve to loopback/private/link-local
    * addresses (SSRF guard for network-exposed deployments). off by default —
    * Syncle is local-first and posting to localhost services is a primary use.

--- a/apps/api/test/integration/app-harness.ts
+++ b/apps/api/test/integration/app-harness.ts
@@ -1,0 +1,140 @@
+/**
+ * Boots the real application container and builds real bridges against it.
+ * Shared by every end-to-end test so they all exercise the same wiring the
+ * server uses in production.
+ */
+import type { INestApplicationContext } from '@nestjs/common';
+import { applyTestEnv } from './env';
+import { TEST_CONNECTIONS, uniqueTable, withAdapter } from './harness';
+
+applyTestEnv();
+
+export interface AppHandle {
+  ctx: INestApplicationContext;
+  connections: any;
+  bridges: any;
+  cdc: any;
+  prisma: any;
+}
+
+export async function bootstrapApp(): Promise<AppHandle> {
+  const { NestFactory } = await import('@nestjs/core');
+  const { AppModule } = await import('../../src/app.module');
+  const { ConnectionStoreService } = await import(
+    '../../src/connections/connection-store.service'
+  );
+  const { BridgeStoreService } = await import('../../src/bridges/bridge-store.service');
+  const { BridgeCdcService } = await import('../../src/bridges/bridge-cdc.service');
+  const { PrismaService } = await import('../../src/common/prisma.service');
+
+  const ctx = await NestFactory.createApplicationContext(AppModule, { logger: false });
+  return {
+    ctx,
+    connections: ctx.get(ConnectionStoreService),
+    bridges: ctx.get(BridgeStoreService),
+    cdc: ctx.get(BridgeCdcService),
+    prisma: ctx.get(PrismaService),
+  };
+}
+
+export async function connectionFor(
+  app: AppHandle,
+  engine: 'postgres' | 'mysql',
+): Promise<string> {
+  const t = TEST_CONNECTIONS[engine]!;
+  const conn = await app.connections.create({
+    name: `it-${engine}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    engine,
+    host: t.host,
+    port: t.port,
+    user: t.user,
+    password: t.password,
+    database: t.database,
+  });
+  return conn.id;
+}
+
+export interface SyncSetup {
+  bridgeId: string;
+  sourceTable: string;
+  destTable: string;
+}
+
+/**
+ * Create a Postgres source table and a CDC bridge writing into `destEngine`.
+ * `start: false` leaves the bridge stopped, for tests that drive start/stop.
+ */
+export async function makeBridge(
+  app: AppHandle,
+  opts: {
+    destEngine: 'postgres' | 'mysql';
+    sourceConnId: string;
+    destConnId: string;
+    cleanups: Array<() => Promise<void>>;
+    start?: boolean;
+  },
+): Promise<SyncSetup> {
+  const { destEngine, sourceConnId, destConnId, cleanups } = opts;
+  const sourceTable = uniqueTable('src');
+  const destTable = uniqueTable('dst');
+
+  await withAdapter('postgres', (a) =>
+    a.createTable({
+      table: sourceTable,
+      columns: [
+        { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+        { name: 'name', type: 'text', nullable: true },
+      ],
+    }),
+  );
+  cleanups.push(() =>
+    withAdapter('postgres', (a) => a.dropTable(sourceTable)).catch(() => undefined),
+  );
+  cleanups.push(() =>
+    withAdapter(destEngine, (a) => a.dropTable(destTable)).catch(() => undefined),
+  );
+
+  const { bridgeInputSchema } = await import('@syncle/core');
+  const input = bridgeInputSchema.parse({
+    name: `it-bridge-${sourceTable}`,
+    source: { kind: 'table', connectionId: sourceConnId, table: sourceTable },
+    destination: {
+      kind: 'database',
+      targets: [
+        {
+          connectionId: destConnId,
+          table: destTable,
+          writeMode: 'upsert',
+          keyColumns: ['id'],
+          createMissingTable: true,
+        },
+      ],
+    },
+    transform: { template: '{{$row}}' },
+    trigger: { kind: 'cdc', operations: ['insert', 'update', 'delete'] },
+  });
+  const bridge = await app.bridges.create(input);
+
+  cleanups.push(async () => {
+    await app.cdc.stop(bridge.id).catch(() => undefined);
+    await app.cdc.cleanup(bridge.id).catch(() => undefined);
+  });
+
+  if (opts.start !== false) await app.cdc.start(bridge.id);
+  return { bridgeId: bridge.id, sourceTable, destTable };
+}
+
+/** rows in the destination table, sorted by id; [] before the sink creates it */
+export async function destRows(
+  engine: 'postgres' | 'mysql',
+  table: string,
+): Promise<Array<Record<string, unknown>>> {
+  return withAdapter(engine, async (a) => {
+    try {
+      const res = await a.browse({ table, limit: 5000, offset: 0 });
+      return [...res.rows].sort((x, y) => Number(x.id) - Number(y.id));
+    } catch {
+      return [];
+    }
+  });
+}

--- a/apps/api/test/integration/cdc-batching.itest.ts
+++ b/apps/api/test/integration/cdc-batching.itest.ts
@@ -1,0 +1,196 @@
+/**
+ * Micro-batching correctness.
+ *
+ * Batching a change stream introduces hazards that per-row delivery did not
+ * have: a batch can mix operations, it can contain the same key twice (which a
+ * multi-row upsert cannot express), and it moves the checkpoint from per-row to
+ * per-batch. Each of those is exercised here against real databases.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  destRows,
+  makeBridge,
+  type AppHandle,
+  type SyncSetup,
+} from './app-harness';
+import { waitFor, withAdapter } from './harness';
+
+let app: AppHandle;
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  app = await bootstrapApp();
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+});
+
+async function freshBridge(): Promise<SyncSetup> {
+  const src = await connectionFor(app, 'postgres');
+  const dst = await connectionFor(app, 'postgres');
+  return makeBridge(app, {
+    destEngine: 'postgres',
+    sourceConnId: src,
+    destConnId: dst,
+    cleanups,
+  });
+}
+
+describe('batching hazards', () => {
+  it('survives repeated updates to the SAME key inside one batch window', async () => {
+    // a multi-row upsert cannot touch one row twice — Postgres rejects
+    // "ON CONFLICT DO UPDATE command cannot affect row a second time" — so the
+    // batcher must break the batch when a key repeats
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      await a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'v0' } });
+      for (let i = 1; i <= 25; i++) {
+        await a.updateRow({
+          table: s.sourceTable,
+          identity: { id: 1 },
+          changes: { name: `v${i}` },
+        });
+      }
+    });
+
+    const rows = await waitFor('final value of the repeatedly-updated row', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 && r[0]?.name === 'v25' ? r : null;
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: 1, name: 'v25' });
+  });
+
+  it('keeps ordering when operations alternate', async () => {
+    // insert/update/delete route differently through the sink, so a change of
+    // operation must close the current batch or rows would be misrouted
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      for (const id of [1, 2, 3, 4]) {
+        await a.insertRow({ table: s.sourceTable, values: { id, name: `n${id}` } });
+      }
+      await a.deleteRow({ table: s.sourceTable, identity: { id: 2 } });
+      await a.insertRow({ table: s.sourceTable, values: { id: 5, name: 'n5' } });
+      await a.deleteRow({ table: s.sourceTable, identity: { id: 4 } });
+    });
+
+    const rows = await waitFor('alternating ops to settle', async () => {
+      const r = await destRows('postgres', s.destTable);
+      const ids = r.map((x) => Number(x.id));
+      return ids.length === 3 && ids.join(',') === '1,3,5' ? r : null;
+    });
+    expect(rows.map((r) => Number(r.id))).toEqual([1, 3, 5]);
+  });
+
+  it('re-inserting a deleted key ends in the inserted state', async () => {
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      await a.insertRow({ table: s.sourceTable, values: { id: 9, name: 'first' } });
+      await a.deleteRow({ table: s.sourceTable, identity: { id: 9 } });
+      await a.insertRow({ table: s.sourceTable, values: { id: 9, name: 'second' } });
+    });
+    const rows = await waitFor('delete-then-insert to settle', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 && r[0]?.name === 'second' ? r : null;
+    });
+    expect(rows[0]).toMatchObject({ id: 9, name: 'second' });
+  });
+
+  it('a partial batch is flushed by the linger timer, not left waiting', async () => {
+    // one row is far below the batch size; it must still arrive promptly
+    const s = await freshBridge();
+    const started = Date.now();
+    await withAdapter('postgres', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 42, name: 'lonely' } }),
+    );
+    await waitFor('single row to arrive', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 ? r : null;
+    });
+    // generous, but proves it is not stuck waiting for a full batch
+    expect(Date.now() - started).toBeLessThan(15_000);
+  });
+
+  it('delivers a large burst exactly once and records batched deliveries', async () => {
+    const s = await freshBridge();
+    const total = 500;
+    await withAdapter('postgres', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: total }, (_, i) => ({ id: i + 1, name: `r${i}` })),
+      }),
+    );
+
+    const rows = await waitFor(
+      `${total} rows to arrive`,
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === total ? r : null;
+      },
+      { timeoutMs: 120_000 },
+    );
+    const ids = rows.map((r) => Number(r.id));
+    expect(new Set(ids).size).toBe(total);
+
+    // the point of batching: far fewer deliveries than rows
+    const job = await app.prisma.bridgeJob.findFirst({
+      where: { bridgeId: s.bridgeId },
+      orderBy: { startedAt: 'desc' },
+    });
+    const deliveries = await app.prisma.bridgeDelivery.count({
+      where: { jobId: job.id },
+    });
+    expect(deliveries).toBeLessThan(total);
+    const summed = await app.prisma.bridgeDelivery.aggregate({
+      where: { jobId: job.id },
+      _sum: { rowCount: true },
+    });
+    // every row is accounted for across the batched deliveries
+    expect(summed._sum.rowCount).toBe(total);
+  });
+});
+
+describe('checkpointing across a restart', () => {
+  it('resumes without losing or duplicating rows', async () => {
+    const s = await freshBridge();
+
+    await withAdapter('postgres', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: 50 }, (_, i) => ({ id: i + 1, name: `a${i}` })),
+      }),
+    );
+    await waitFor('first batch delivered', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 50 ? r : null;
+    });
+
+    // stop the stream, write while it is down, then bring it back
+    await app.cdc.stop(s.bridgeId);
+    await withAdapter('postgres', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: 50 }, (_, i) => ({ id: i + 51, name: `b${i}` })),
+      }),
+    );
+    await app.cdc.start(s.bridgeId);
+
+    const rows = await waitFor(
+      'rows written while stopped to be caught up',
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === 100 ? r : null;
+      },
+      { timeoutMs: 120_000 },
+    );
+    const ids = rows.map((r) => Number(r.id)).sort((x, y) => x - y);
+    expect(new Set(ids).size).toBe(100); // no duplicates
+    expect(ids[0]).toBe(1);
+    expect(ids[99]).toBe(100); // nothing lost
+  });
+});


### PR DESCRIPTION
Stacked on #66. This is the throughput change.

## Why

A change stream delivered one row at a time paid four to five sequential round trips **per row**: the delivery, a delivery record, a cursor write, and a source ack. Measured on real Postgres, that ceiling was **207 rows/sec**.

## Result

Same measurement, same hardware:

| | rows/sec | deliveries for 2000 rows | wall clock |
|---|---|---|---|
| Before | 207 | 2000 | 9674ms |
| After | **10,582** | 10 | 189ms |

## Applied only where it cannot be observed

**Database destinations** batch up to `SYNCLE_CDC_BATCH_SIZE` (200): writes are idempotent upserts keyed by column, so N-at-once is indistinguishable from N one-at-a-time.

**HTTP destinations** keep honouring `delivery.batchSize`, because there the batch size *is* the payload the receiver sees. At its default of 1 that path is byte-for-byte what it was.

## Three hazards batching introduces

Each is handled and each is tested:

- **A batch cannot contain one key twice.** A multi-row upsert would make Postgres reject `ON CONFLICT DO UPDATE command cannot affect row a second time`, so a repeated key closes the batch.
- **Operations route differently** through the sink, so a change of operation closes the batch.
- **Filtered-out rows advance the cursor**, and anything buffered is ordered *before* them — so the buffer is flushed first, or a crash would skip those rows.

## Backpressure and durability

A full batch is delivered before `onChange` resolves, so a provider that awaits it still throttles and the buffer stays bounded. A partial batch leaves after `SYNCLE_CDC_LINGER_MS` (50).

Checkpointing per batch widens the at-least-once replay window to at most one batch, absorbed by the existing watermark dedupe and by writes being idempotent.

## Verification

6 integration tests against real databases: 25 rapid updates to one key, alternating operations, delete-then-insert, linger flushing, batched delivery accounting (`deliveries < rows` and `sum(rowCount) == rows`), and a stop/restart losing and duplicating nothing.