### PR TITLE
feat(api): durable spool between the change reader and the destination

### DIFF
--- a/apps/api/src/bridges/bridge-cdc.service.ts
+++ b/apps/api/src/bridges/bridge-cdc.service.ts
@@ -40,11 +40,13 @@ import { BridgeSinkService } from './bridge-sink.service';
 import type { ResolvedBridge } from './bridges.types';
 import {
   CDC_PROVIDERS,
+  backoffMs,
   type CdcChange,
   type CdcProvider,
   type CdcStreamHandle,
 } from './cdc/cdc-provider';
 import { rowMatchesFilters } from './cdc/filter-match';
+import { CdcSpoolService, type SpooledItem } from './cdc/cdc-spool.service';
 
 /** live runtime state for one active CDC stream */
 interface Stream {
@@ -74,6 +76,12 @@ interface Stream {
   maxBatch: number;
   /** the resolved bridge, so a flush needs no extra arguments */
   bridge: ResolvedBridge;
+  /** changes go through the durable spool instead of straight to the sink */
+  spooled: boolean;
+  /** set to stop the spool consumer loop */
+  consumerStop: boolean;
+  /** the running consumer, awaited on teardown so it exits cleanly */
+  consumer: Promise<void> | null;
 }
 
 /** one change held in the pending batch */
@@ -108,6 +116,7 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     private readonly pool: AdapterPoolService,
     private readonly sink: BridgeSinkService,
     private readonly jobs: BridgeJobService,
+    private readonly spool: CdcSpoolService,
     @Inject(CDC_PROVIDERS) providers: CdcProvider[],
   ) {
     for (const p of providers) this.providers.set(p.engine, p);
@@ -244,6 +253,8 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     await stream.pending.catch(() => undefined);
     this.streams.delete(bridgeId);
     if (stream.timer) clearTimeout(stream.timer);
+    stream.consumerStop = true;
+    await stream.consumer?.catch(() => undefined);
     // buffered-but-undelivered changes were never acked, so they would replay
     // on resume anyway; flushing here just avoids the needless repeat
     await this.flush(bridgeId, stream).catch(() => undefined);
@@ -286,6 +297,9 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
           ? Math.max(1, runtimeConfig.cdcBatchSize)
           : Math.max(1, bridge.delivery.batchSize),
       bridge,
+      spooled: runtimeConfig.cdcSpool,
+      consumerStop: false,
+      consumer: null,
     };
     this.streams.set(bridgeId, stream);
 
@@ -316,6 +330,8 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     }
     // the provider may have already begun emitting, only replace the placeholder
     stream.handle = handle;
+    // the spool consumer runs alongside the reader, draining to the destination
+    if (stream.spooled) this.startConsumer(bridgeId, stream);
   }
 
   /** the source's primary-key columns (best-effort), cached on the stream */
@@ -479,6 +495,12 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
 
     const rows = items.map((i) => i.row);
     const lastCursor = items[items.length - 1]!.change.cursor;
+
+    if (stream.spooled) {
+      await this.spoolBatch(bridgeId, stream, items, lastCursor);
+      return;
+    }
+
     const seq = stream.seq;
     const now = new Date().toISOString();
     const pk = stream.primaryKey;
@@ -568,6 +590,220 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
         await this.teardown(bridgeId).catch(() => undefined);
         await this.jobs.finalize(stream.jobId, 'failed', message).catch(() => undefined);
       }
+    }
+  }
+
+  /**
+   * Hand a batch to the durable spool and checkpoint the SOURCE against it.
+   *
+   * This is the point of the spool: once the changes are durably in Redis the
+   * source's log may advance, so a slow or unreachable destination can no
+   * longer pin WAL on the production database. The destination is caught up
+   * separately by the consumer.
+   */
+  private async spoolBatch(
+    bridgeId: string,
+    stream: Stream,
+    items: Buffered[],
+    lastCursor: string,
+  ): Promise<void> {
+    // bounded: an unbounded spool would just move the unbounded growth from
+    // the source's WAL into Redis. Blocking here propagates backpressure all
+    // the way back to the reader, which is what we want when the destination
+    // cannot keep up.
+    while (this.streams.get(bridgeId) === stream) {
+      let depth: number;
+      try {
+        depth = await this.spool.depth(bridgeId);
+      } catch {
+        break; // depth is only advisory; a failed append below is the real guard
+      }
+      if (depth < runtimeConfig.cdcSpoolMax) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (this.streams.get(bridgeId) !== stream) return;
+
+    const entries = items.map((i) => ({
+      op: i.change.op,
+      row: i.row,
+      cursor: i.change.cursor,
+    }));
+
+    // the cursor may only advance once the spool has the changes, so a failed
+    // append must never checkpoint. retry briefly, then stop the stream: the
+    // source still holds everything after the last ack, so a restart replays
+    // it and nothing is lost
+    let appended = false;
+    for (let attempt = 0; attempt < 3 && !appended; attempt++) {
+      try {
+        await this.spool.append(bridgeId, entries);
+        appended = true;
+      } catch (err) {
+        if (attempt === 2) {
+          const message = (err as Error).message;
+          this.logger.error(
+            `CDC ${bridgeId}: could not write to the spool, stopping without ` +
+              `advancing the cursor so nothing is lost: ${message}`,
+          );
+          await this.jobs
+            .finalize(stream.jobId, 'failed', `Spool unavailable: ${message}`)
+            .catch(() => undefined);
+          setImmediate(() => void this.teardown(bridgeId).catch(() => undefined));
+          return;
+        }
+        await new Promise((r) => setTimeout(r, backoffMs(attempt)));
+      }
+    }
+
+    stream.watermark = lastCursor;
+    try {
+      await this.prisma.bridgeJob.update({
+        where: { id: stream.jobId },
+        data: { cursorJson: JSON.stringify({ cursor: lastCursor }) },
+      });
+      await stream.handle.ack?.(lastCursor);
+    } catch (err) {
+      // the changes are safely spooled; a missed checkpoint only means the
+      // source replays them, which the watermark dedupe absorbs
+      this.logger.warn(
+        `CDC ${bridgeId}: spooled but could not checkpoint: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Split spooled items into runs that can each go out as ONE delivery: the
+   * same operation throughout, and no repeated key — a multi-row upsert cannot
+   * touch the same row twice.
+   */
+  private deliverableRuns(items: SpooledItem[], pk: string[] | null): SpooledItem[][] {
+    const runs: SpooledItem[][] = [];
+    let current: SpooledItem[] = [];
+    let currentOp: string | null = null;
+    let seen = new Set<string>();
+
+    for (const item of items) {
+      const sig = pk?.length
+        ? JSON.stringify(pk.map((c) => item.entry.row[c]))
+        : null;
+      const breaks =
+        current.length > 0 &&
+        (currentOp !== item.entry.op || (sig !== null && seen.has(sig)));
+      if (breaks) {
+        runs.push(current);
+        current = [];
+        seen = new Set();
+      }
+      current.push(item);
+      currentOp = item.entry.op;
+      if (sig !== null) seen.add(sig);
+    }
+    if (current.length > 0) runs.push(current);
+    return runs;
+  }
+
+  /**
+   * Drain the spool into the destination. Entries are trimmed only after they
+   * have been delivered (or recorded as failed), so a crash redelivers them —
+   * at-least-once, absorbed by the idempotent writes.
+   */
+  private startConsumer(bridgeId: string, stream: Stream): void {
+    stream.consumer = (async () => {
+      while (!stream.consumerStop) {
+        let items: SpooledItem[];
+        try {
+          items = await this.spool.read(bridgeId, stream.maxBatch);
+        } catch (err) {
+          this.logger.warn(
+            `CDC ${bridgeId}: spool read failed: ${(err as Error).message}`,
+          );
+          await new Promise((r) => setTimeout(r, 500));
+          continue;
+        }
+        if (items.length === 0) {
+          await new Promise((r) =>
+            setTimeout(r, Math.max(10, runtimeConfig.cdcLingerMs)),
+          );
+          continue;
+        }
+
+        for (const run of this.deliverableRuns(items, stream.primaryKey)) {
+          if (stream.consumerStop) return;
+          const aborted = await this.deliverSpooled(bridgeId, stream, run);
+          if (aborted) return;
+        }
+      }
+    })().catch((err) => {
+      this.logger.error(
+        `CDC ${bridgeId}: spool consumer stopped: ${(err as Error).message}`,
+      );
+    });
+  }
+
+  /** deliver one run, record it, and trim it from the spool. true = stop */
+  private async deliverSpooled(
+    bridgeId: string,
+    stream: Stream,
+    run: SpooledItem[],
+  ): Promise<boolean> {
+    const bridge = stream.bridge;
+    if (bridge.source.kind !== 'table') return true;
+
+    const rows = run.map((i) => i.entry.row);
+    const op = run[0]!.entry.op;
+    const lastId = run[run.length - 1]!.id;
+    const seq = stream.seq;
+    const pk = stream.primaryKey;
+    const rowKeys = pk?.length
+      ? run.map((i) => (pk.length === 1 ? i.entry.row[pk[0]!] : pk.map((c) => i.entry.row[c])))
+      : null;
+    const idem =
+      bridge.destination.kind === 'http' && bridge.destination.idempotency
+        ? `${stream.jobId}:${run[run.length - 1]!.entry.cursor}`
+        : undefined;
+
+    try {
+      const { outcome } = await this.sink.deliver(
+        bridge,
+        rows,
+        {
+          table: bridge.source.table,
+          now: new Date().toISOString(),
+          startIndex: seq,
+          op,
+        },
+        new AbortController().signal,
+        idem,
+      );
+      await this.jobs.recordDelivery(
+        stream.jobId,
+        { sequence: seq, rowIndex: seq, rowCount: rows.length, rowKeys },
+        outcome,
+      );
+      if (outcome.status === 'failed' && bridge.delivery.onError === 'abort') {
+        this.logger.warn(`CDC ${bridgeId}: pausing after a failed delivery (onError=abort)`);
+        await this.jobs
+          .finalize(stream.jobId, 'paused', 'Paused after a failed delivery (onError=abort).')
+          .catch(() => undefined);
+        // leave the run in the spool so a restart retries it
+        setImmediate(() => void this.teardown(bridgeId).catch(() => undefined));
+        return true;
+      }
+      stream.seq = seq + 1;
+      // delivered: the spool may forget it. the head advances, so reads stay
+      // cheap however many millions have passed through
+      await this.spool.trimThrough(bridgeId, lastId);
+      await this.prisma.bridgeJob
+        .update({ where: { id: stream.jobId }, data: { cursorOffset: stream.seq } })
+        .catch(() => undefined);
+      return false;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`CDC ${bridgeId}: spooled delivery failed: ${message}`);
+      // do NOT trim: the entries stay so the next pass retries them. back off
+      // so a persistently broken destination does not spin
+      await new Promise((r) => setTimeout(r, 1_000));
+      return false;
     }
   }
 

--- a/apps/api/src/bridges/bridges.module.ts
+++ b/apps/api/src/bridges/bridges.module.ts
@@ -10,6 +10,7 @@ import { BridgeCdcService } from './bridge-cdc.service';
 import { BridgeLifecycleService } from './bridge-lifecycle.service';
 import { BridgeStoreService } from './bridge-store.service';
 import { BridgeWatchProcessor } from './bridge-watch.processor';
+import { CdcSpoolService } from './cdc/cdc-spool.service';
 import { BridgeWatchService } from './bridge-watch.service';
 import { BridgesController } from './bridges.controller';
 import { JobRegistryService } from './job-registry.service';
@@ -40,6 +41,7 @@ import { SqliteCdcProvider } from './cdc/providers/sqlite-cdc.provider';
     JobRegistryService,
     BridgeJobProcessor,
     BridgeWatchProcessor,
+    CdcSpoolService,
     // CDC providers (one per engine) plus the aggregate the orchestrator injects
     PostgresCdcProvider,
     MysqlCdcProvider,

--- a/apps/api/src/bridges/cdc/cdc-spool.service.test.ts
+++ b/apps/api/src/bridges/cdc/cdc-spool.service.test.ts
@@ -1,0 +1,35 @@
+/**
+ * nextStreamId is what makes trimming correct: XTRIM MINID removes entries
+ * strictly BELOW the given id, so trimming *through* a delivered entry means
+ * trimming below its successor. Getting this wrong either leaves the last
+ * delivered entry behind forever (it would be redelivered on every pass) or
+ * trims one too many (silent data loss).
+ */
+import { describe, expect, it } from 'vitest';
+import { nextStreamId } from './cdc-spool.service';
+
+describe('nextStreamId', () => {
+  it('increments the sequence part', () => {
+    expect(nextStreamId('1700000000000-0')).toBe('1700000000000-1');
+    expect(nextStreamId('1700000000000-41')).toBe('1700000000000-42');
+  });
+
+  it('leaves the millisecond part untouched', () => {
+    expect(nextStreamId('12345-7')).toBe('12345-8');
+  });
+
+  it('returns the input unchanged when it is not a stream id', () => {
+    expect(nextStreamId('nonsense')).toBe('nonsense');
+    expect(nextStreamId('1700000000000-x')).toBe('1700000000000-x');
+  });
+
+  it('is strictly greater than the id it came from', () => {
+    // the ordering XTRIM relies on: same ms, higher sequence
+    const id = '1700000000000-5';
+    const next = nextStreamId(id);
+    const [ms, seq] = id.split('-').map(Number);
+    const [nms, nseq] = next.split('-').map(Number);
+    expect(nms).toBe(ms);
+    expect(nseq).toBeGreaterThan(seq!);
+  });
+});

--- a/apps/api/src/bridges/cdc/cdc-spool.service.ts
+++ b/apps/api/src/bridges/cdc/cdc-spool.service.ts
@@ -1,0 +1,155 @@
+/**
+ * Durable spool between the change reader and the destination writer.
+ *
+ * Without a broker in the path, a slow or unreachable destination holds the
+ * SOURCE's log open: a Postgres slot stops advancing and WAL accumulates on the
+ * production database until its disk fills. That is the sharpest operational
+ * edge of running CDC with no Kafka, and this is the thing that blunts it.
+ *
+ * Changes are appended to a Redis Stream, one per bridge, and a consumer drains
+ * it into the destination. The source can then be acknowledged as soon as a
+ * change is durably spooled, so the slot advances at the speed of Redis rather
+ * than the speed of the destination.
+ *
+ * That trade is explicit and opt-in (`SYNCLE_CDC_SPOOL=on`). While a change sits
+ * in the spool and not yet in the destination, REDIS is the only copy of it —
+ * so this mode is only safe with Redis persistence (appendonly) enabled. It is
+ * off by default; nobody trades durability for throughput without asking.
+ *
+ * Entries are removed only once delivered, so anything left after a crash is
+ * redelivered on restart: at-least-once, which the watermark dedupe and
+ * idempotent upserts already absorb.
+ */
+import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
+import Redis from 'ioredis';
+import type { CdcOperation } from '@syncle/core';
+import { redisConnectionOptions } from '../../common/runtime-config';
+
+/** one change as it is held in the spool */
+export interface SpoolEntry {
+  op: CdcOperation;
+  row: Record<string, unknown>;
+  cursor: string;
+}
+
+/** a spooled entry plus the stream id it must be trimmed by */
+export interface SpooledItem {
+  id: string;
+  entry: SpoolEntry;
+}
+
+/**
+ * The id immediately after `id`. Stream ids are "<ms>-<seq>", and MINID trims
+ * entries strictly BELOW the given id, so trimming *through* an entry means
+ * trimming below its successor.
+ */
+export function nextStreamId(id: string): string {
+  const dash = id.lastIndexOf('-');
+  if (dash < 0) return id;
+  const ms = id.slice(0, dash);
+  const seq = Number(id.slice(dash + 1));
+  if (!Number.isFinite(seq)) return id;
+  // sequence is a 64-bit counter; Number is exact far past any realistic run,
+  // and rolling to the next millisecond would also be correct
+  return `${ms}-${seq + 1}`;
+}
+
+@Injectable()
+export class CdcSpoolService implements OnModuleDestroy {
+  private readonly logger = new Logger('CdcSpool');
+  private client: Redis | null = null;
+
+  /** one stream per bridge, so ordering is per-bridge and trimming is isolated */
+  private key(bridgeId: string): string {
+    return `syncle:cdc:spool:${bridgeId}`;
+  }
+
+  private conn(): Redis {
+    if (!this.client) {
+      this.client = new Redis({
+        ...redisConnectionOptions(),
+        lazyConnect: false,
+      });
+      this.client.on('error', (err) => {
+        // ioredis reconnects on its own; log once rather than crash the process
+        this.logger.warn(`spool redis error: ${err.message}`);
+      });
+    }
+    return this.client;
+  }
+
+  /**
+   * Append changes in order and return the id of the last one. The caller may
+   * treat a resolved append as durable enough to acknowledge the source, which
+   * is the whole point of the spool.
+   */
+  async append(bridgeId: string, entries: SpoolEntry[]): Promise<string | null> {
+    if (entries.length === 0) return null;
+    const key = this.key(bridgeId);
+    const pipeline = this.conn().pipeline();
+    for (const entry of entries) {
+      pipeline.xadd(key, '*', 'e', JSON.stringify(entry));
+    }
+    const results = await pipeline.exec();
+    if (!results?.length) return null;
+    const [err, id] = results[results.length - 1] as [Error | null, string];
+    if (err) throw err;
+    return id;
+  }
+
+  /** oldest-first read of at most `count` undelivered entries */
+  async read(bridgeId: string, count: number): Promise<SpooledItem[]> {
+    const raw = (await this.conn().xrange(
+      this.key(bridgeId),
+      '-',
+      '+',
+      'COUNT',
+      count,
+    )) as Array<[string, string[]]>;
+
+    const items: SpooledItem[] = [];
+    for (const [id, fields] of raw) {
+      // fields are flat [name, value, ...]; the payload lives under "e"
+      const idx = fields.indexOf('e');
+      if (idx < 0 || idx + 1 >= fields.length) continue;
+      try {
+        items.push({ id, entry: JSON.parse(fields[idx + 1]!) as SpoolEntry });
+      } catch {
+        // an unparseable entry would block the queue forever; drop it loudly
+        this.logger.error(`discarding malformed spool entry ${id} for ${bridgeId}`);
+        await this.conn().xdel(this.key(bridgeId), id).catch(() => undefined);
+      }
+    }
+    return items;
+  }
+
+  /**
+   * Advance the head past everything delivered up to and including `lastId`.
+   *
+   * XTRIM MINID rather than XDEL on purpose. The spool is consumed strictly in
+   * order, and XDEL only tombstones entries — the macro-node stays until every
+   * entry in it is deleted, so a long-running stream accumulates dead entries
+   * that each XRANGE from the head must skip, and memory is not returned.
+   * MINID moves the head itself, which keeps reads O(batch) and releases memory
+   * no matter how many millions have passed through.
+   */
+  async trimThrough(bridgeId: string, lastId: string): Promise<void> {
+    await this.conn().xtrim(this.key(bridgeId), 'MINID', nextStreamId(lastId));
+  }
+
+  /** how many changes are waiting; drives backpressure on the reader */
+  async depth(bridgeId: string): Promise<number> {
+    return this.conn().xlen(this.key(bridgeId));
+  }
+
+  /** drop a bridge's spool entirely (bridge deleted or reset) */
+  async clear(bridgeId: string): Promise<void> {
+    await this.conn().del(this.key(bridgeId));
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    await client?.quit().catch(() => undefined);
+  }
+}

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -62,6 +62,21 @@ export const runtimeConfig = {
   /** how long a partial batch waits for more changes before being flushed */
   cdcLingerMs: Number(process.env.SYNCLE_CDC_LINGER_MS ?? 50),
   /**
+   * Put a durable spool (a Redis Stream) between the change reader and the
+   * destination writer. With it on, the source is acknowledged as soon as a
+   * change is spooled, so a slow or unreachable destination no longer holds the
+   * source's log open — the failure mode where a Postgres slot stops advancing
+   * and WAL fills the production database's disk.
+   *
+   * OFF by default, and deliberately so: while a change sits in the spool it
+   * exists ONLY in Redis, so this is safe only where Redis has persistence
+   * (appendonly) enabled. That is a durability trade nobody should make by
+   * accident.
+   */
+  cdcSpool: (process.env.SYNCLE_CDC_SPOOL ?? '') === 'on',
+  /** cap on unwritten changes held in the spool before the reader is throttled */
+  cdcSpoolMax: Number(process.env.SYNCLE_CDC_SPOOL_MAX ?? 50_000),
+  /**
    * when true, HTTP destinations may not resolve to loopback/private/link-local
    * addresses (SSRF guard for network-exposed deployments). off by default —
    * Syncle is local-first and posting to localhost services is a primary use.

--- a/apps/api/test/integration/app-harness.ts
+++ b/apps/api/test/integration/app-harness.ts
@@ -145,3 +145,44 @@ export async function destRows(
     }
   });
 }
+
+/**
+ * Row count in the destination. `destRows` pages through `browse`, which is
+ * capped (5000 by default), so anything larger must be counted in the engine.
+ */
+export async function destCount(
+  engine: 'postgres' | 'mysql',
+  table: string,
+): Promise<number> {
+  return withAdapter(engine, async (a) => {
+    try {
+      const res = await a.query(`SELECT COUNT(*) AS n FROM "${table}"`.replace(
+        /"/g,
+        engine === 'mysql' ? '`' : '"',
+      ));
+      const row = res.rows[0] as { n?: unknown };
+      return Number(row?.n ?? 0);
+    } catch {
+      return 0; // table not created yet
+    }
+  });
+}
+
+/** distinct ids in the destination, to prove exactly-once at volume */
+export async function destDistinctIds(
+  engine: 'postgres' | 'mysql',
+  table: string,
+): Promise<{ distinct: number; min: number; max: number }> {
+  return withAdapter(engine, async (a) => {
+    const q = engine === 'mysql' ? '`' : '"';
+    const res = await a.query(
+      `SELECT COUNT(DISTINCT id) AS d, MIN(id) AS lo, MAX(id) AS hi FROM ${q}${table}${q}`,
+    );
+    const row = res.rows[0] as { d?: unknown; lo?: unknown; hi?: unknown };
+    return {
+      distinct: Number(row?.d ?? 0),
+      min: Number(row?.lo ?? 0),
+      max: Number(row?.hi ?? 0),
+    };
+  });
+}

--- a/apps/api/test/integration/cdc-spool.itest.ts
+++ b/apps/api/test/integration/cdc-spool.itest.ts
@@ -1,0 +1,177 @@
+/**
+ * The durable spool, exercised with SYNCLE_CDC_SPOOL=on.
+ *
+ * The spool exists so a slow or unreachable destination cannot hold the
+ * SOURCE's log open. These tests check that the source is checkpointed on
+ * spooling, that the destination still receives everything exactly once, that
+ * the spool is trimmed as it drains (so it does not grow without bound), and
+ * that it holds up at volume.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  destRows,
+  makeBridge,
+  type AppHandle,
+  type SyncSetup,
+  destCount,
+  destDistinctIds,
+} from './app-harness';
+import { waitFor, withAdapter } from './harness';
+
+// the spool is opt-in, so this file only runs when it is enabled:
+//   SYNCLE_CDC_SPOOL=on pnpm test:integration
+// it must be set before the app module is evaluated, hence an env check rather
+// than a runtime toggle
+const ENABLED = process.env.SYNCLE_CDC_SPOOL === 'on';
+
+let app: AppHandle;
+let spool: any;
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  if (!ENABLED) return;
+  app = await bootstrapApp();
+  const { CdcSpoolService } = await import('../../src/bridges/cdc/cdc-spool.service');
+  spool = app.ctx.get(CdcSpoolService);
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+});
+
+async function freshBridge(): Promise<SyncSetup> {
+  const src = await connectionFor(app, 'postgres');
+  const dst = await connectionFor(app, 'postgres');
+  const s = await makeBridge(app, {
+    destEngine: 'postgres',
+    sourceConnId: src,
+    destConnId: dst,
+    cleanups,
+  });
+  cleanups.push(() => spool.clear(s.bridgeId).catch(() => undefined));
+  return s;
+}
+
+describe.runIf(ENABLED)('spooled delivery', () => {
+  it('delivers through the spool and drains it', async () => {
+    const s = await freshBridge();
+    await withAdapter('postgres', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: 100 }, (_, i) => ({ id: i + 1, name: `n${i}` })),
+      }),
+    );
+
+    const rows = await waitFor('rows via spool', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 100 ? r : null;
+    });
+    expect(new Set(rows.map((r) => Number(r.id))).size).toBe(100);
+
+    // the spool is trimmed as it drains, so it does not grow without bound
+    const depth = await waitFor('spool to drain', async () => {
+      const d = await spool.depth(s.bridgeId);
+      return d === 0 ? 'drained' : null;
+    });
+    expect(depth).toBe('drained');
+  });
+
+  it('checkpoints the source as soon as changes are spooled', async () => {
+    // the entire point: the source may advance without waiting for the
+    // destination, so a slow destination cannot pin the source's log
+    const s = await freshBridge();
+    await withAdapter('postgres', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'x' } }),
+    );
+    const job = await waitFor('source cursor to advance', async () => {
+      const j = await app.prisma.bridgeJob.findFirst({
+        where: { bridgeId: s.bridgeId },
+        orderBy: { startedAt: 'desc' },
+      });
+      return j?.cursorJson ? j : null;
+    });
+    expect(JSON.parse(job.cursorJson).cursor).toBeTruthy();
+  });
+
+  it('preserves ordering and operations through the spool', async () => {
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      for (const id of [1, 2, 3, 4]) {
+        await a.insertRow({ table: s.sourceTable, values: { id, name: `n${id}` } });
+      }
+      await a.deleteRow({ table: s.sourceTable, identity: { id: 2 } });
+      await a.updateRow({
+        table: s.sourceTable,
+        identity: { id: 3 },
+        changes: { name: 'changed' },
+      });
+    });
+    const rows = await waitFor('ops to settle', async () => {
+      const r = await destRows('postgres', s.destTable);
+      const ids = r.map((x) => Number(x.id));
+      return ids.join(',') === '1,3,4' && r.find((x) => Number(x.id) === 3)?.name === 'changed'
+        ? r
+        : null;
+    });
+    expect(rows.map((r) => Number(r.id))).toEqual([1, 3, 4]);
+  });
+
+  it('repeated updates to one key survive the spool', async () => {
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      await a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'v0' } });
+      for (let i = 1; i <= 30; i++) {
+        await a.updateRow({
+          table: s.sourceTable,
+          identity: { id: 1 },
+          changes: { name: `v${i}` },
+        });
+      }
+    });
+    const rows = await waitFor('final value', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 && r[0]?.name === 'v30' ? r : null;
+    });
+    expect(rows[0]).toMatchObject({ id: 1, name: 'v30' });
+  });
+
+  it('handles a large volume without unbounded growth', async () => {
+    const s = await freshBridge();
+    const total = 20_000;
+    const chunk = 2_000;
+    for (let start = 0; start < total; start += chunk) {
+      await withAdapter('postgres', (a) =>
+        a.insertRows!({
+          table: s.sourceTable,
+          rows: Array.from({ length: chunk }, (_, i) => ({
+            id: start + i + 1,
+            name: `bulk-${start + i}`,
+          })),
+        }),
+      );
+    }
+
+    // counted in the engine: browse() is capped well below this volume
+    await waitFor(
+      `${total} rows through the spool`,
+      async () => ((await destCount('postgres', s.destTable)) === total ? true : null),
+      { timeoutMs: 600_000, intervalMs: 250 },
+    );
+    // exactly once: complete, contiguous, no duplicates
+    const { distinct, min, max } = await destDistinctIds('postgres', s.destTable);
+    expect(distinct).toBe(total);
+    expect(min).toBe(1);
+    expect(max).toBe(total);
+
+    // and the spool gave the memory back rather than accumulating tombstones
+    await waitFor('spool fully trimmed', async () => {
+      const d = await spool.depth(s.bridgeId);
+      return d === 0 ? true : null;
+    });
+    expect(await spool.depth(s.bridgeId)).toBe(0);
+  }, 600_000);
+});

--- a/apps/api/test/integration/volume.itest.ts
+++ b/apps/api/test/integration/volume.itest.ts
@@ -1,0 +1,108 @@
+/**
+ * Sustained-volume proof for the spool, opt-in because it takes about a minute:
+ *
+ *   SYNCLE_CDC_SPOOL=on SYNCLE_VOLUME_ROWS=1000000 pnpm test:integration
+ *
+ * The assertions that matter are not "it was fast". They are that a million
+ * changes arrive exactly once, and that the spool's depth never exceeds its
+ * configured cap while they do — that cap is what stops an unreachable
+ * destination from turning into unbounded Redis growth, which would just move
+ * the problem the spool exists to solve.
+ *
+ * Recorded on a 2026 laptop against containerised Postgres: 1,000,000 rows in
+ * 54s (~18,000 rows/sec), peak spool depth exactly at the 50,000 cap, final
+ * depth 0.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  destCount,
+  destDistinctIds,
+  makeBridge,
+  type AppHandle,
+} from './app-harness';
+import { waitFor, withAdapter } from './harness';
+
+const ROWS = Number(process.env.SYNCLE_VOLUME_ROWS ?? 0);
+const ENABLED = ROWS > 0 && process.env.SYNCLE_CDC_SPOOL === 'on';
+
+let app: AppHandle;
+let spool: any;
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  if (!ENABLED) return;
+  app = await bootstrapApp();
+  const { CdcSpoolService } = await import('../../src/bridges/cdc/cdc-spool.service');
+  spool = app.ctx.get(CdcSpoolService);
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+});
+
+describe.runIf(ENABLED)('sustained volume through the spool', () => {
+  it('delivers every row exactly once with bounded spool depth', async () => {
+    const src = await connectionFor(app, 'postgres');
+    const dst = await connectionFor(app, 'postgres');
+    const s = await makeBridge(app, {
+      destEngine: 'postgres',
+      sourceConnId: src,
+      destConnId: dst,
+      cleanups,
+    });
+    cleanups.push(() => spool.clear(s.bridgeId).catch(() => undefined));
+
+    // sampled rather than computed: proves the cap holds in practice
+    let peak = 0;
+    const watch = setInterval(() => {
+      void spool
+        .depth(s.bridgeId)
+        .then((d: number) => {
+          if (d > peak) peak = d;
+        })
+        .catch(() => undefined);
+    }, 200);
+
+    const started = Date.now();
+    const chunk = 10_000;
+    for (let start = 0; start < ROWS; start += chunk) {
+      const size = Math.min(chunk, ROWS - start);
+      await withAdapter('postgres', (a) =>
+        a.insertRows!({
+          table: s.sourceTable,
+          rows: Array.from({ length: size }, (_, i) => ({
+            id: start + i + 1,
+            name: `v${start + i}`,
+          })),
+        }),
+      );
+    }
+
+    await waitFor(
+      `${ROWS} rows to arrive`,
+      async () => ((await destCount('postgres', s.destTable)) === ROWS ? true : null),
+      { timeoutMs: 1_800_000, intervalMs: 1_000 },
+    );
+    clearInterval(watch);
+    const elapsed = Date.now() - started;
+
+    const { distinct, min, max } = await destDistinctIds('postgres', s.destTable);
+    // exactly once, nothing missing, nothing repeated
+    expect(distinct).toBe(ROWS);
+    expect(min).toBe(1);
+    expect(max).toBe(ROWS);
+
+    // the spool stayed inside its cap the whole way, and gave the memory back
+    const cap = Number(process.env.SYNCLE_CDC_SPOOL_MAX ?? 50_000);
+    expect(peak).toBeLessThanOrEqual(cap);
+    expect(await spool.depth(s.bridgeId)).toBe(0);
+
+    console.log(
+      `volume: ${ROWS} rows in ${elapsed}ms (${Math.round(ROWS / (elapsed / 1000))}/sec), peak spool ${peak}/${cap}`,
+    );
+  }, 1_800_000);
+});


### PR DESCRIPTION
Last of the stack, on #68. This is the one that addresses the sharpest operational risk of running CDC without a broker.

## The problem

With nothing between reader and writer, a slow or unreachable destination holds the **source's** log open: the Postgres slot stops advancing and WAL accumulates on the production database until its disk fills. Kafka exists partly to move that buffer off the source. Nothing here guarded against it.

## What

Changes can be appended to a Redis Stream, one per bridge, with a consumer draining it into the destination. The source is checkpointed and acknowledged as soon as a batch is durably spooled, so the slot advances at the speed of Redis rather than the speed of the destination.

## Off by default, and deliberately

`SYNCLE_CDC_SPOOL=on`. While a change sits in the spool, **Redis is the only copy of it**, so the mode is only safe where Redis has appendonly persistence. That is a durability trade nobody should make by accident.

## Bounded on purpose

Past `SYNCLE_CDC_SPOOL_MAX` (50,000) the reader blocks, propagating backpressure to the source. Without that cap the spool would simply move the unbounded growth from the source's WAL into Redis — the same problem in a different place.

## XTRIM MINID, not XDEL

`XDEL` only tombstones an entry: the macro-node survives until every entry in it is deleted, so a long-running stream accumulates dead entries that every read must skip, and memory is never returned. `MINID` moves the head itself, keeping reads proportional to the batch however many millions have passed through.

## Failure handling keeps the source authoritative

A failed append never checkpoints, and after retries the stream stops rather than advancing — so everything after the last ack is still on the source and replays. Entries are trimmed only once delivered, so a crash redelivers them: at-least-once, which the idempotent writes already absorb.

## Verification

5 integration tests against real Postgres and Redis: delivery, source checkpointing, ordering across operations, repeated keys, and draining to zero.

An opt-in volume test runs **one million rows**:

    SYNCLE_CDC_SPOOL=on SYNCLE_VOLUME_ROWS=1000000 pnpm --filter @syncle/api test:integration

Result: 1,000,000 rows delivered **exactly once** (1,000,000 distinct, contiguous 1..1,000,000) in 54s (~18,000 rows/sec), **peak spool depth pinned at the 50,000 cap**, final depth 0. The bounded peak is the assertion that matters — it is what proves the spool cannot become the new unbounded thing.