### PR TITLE
docs: correct the MySQL claims and name the limits that bite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- MySQL CDC refuses to resume when the connection reaches a different server
+  than the one that issued its stored binlog position. File and position are
+  only meaningful on the issuing server, so after a failover the old cursor
+  pointed somewhere unrelated and the stream read it anyway. Cursors now carry
+  the server's `@@server_uuid`, and the transaction's GTID alongside it.
+- A MySQL bridge no longer starts reporting itself as running before the binlog
+  reader is positioned. On a fresh bridge that races the first writes, and rows
+  written immediately after starting were lost.
+
+### Changed
+
+- Documentation no longer claims MariaDB support. Connections, replay and watch
+  bridges work through `mysql2`, but CDC reads the binlog with a client that
+  targets MySQL and has not been verified against MariaDB. The 1.0.0 notes
+  below listed it; that was the claim being corrected here, not a regression.
+- `binlog_transaction_compression` is documented as unsupported. MySQL 8.0.20+
+  can wrap row events in a compressed payload event that the binlog reader
+  cannot decode, so those rows are not seen.
+
 ## [1.2.0] - 2026-08-21
 
 Setup no longer sends you to the container logs.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Connect your databases, draw a **bridge** from a source to one or more
 destinations, and Syncle keeps them in sync: the moment a row changes in the
 source, it's written to every destination you linked. Any engine to any engine —
-**PostgreSQL · MySQL/MariaDB · SQLite · MongoDB · Redis** — plus HTTP endpoints
+**PostgreSQL · MySQL · SQLite · MongoDB · Redis** — plus HTTP endpoints
 when you need them.
 
 <sub>A bridge is just: a source → one or more destinations → kept in sync.</sub>
@@ -26,7 +26,7 @@ when you need them.
 ![Next.js](https://img.shields.io/badge/Next.js-15-000000?logo=nextdotjs&logoColor=white)
 
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white)
-![MySQL](https://img.shields.io/badge/MySQL%20%2F%20MariaDB-4479A1?logo=mysql&logoColor=white)
+![MySQL](https://img.shields.io/badge/MySQL-4479A1?logo=mysql&logoColor=white)
 ![SQLite](https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white)
 ![MongoDB](https://img.shields.io/badge/MongoDB-47A248?logo=mongodb&logoColor=white)
 ![Redis](https://img.shields.io/badge/Redis-DC382D?logo=redis&logoColor=white)
@@ -421,7 +421,7 @@ for you and spells out what's missing.
 | Engine     | Mechanism              | What it needs                                                                                               |
 | ---------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- |
 | PostgreSQL | logical replication    | `wal_level=logical`, a role with REPLICATION (slot/publication auto-made)                                   |
-| MySQL      | binary log             | `log_bin=ON`, `binlog_format=ROW`, `binlog_row_image=FULL`, REPLICATION grants                              |
+| MySQL      | binary log             | `log_bin=ON`, `binlog_format=ROW`, `binlog_row_image=FULL`, REPLICATION grants, `binlog_transaction_compression=OFF` |
 | MongoDB    | change streams         | a replica set (a single-node one is fine for dev); pre-images auto-enabled so deletes propagate by your key |
 | Redis      | keyspace notifications | `notify-keyspace-events` (Syncle enables it when it can)                                               |
 | SQLite     | —                      | not supported; use a watch bridge instead                                                                     |
@@ -429,6 +429,21 @@ for you and spells out what's missing.
 > Redis CDC is real-time only and non-durable — events that happen while Syncle
 > is offline can't be recovered, so prefer a watch bridge there if you need
 > guarantees.
+
+**MySQL specifics.**
+
+- **`binlog_transaction_compression` is not supported.** MySQL 8.0.20+ can wrap
+  a transaction's row events inside a compressed payload event, which the
+  binlog reader has no decoder for — the rows inside it are not seen. Leave it
+  `OFF` on a source you stream from.
+- **MariaDB is untested.** Connections, replay and watch bridges go through
+  `mysql2` and work, but CDC reads the binlog with a client that targets MySQL,
+  and that path has not been verified against MariaDB. Treat MariaDB CDC as
+  unsupported until it has been.
+- **Binlog positions are per-server.** A cursor records the server's
+  `@@server_uuid`; if a connection later reaches a different server (a
+  failover), the bridge refuses to resume rather than reading unrelated
+  offsets. Reset it to start from the current position.
 
 ## Scripts
 

--- a/website/app/docs/cdc/page.tsx
+++ b/website/app/docs/cdc/page.tsx
@@ -46,7 +46,7 @@ export default function Page() {
               <td>Publication and replication slot, per bridge</td>
             </tr>
             <tr>
-              <td>MySQL / MariaDB</td>
+              <td>MySQL</td>
               <td>Row-based binlog</td>
               <td>
                 <code>log_bin=ON</code>, <code>binlog_format=ROW</code>,{' '}
@@ -103,7 +103,7 @@ export default function Page() {
         off without skipping changes.
       </p>
 
-      <h3 id="mysql">MySQL / MariaDB</h3>
+      <h3 id="mysql">MySQL</h3>
       <p>
         Syncle connects as a replication client and decodes row events from
         the binary log. Four server settings matter, and on managed MySQL
@@ -122,6 +122,33 @@ server_id        = 1   # any unique id`}</CodeBlock>
         There is nothing to provision — the binlog already exists. The cursor
         is the binlog file and position, so MySQL CDC is durable and resumes
         exactly after a restart, even in the middle of a multi-row statement.
+      </p>
+      <p>
+        Three limits are worth knowing before you point a bridge at MySQL.
+      </p>
+      <p>
+        <strong>
+          <code>binlog_transaction_compression</code> is not supported.
+        </strong>{' '}
+        MySQL 8.0.20 and later can wrap a transaction&apos;s row events inside a
+        compressed payload event, and the binlog reader has no decoder for it —
+        the rows inside are not seen. Leave it <code>OFF</code> on a source you
+        stream from.
+      </p>
+      <p>
+        <strong>MariaDB is untested.</strong> Connections, replay and watch
+        bridges go through <code>mysql2</code> and work, but CDC reads the
+        binlog with a client that targets MySQL and that path has not been
+        verified against MariaDB. Treat MariaDB CDC as unsupported until it has
+        been.
+      </p>
+      <p>
+        <strong>Binlog positions belong to one server.</strong> A cursor records
+        the server&apos;s <code>@@server_uuid</code> (and the GTID of the
+        transaction it sits at). If the connection later reaches a different
+        server — after a failover, say — the bridge refuses to resume rather
+        than reading unrelated offsets, and says so. Reset it to start from the
+        current position.
       </p>
 
       <h3 id="mongodb">MongoDB</h3>

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -16,7 +16,7 @@ export default function DocsIndex() {
       </p>
 
       <p>
-        It speaks five engines — PostgreSQL, MySQL/MariaDB, SQLite, MongoDB
+        It speaks five engines — PostgreSQL, MySQL, SQLite, MongoDB
         and Redis — and any of them can sit on either end of a bridge. A
         relational table can feed a document store, a document collection can
         feed a key-value cache, and an HTTP endpoint can stand in for a

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -115,7 +115,7 @@ export default function Home() {
           </p>
 
           <p className="mt-4 max-w-[70ch]">
-            It speaks PostgreSQL, MySQL and MariaDB, SQLite, MongoDB and Redis,
+            It speaks PostgreSQL, MySQL, SQLite, MongoDB and Redis,
             and any of them can sit on either end. An HTTP endpoint works as a
             destination too, when the thing that needs the rows is a service
             rather than a database.

--- a/website/lib/content.ts
+++ b/website/lib/content.ts
@@ -25,7 +25,7 @@ export const DESCRIPTION =
 export const FAQ: { q: string; a: string }[] = [
   {
     q: 'Which databases can Syncle sync between?',
-    a: 'PostgreSQL, MySQL and MariaDB, SQLite, MongoDB and Redis — in any combination. A relational source can write into a document or key-value store and back, with values translated to fit the target. HTTP endpoints work as a destination too, when you are feeding a service rather than a database.',
+    a: 'PostgreSQL, MySQL, SQLite, MongoDB and Redis — in any combination. A relational source can write into a document or key-value store and back, with values translated to fit the target. HTTP endpoints work as a destination too, when you are feeding a service rather than a database.',
   },
   {
     q: 'Does it sync in real time, or on a schedule?',


### PR DESCRIPTION
Independent of the CDC stack (#64–#69) — this only touches documentation and can merge on its own, in any order.

## MariaDB was overclaimed

It was listed as a supported engine everywhere. Connections, replay and watch bridges **do** work through `mysql2` — but CDC reads the binlog with a client that targets MySQL and has never been verified against MariaDB.

The top-level "engines it syncs" claims (landing page, docs index, README headline, FAQ) now say MySQL. The CDC page states plainly that MariaDB CDC is untested.

**The workbench pages still say MySQL/MariaDB on purpose.** Browsing, queries, DDL and SSH tunnels genuinely do work there. The distinction between "the workbench speaks MariaDB" and "CDC has not been tested against MariaDB" is the accurate position, not an inconsistency.

## `binlog_transaction_compression` was undocumented

MySQL 8.0.20+ can wrap a transaction's row events inside a compressed payload event that the binlog reader has no decoder for, so **those rows are silently not seen**. It is now listed as a required server setting (`OFF`) in the prerequisites table and explained on the CDC docs page.

Worth flagging: this is documentation only. A readiness check that refuses to start against a compressed source is still not implemented, so today the protection is that an operator reads this.

## Binlog positions are per-server

Also previously unstated, and now covered — a cursor carries the issuing server's `@@server_uuid`, and a resume against a different server is refused. (The code for that is #68; this documents it.)

## On the changelog

The 1.0.0 entry is left exactly as written. A changelog records what was released, not what we later wish it had said — so the correction goes under `[Unreleased]` instead, where it also notes the two MySQL fixes from #68.

Website builds clean.