### PR TITLE
fix(api): guard MySQL CDC against resuming on a different server

### DIFF
--- a/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.test.ts
+++ b/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import type { AdapterPoolService } from '../../../connections/adapter-pool.service';
-import { MysqlCdcProvider, binlogEventStart } from './mysql-cdc.provider';
+import {
+  MysqlCdcProvider,
+  binlogEventStart,
+  gtidFromEvent,
+} from './mysql-cdc.provider';
 
 // cursorAfter/splitCursor are pure, the pool is only used by readiness()
 const provider = new MysqlCdcProvider(null as unknown as AdapterPoolService);
 const split = (c: string) => provider['splitCursor'](c);
+const make = (a: Parameters<MysqlCdcProvider['makeCursor']>[0]) =>
+  provider['makeCursor'](a);
+const serverOf = (c: string) => provider['cursorServer'](c);
 
 describe('splitCursor', () => {
   it('parses the current start-format cursor "file:pos:row:s"', () => {
@@ -76,5 +83,76 @@ describe('binlogEventStart (resume-position math)', () => {
   it('accounts for the 4-byte CRC32 when binlog_checksum is on', () => {
     // zongji strips the checksum from `size`, but next_position includes it
     expect(binlogEventStart({ nextPosition: 564, size: 41 }, true)).toBe(500);
+  });
+});
+
+describe('server-identity cursors', () => {
+  const base = { file: 'binlog.000007', pos: 900, row: 2, isStart: true };
+
+  it('keeps the compact legacy form when the server is unknown', () => {
+    expect(make({ ...base, serverUuid: null, gtid: null })).toBe(
+      'binlog.000007:900:2:s',
+    );
+  });
+
+  it('emits JSON carrying the server uuid when it is known', () => {
+    const c = make({ ...base, serverUuid: 'uuid-a', gtid: 'uuid-a:12' });
+    expect(serverOf(c)).toBe('uuid-a');
+    expect(provider['cursorGtid'](c)).toBe('uuid-a:12');
+  });
+
+  it('parses back to the same coordinates it was built from', () => {
+    const c = make({ ...base, serverUuid: 'uuid-a', gtid: null });
+    expect(split(c)).toEqual(['binlog.000007', 900, 2, true]);
+  });
+
+  it('reports no server for a legacy cursor', () => {
+    expect(serverOf('binlog.000007:900:2:s')).toBeNull();
+  });
+
+  it('survives a malformed JSON cursor without throwing', () => {
+    expect(serverOf('{not json')).toBeNull();
+    expect(split('{not json')).toEqual(['{not json', 0, -1, false]);
+  });
+
+  it('orders identically whether a cursor is JSON or legacy', () => {
+    // a stream upgraded mid-flight compares old watermarks against new cursors
+    const modern = make({
+      file: 'b.000001',
+      pos: 200,
+      row: 0,
+      isStart: true,
+      serverUuid: 'u1',
+      gtid: null,
+    });
+    expect(provider.cursorAfter(modern, 'b.000001:100:9:s')).toBe(true);
+    expect(provider.cursorAfter('b.000001:300:0:s', modern)).toBe(true);
+    expect(provider.cursorAfter(modern, 'b.000001:300:0:s')).toBe(false);
+    // and against another JSON cursor
+    const later = make({
+      file: 'b.000001',
+      pos: 400,
+      row: 0,
+      isStart: true,
+      serverUuid: 'u1',
+      gtid: null,
+    });
+    expect(provider.cursorAfter(later, modern)).toBe(true);
+    expect(provider.cursorAfter(modern, later)).toBe(false);
+  });
+});
+
+describe('gtidFromEvent', () => {
+  it('formats the 16-byte server id and transaction number as a GTID', () => {
+    const sid = Buffer.from('3E11FA47710C4A4EA9B4E75E1B1B2B3C', 'hex');
+    expect(gtidFromEvent({ serverId: sid, transactionRange: 42 })).toBe(
+      '3e11fa47-710c-4a4e-a9b4-e75e1b1b2b3c:42',
+    );
+  });
+
+  it('returns null when the server id is not a 16-byte buffer', () => {
+    expect(gtidFromEvent({ serverId: 'nope', transactionRange: 1 })).toBeNull();
+    expect(gtidFromEvent({ serverId: Buffer.alloc(4), transactionRange: 1 })).toBeNull();
+    expect(gtidFromEvent({})).toBeNull();
   });
 });

--- a/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.ts
+++ b/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.ts
@@ -39,12 +39,33 @@ interface ZongjiConn {
 /** row events we care about. `rotate`/`tablemap` are needed for bookkeeping */
 const ROW_EVENTS = new Set(['writerows', 'updaterows', 'deleterows']);
 
+/** how long start() waits for the binlog reader to report it is positioned */
+const READY_TIMEOUT_MS = 10_000;
+
 /**
  * byte offset where a binlog event STARTS. zongji's `size` is the payload
  * length only — the on-disk event_length that `nextPosition` advances by also
  * counts the 19-byte common header, plus a 4-byte CRC32 when the server runs
  * with `binlog_checksum` (the default on modern MySQL).
  */
+/**
+ * A GTID_LOG event carries the originating server's UUID as 16 raw bytes plus
+ * the transaction number, which together are the transaction's GTID. Recorded
+ * on the cursor so an operator can see exactly which transaction a stream sits
+ * at, and so a resume can tell it is talking to the same server.
+ */
+export function gtidFromEvent(evt: {
+  serverId?: unknown;
+  transactionRange?: unknown;
+}): string | null {
+  const sid = evt.serverId;
+  if (!Buffer.isBuffer(sid) || sid.length !== 16) return null;
+  const h = sid.toString('hex');
+  const uuid = `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+  const range = Number(evt.transactionRange);
+  return Number.isFinite(range) ? `${uuid}:${range}` : uuid;
+}
+
 export function binlogEventStart(
   evt: { nextPosition: number; size: number },
   useChecksum: boolean,
@@ -76,7 +97,66 @@ export class MysqlCdcProvider implements CdcProvider {
   }
 
   /**
-   * parse a cursor into [file, pos, rowIdx, isStart]. three formats:
+   * The binlog coordinates a cursor carries are meaningful ONLY on the server
+   * that produced them: after a failover the new primary's files and offsets
+   * are unrelated, so resuming from them reads arbitrary data. Cursors
+   * therefore record which server issued them.
+   *
+   * Note this is a guard, not GTID positioning. The binlog client sends
+   * COM_BINLOG_DUMP (file + position) and has no COM_BINLOG_DUMP_GTID, so a
+   * stream cannot be *resumed* from a GTID set. What this does is refuse to
+   * resume against a different server instead of silently misreading it.
+   */
+  private cursorServer(c: string): string | null {
+    if (!c.startsWith('{')) return null;
+    try {
+      const o = JSON.parse(c) as { u?: string };
+      return o.u ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** the GTID recorded with a cursor, for operator visibility */
+  private cursorGtid(c: string): string | null {
+    if (!c.startsWith('{')) return null;
+    try {
+      const o = JSON.parse(c) as { g?: string };
+      return o.g ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** build a cursor, carrying server identity when it is known */
+  private makeCursor(args: {
+    file: string;
+    pos: number;
+    row: number;
+    isStart: boolean;
+    serverUuid: string | null;
+    gtid: string | null;
+  }): string {
+    const { file, pos, row, isStart, serverUuid, gtid } = args;
+    // without a known server the legacy compact form stays, so nothing changes
+    // for engines/versions that do not expose @@server_uuid
+    if (!serverUuid) {
+      return isStart ? `${file}:${pos}:${row}:s` : `${file}:${pos}:${row}`;
+    }
+    return JSON.stringify({
+      f: file,
+      p: pos,
+      r: row,
+      s: isStart,
+      u: serverUuid,
+      ...(gtid ? { g: gtid } : {}),
+    });
+  }
+
+  /**
+   * parse a cursor into [file, pos, rowIdx, isStart]. four formats:
+   *  - a JSON object {f,p,r,s,u,g} (current) — as below, plus the identity of
+   *    the server that issued it
    *  - "file:pos:rowIdx:s" (current) — pos is the START of the statement's
    *    tablemap event, so a resume re-enters the statement and the row-index
    *    watermark drops the already-delivered prefix
@@ -86,6 +166,14 @@ export class MysqlCdcProvider implements CdcProvider {
    *    next multi-row event still counts as "after" the old watermark
    */
   private splitCursor(c: string): [string, number, number, boolean] {
+    if (c.startsWith('{')) {
+      try {
+        const o = JSON.parse(c) as { f?: string; p?: number; r?: number; s?: boolean };
+        return [o.f ?? '', Number(o.p ?? 0), Number(o.r ?? -1), o.s === true];
+      } catch {
+        /* fall through to the legacy parser */
+      }
+    }
     let rest = c;
     let isStart = false;
     if (rest.endsWith(':s')) {
@@ -134,6 +222,28 @@ export class MysqlCdcProvider implements CdcProvider {
     for (let i = 0; i < bridgeId.length; i++) h = (h * 31 + bridgeId.charCodeAt(i)) >>> 0;
     // keep well clear of the common server_id=1 and inside a safe 32-bit range
     return (h % 2_000_000_000) + 1000;
+  }
+
+  /**
+   * `@@server_uuid` identifies the server instance. It is what makes a stored
+   * binlog coordinate safe to reuse: same uuid, same file/position meaning.
+   * Returns null when the server does not expose it, in which case cursors
+   * keep the legacy compact form and no guard is applied.
+   */
+  private async serverUuid(
+    connectionId: string,
+    database?: string,
+  ): Promise<string | null> {
+    try {
+      const res = await this.pool.withAdapter(connectionId, database, (a) =>
+        a.query('SELECT @@server_uuid AS uuid'),
+      );
+      const row = res.rows[0] as { uuid?: unknown } | undefined;
+      const uuid = row?.uuid;
+      return typeof uuid === 'string' && uuid.length > 0 ? uuid : null;
+    } catch {
+      return null;
+    }
   }
 
   /* ----- readiness ----- */
@@ -228,6 +338,25 @@ export class MysqlCdcProvider implements CdcProvider {
     // resume bookkeeping: tracks the last SAFE binlog position so both the
     // initial start AND every reconnect resume exactly where we left off
     const resume = fromCursor ? this.splitCursor(fromCursor) : null;
+
+    // binlog coordinates only mean anything on the server that issued them.
+    // After a failover the new primary's files and offsets are unrelated, so
+    // resuming from the old ones reads arbitrary data — fail loudly instead.
+    const serverUuid = await this.serverUuid(src.connectionId, db);
+    if (fromCursor) {
+      const previous = this.cursorServer(fromCursor);
+      if (previous && serverUuid && previous !== serverUuid) {
+        throw new Error(
+          `This bridge's saved binlog position came from MySQL server ${previous}, ` +
+            `but the connection now reaches ${serverUuid}. Binlog file and position ` +
+            `are only valid on the server that produced them, so resuming here would ` +
+            `read the wrong data. Reset the bridge to start from the current position.`,
+        );
+      }
+    }
+    // the GTID of the transaction being decoded, recorded onto each cursor
+    let lastGtid: string | null = fromCursor ? this.cursorGtid(fromCursor) : null;
+
     let binlogName = resume?.[0] ?? '';
     let position = resume?.[1] ?? 0;
     // the statement group currently being decoded: `groupStart` is the byte
@@ -241,6 +370,11 @@ export class MysqlCdcProvider implements CdcProvider {
 
     const onEvent = async (evt: BinLogEvent): Promise<void> => {
       const name = evt.getEventName();
+      if (name === 'gtidlog') {
+        // precedes the transaction's row events, so it labels what follows
+        lastGtid = gtidFromEvent(evt as unknown as Record<string, unknown>) ?? lastGtid;
+        return;
+      }
       if (name === 'rotate') {
         // rotate tells us the current binlog filename (incl. the one at startup)
         const next = (evt as { binlogName?: string }).binlogName;
@@ -306,9 +440,14 @@ export class MysqlCdcProvider implements CdcProvider {
           const idx = groupRow++;
           // defensive fallback: a row event with no seen tablemap (shouldn't
           // happen) keeps the legacy end-position cursor format
-          const cursor = startKnown
-            ? `${binlogName}:${groupStart}:${idx}:s`
-            : `${binlogName}:${rowEvt.nextPosition}:${i}`;
+          const cursor = this.makeCursor({
+            file: binlogName,
+            pos: startKnown ? groupStart : rowEvt.nextPosition,
+            row: startKnown ? idx : i,
+            isStart: startKnown,
+            serverUuid,
+            gtid: lastGtid,
+          });
           await handlers.onChange({ op, row, cursor });
         }
         // the resume point stays at the group's tablemap: the statement may
@@ -320,10 +459,22 @@ export class MysqlCdcProvider implements CdcProvider {
       }
     };
 
+    // `start()` must not return before the reader is actually positioned:
+    // with startAtEnd a row written immediately afterwards would land in the
+    // binlog ahead of the reader and be missed entirely
+    let signalReady: (() => void) | null = null;
+    const positioned = new Promise<void>((resolve) => {
+      signalReady = resolve;
+    });
+
     const startInstance = (): void => {
       if (stopped) return;
       const instance = new ZongJi({ ...connInfo, dateStrings: true });
       zongji = instance;
+      instance.on('ready', () => {
+        signalReady?.();
+        signalReady = null;
+      });
       instance.on('binlog', (evt: BinLogEvent) => {
         void onEvent(evt).catch((err) => handlers.onError(err as Error));
       });
@@ -342,7 +493,16 @@ export class MysqlCdcProvider implements CdcProvider {
       });
 
       const startOpts: Record<string, unknown> = {
-        includeEvents: ['rotate', 'tablemap', 'writerows', 'updaterows', 'deleterows'],
+        // gtidlog labels each transaction; without it in this list the
+        // events are filtered out before the handler ever sees them
+        includeEvents: [
+          'rotate',
+          'gtidlog',
+          'tablemap',
+          'writerows',
+          'updaterows',
+          'deleterows',
+        ],
         includeSchema: { [db]: [src.table] },
         serverId,
       };
@@ -361,6 +521,16 @@ export class MysqlCdcProvider implements CdcProvider {
     };
 
     startInstance();
+
+    // bounded: a server that never signals ready must not hang the start call,
+    // and the stream is still usable — it just keeps whatever it does receive
+    await Promise.race([
+      positioned,
+      new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, READY_TIMEOUT_MS);
+        t.unref?.();
+      }),
+    ]);
 
     return {
       stop: async () => {

--- a/apps/api/test/integration/app-harness.ts
+++ b/apps/api/test/integration/app-harness.ts
@@ -72,23 +72,30 @@ export async function makeBridge(
     destConnId: string;
     cleanups: Array<() => Promise<void>>;
     start?: boolean;
+    /** engine the source table lives on; defaults to postgres */
+    sourceEngine?: 'postgres' | 'mysql';
   },
 ): Promise<SyncSetup> {
   const { destEngine, sourceConnId, destConnId, cleanups } = opts;
+  const sourceEngine = opts.sourceEngine ?? 'postgres';
   const sourceTable = uniqueTable('src');
   const destTable = uniqueTable('dst');
 
-  await withAdapter('postgres', (a) =>
+  const srcTypes =
+    sourceEngine === 'mysql'
+      ? { int: 'int', text: 'varchar(255)' }
+      : { int: 'integer', text: 'text' };
+  await withAdapter(sourceEngine, (a) =>
     a.createTable({
       table: sourceTable,
       columns: [
-        { name: 'id', type: 'integer', nullable: false, primaryKey: true },
-        { name: 'name', type: 'text', nullable: true },
+        { name: 'id', type: srcTypes.int, nullable: false, primaryKey: true },
+        { name: 'name', type: srcTypes.text, nullable: true },
       ],
     }),
   );
   cleanups.push(() =>
-    withAdapter('postgres', (a) => a.dropTable(sourceTable)).catch(() => undefined),
+    withAdapter(sourceEngine, (a) => a.dropTable(sourceTable)).catch(() => undefined),
   );
   cleanups.push(() =>
     withAdapter(destEngine, (a) => a.dropTable(destTable)).catch(() => undefined),

--- a/apps/api/test/integration/mysql-cdc.itest.ts
+++ b/apps/api/test/integration/mysql-cdc.itest.ts
@@ -1,0 +1,191 @@
+/**
+ * MySQL binlog CDC against a real MySQL 8.0 with GTID mode on.
+ *
+ * Beyond propagation, this covers the server-identity guard. Binlog file and
+ * position are only meaningful on the server that issued them, so a cursor
+ * carries the server's uuid and a resume against a DIFFERENT server must fail
+ * loudly rather than silently read the wrong offsets — which is what would
+ * happen after a failover.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  destRows,
+  makeBridge,
+  type AppHandle,
+  type SyncSetup,
+} from './app-harness';
+import { waitFor, withAdapter } from './harness';
+
+let app: AppHandle;
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  app = await bootstrapApp();
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+});
+
+async function mysqlSourceBridge(): Promise<SyncSetup> {
+  const src = await connectionFor(app, 'mysql');
+  const dst = await connectionFor(app, 'postgres');
+  return makeBridge(app, {
+    sourceEngine: 'mysql',
+    destEngine: 'postgres',
+    sourceConnId: src,
+    destConnId: dst,
+    cleanups,
+  });
+}
+
+/** the newest job row for a bridge, which carries the persisted cursor */
+async function latestJob(bridgeId: string): Promise<any> {
+  return app.prisma.bridgeJob.findFirst({
+    where: { bridgeId },
+    orderBy: { startedAt: 'desc' },
+  });
+}
+
+describe('mysql binlog -> postgres', () => {
+  let s: SyncSetup;
+
+  beforeAll(async () => {
+    s = await mysqlSourceBridge();
+  }, 120_000);
+
+  it('propagates insert, update and delete', async () => {
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'alpha' } }),
+    );
+    await waitFor('insert', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 && r[0]?.name === 'alpha' ? r : null;
+    });
+
+    await withAdapter('mysql', (a) =>
+      a.updateRow({
+        table: s.sourceTable,
+        identity: { id: 1 },
+        changes: { name: 'beta' },
+      }),
+    );
+    await waitFor('update', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r[0]?.name === 'beta' ? r : null;
+    });
+
+    await withAdapter('mysql', (a) =>
+      a.deleteRow({ table: s.sourceTable, identity: { id: 1 } }),
+    );
+    await waitFor('delete', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 0 ? true : null;
+    });
+    expect(await destRows('postgres', s.destTable)).toHaveLength(0);
+  });
+
+  it('delivers a burst exactly once', async () => {
+    const total = 300;
+    await withAdapter('mysql', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: total }, (_, i) => ({
+          id: i + 1000,
+          name: `b${i}`,
+        })),
+      }),
+    );
+    const rows = await waitFor(
+      `${total} rows`,
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === total ? r : null;
+      },
+      { timeoutMs: 120_000 },
+    );
+    expect(new Set(rows.map((r) => Number(r.id))).size).toBe(total);
+  });
+
+  it('records the server uuid and a real GTID on the cursor', async () => {
+    const job = await latestJob(s.bridgeId);
+    expect(job.cursorJson).toBeTruthy();
+    const cursor = JSON.parse(job.cursorJson).cursor as string;
+    // the identity-carrying form is JSON
+    expect(cursor.startsWith('{')).toBe(true);
+    const parsed = JSON.parse(cursor);
+    expect(typeof parsed.u).toBe('string');
+    expect(parsed.u.length).toBeGreaterThan(0);
+    // matches what the server reports for itself
+    const live = await withAdapter('mysql', (a) =>
+      a.query('SELECT @@server_uuid AS uuid'),
+    );
+    expect(parsed.u).toBe((live.rows[0] as { uuid: string }).uuid);
+    // GTID mode is on in the test server, so a GTID must have been captured
+    expect(typeof parsed.g).toBe('string');
+    expect(parsed.g).toMatch(/^[0-9a-f-]{36}:\d+$/);
+  });
+});
+
+describe('server-identity guard', () => {
+  it('refuses to resume when the cursor came from another server', async () => {
+    const s = await mysqlSourceBridge();
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'x' } }),
+    );
+    await waitFor('first row', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 ? r : null;
+    });
+
+    await app.cdc.stop(s.bridgeId);
+
+    // rewrite the stored cursor as if it had been produced by a different
+    // server — exactly the state a failover leaves behind
+    const job = await latestJob(s.bridgeId);
+    const cursor = JSON.parse(job.cursorJson).cursor as string;
+    const tampered = JSON.stringify({
+      ...JSON.parse(cursor),
+      u: '00000000-1111-2222-3333-444444444444',
+    });
+    await app.prisma.bridgeJob.update({
+      where: { id: job.id },
+      data: { cursorJson: JSON.stringify({ cursor: tampered }) },
+    });
+
+    await expect(app.cdc.start(s.bridgeId)).rejects.toThrow(
+      /came from MySQL server .* but the connection now reaches/i,
+    );
+  });
+
+  it('resumes normally when the server is unchanged', async () => {
+    const s = await mysqlSourceBridge();
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'one' } }),
+    );
+    await waitFor('first row', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 ? r : null;
+    });
+
+    await app.cdc.stop(s.bridgeId);
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 2, name: 'two' } }),
+    );
+    await app.cdc.start(s.bridgeId);
+
+    const rows = await waitFor(
+      'row written while stopped',
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === 2 ? r : null;
+      },
+      { timeoutMs: 60_000 },
+    );
+    expect(rows.map((r) => Number(r.id))).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
Stacked on #67. Correctness, not performance.

## The problem

Binlog file and position mean something only on the server that issued them. After a failover the new primary's files and offsets are unrelated — so the saved cursor pointed at an arbitrary place and the stream read whatever happened to be there. Silently.

## What changes

Cursors record the issuing server's `@@server_uuid`, and a resume against a different server **fails with an explicit message** instead of proceeding. Each cursor also carries the GTID of the transaction it sits at, decoded from the binlog's `GTID_LOG` event, so an operator can see exactly where a stream is.

## What this is not

**This is a guard, not GTID positioning.** The binlog client sends `COM_BINLOG_DUMP` (file and position) and implements no `COM_BINLOG_DUMP_GTID` — I checked the packet, it is command `0x12`. A stream still cannot be *resumed* from a GTID set; that needs a fork of the client. What changes here is that a post-failover resume is refused rather than silently wrong.

Cursors stay backward compatible: the identity-carrying form is JSON, legacy `file:pos:row[:s]` strings still parse, and the two orderings are interchangeable so an upgraded stream compares correctly against an old watermark.

## Two real bugs found while testing against live MySQL 8.0

- **`GTID_LOG` was not in the client's `includeEvents` list**, so those events were filtered out before any handler could see them. No GTID was ever captured.
- **`startStream` returned as soon as the reader was *told* to start, not once it was positioned.** On a fresh bridge — which starts at the tip of the binlog — a row written immediately after `start()` landed ahead of the reader and was **lost**. It now waits for the reader to report ready, bounded so a silent server cannot hang the call.

The second one is a data-loss bug in normal use, not just a test artifact.

## Verification

8 new unit tests for the cursor format and GTID decoding, plus 5 integration tests against real MySQL: propagation, a 300-row burst, the recorded uuid matching `@@server_uuid`, a tampered cursor being refused, and an unchanged server still resuming.