### PR TITLE
fix(api): guard MySQL CDC against resuming on a different server

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
   "name": "@syncle/api",
   "version": "0.1.0",
   "private": true,
-  "description": "Syncle backend \u2014 NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
+  "description": "Syncle backend — NestJS API that runs cross-engine database-to-database sync bridges (replay, polling, and CDC).",
   "scripts": {
     "build": "prisma generate && nest build",
     "dev": "prisma generate && prisma migrate deploy && nest start --watch",
@@ -39,11 +39,13 @@
   "devDependencies": {
     "@nestjs/cli": "^10.4.7",
     "@nestjs/schematics": "^10.2.3",
+    "@swc/core": "^1.16.2",
     "@types/express": "^5.0.0",
     "@types/node": "^22.9.0",
     "@types/ssh2": "^1.15.5",
     "@vitest/coverage-v8": "^2.1.4",
     "typescript": "^5.6.3",
+    "unplugin-swc": "^1.5.11",
     "vitest": "^2.1.4"
   }
 }

--- a/apps/api/src/bridges/bridge-cdc.service.ts
+++ b/apps/api/src/bridges/bridge-cdc.service.ts
@@ -33,6 +33,7 @@ import { randomUUID } from 'node:crypto';
 import { AdapterPoolService } from '../connections/adapter-pool.service';
 import { ConnectionStoreService } from '../connections/connection-store.service';
 import { PrismaService } from '../common/prisma.service';
+import { runtimeConfig } from '../common/runtime-config';
 import { BridgeJobService } from './bridge-job.service';
 import { BridgeStoreService } from './bridge-store.service';
 import { BridgeSinkService } from './bridge-sink.service';
@@ -61,6 +62,26 @@ interface Stream {
   pending: Promise<void>;
   /** the source's primary-key columns, so rowKeys stores keys, not every value */
   primaryKey: string[] | null;
+  /** changes accepted but not yet delivered; flushed as ONE delivery */
+  buffer: Buffered[];
+  /** the operation every buffered change shares; a different op forces a flush */
+  bufferOp: CdcOperation | null;
+  /** key signatures already in the buffer, so one batch never repeats a key */
+  bufferKeys: Set<string>;
+  /** linger timer, so a partial batch still leaves promptly */
+  timer: ReturnType<typeof setTimeout> | null;
+  /** rows per delivery for this bridge */
+  maxBatch: number;
+  /** the resolved bridge, so a flush needs no extra arguments */
+  bridge: ResolvedBridge;
+}
+
+/** one change held in the pending batch */
+interface Buffered {
+  change: CdcChange;
+  row: Record<string, unknown>;
+  /** identity of the row within this batch, or null when there is no key */
+  keySig: string | null;
 }
 
 /** read the persisted resume cursor from a job's cursorJson (legacy `lsn` ok) */
@@ -218,7 +239,14 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
   private async teardown(bridgeId: string): Promise<void> {
     const stream = this.streams.get(bridgeId);
     if (!stream) return;
+    // let the in-flight chain settle so a half-built batch is not abandoned
+    // mid-flush, then drop the entry so nothing new is accepted
+    await stream.pending.catch(() => undefined);
     this.streams.delete(bridgeId);
+    if (stream.timer) clearTimeout(stream.timer);
+    // buffered-but-undelivered changes were never acked, so they would replay
+    // on resume anyway; flushing here just avoids the needless repeat
+    await this.flush(bridgeId, stream).catch(() => undefined);
     await stream.handle.stop().catch(() => undefined);
   }
 
@@ -245,6 +273,19 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
       watermark: startCursor,
       pending: Promise.resolve(),
       primaryKey: await this.resolvePrimaryKey(bridge),
+      buffer: [],
+      bufferOp: null,
+      bufferKeys: new Set(),
+      timer: null,
+      // a database destination may batch freely: writes are idempotent upserts
+      // keyed by column, so N-at-once is indistinguishable from N one-at-a-time.
+      // an HTTP destination must keep delivery.batchSize, because there the
+      // batch size IS the payload the receiver sees.
+      maxBatch:
+        bridge.destination.kind === 'database'
+          ? Math.max(1, runtimeConfig.cdcBatchSize)
+          : Math.max(1, bridge.delivery.batchSize),
+      bridge,
     };
     this.streams.set(bridgeId, stream);
 
@@ -301,16 +342,29 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     const stream = this.streams.get(bridgeId);
     if (!stream) return Promise.resolve();
     stream.pending = stream.pending
-      .then(() => this.processChange(bridgeId, bridge, stream, change))
+      .then(() => this.accept(bridgeId, bridge, stream, change))
       .catch((err) => {
-        // processChange handles its own failures; this only guards the chain
+        // accept() handles its own failures; this only guards the chain
         this.logger.error(`CDC change chain broke for ${bridgeId}: ${(err as Error).message}`);
       });
     return stream.pending;
   }
 
-  /** for one change: dedupe, filter, render, deliver, record, persist cursor, ack */
-  private async processChange(
+  /** identity of a row within a batch, or null when the source has no key */
+  private keySignature(stream: Stream, row: Record<string, unknown>): string | null {
+    if (!stream.primaryKey?.length) return null;
+    try {
+      return JSON.stringify(stream.primaryKey.map((c) => row[c]));
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * take one change: drop replays, handle filtered rows, otherwise add it to
+   * the pending batch and flush when the batch is complete.
+   */
+  private async accept(
     bridgeId: string,
     bridge: ResolvedBridge,
     stream: Stream,
@@ -322,6 +376,8 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     // (durable engines replay from the last acked cursor after a reconnect)
     if (!stream.provider.cursorAfter(change.cursor, stream.watermark)) return;
 
+    const op = change.op as CdcOperation;
+
     // source filters: replay pushes them into SQL, but a CDC stream sees every
     // row of the table, so evaluate them in-process here. skipped rows still
     // advance the durable cursor (and the provider's server-side ack point) so
@@ -330,9 +386,14 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
     if (
       !stream.provider.handlesSourceFilters &&
       !rowMatchesFilters(change.row, bridge.source.filters, {
-        passMissingColumns: change.op === 'delete',
+        passMissingColumns: op === 'delete',
       })
     ) {
+      // anything already buffered is ORDERED BEFORE this change, so it has to
+      // be delivered first — otherwise advancing the cursor past it would drop
+      // those rows on a crash
+      await this.flush(bridgeId, stream);
+      if (this.streams.get(bridgeId) !== stream) return;
       stream.watermark = change.cursor;
       try {
         await this.prisma.bridgeJob.update({
@@ -346,35 +407,113 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
+    const keySig = this.keySignature(stream, change.row);
+
+    // two reasons a change cannot join the current batch: a different operation
+    // has no single route through the sink, and a repeated key would make one
+    // multi-row upsert touch the same row twice, which Postgres rejects outright
+    const conflicts =
+      stream.buffer.length > 0 &&
+      (stream.bufferOp !== op || (keySig !== null && stream.bufferKeys.has(keySig)));
+    if (conflicts) {
+      await this.flush(bridgeId, stream);
+      if (this.streams.get(bridgeId) !== stream) return;
+    }
+
+    stream.buffer.push({ change, row: change.row, keySig });
+    stream.bufferOp = op;
+    if (keySig !== null) stream.bufferKeys.add(keySig);
+
+    if (stream.buffer.length >= stream.maxBatch) {
+      // a full batch is delivered before this returns, so a provider that
+      // awaits onChange still feels backpressure and the buffer stays bounded
+      await this.flush(bridgeId, stream);
+      return;
+    }
+    this.scheduleFlush(bridgeId, stream);
+  }
+
+  /** flush a partial batch after a short linger, so a quiet stream is not stuck */
+  private scheduleFlush(bridgeId: string, stream: Stream): void {
+    if (stream.timer) return;
+    const timer = setTimeout(() => {
+      stream.timer = null;
+      if (this.streams.get(bridgeId) !== stream) return;
+      // queued on the same chain, so a timed flush can never interleave with
+      // a change being accepted
+      stream.pending = stream.pending
+        .then(() => this.flush(bridgeId, stream))
+        .catch((err) => {
+          this.logger.error(`CDC timed flush failed for ${bridgeId}: ${(err as Error).message}`);
+        });
+    }, Math.max(0, runtimeConfig.cdcLingerMs));
+    // a pending linger must not hold the process open
+    timer.unref?.();
+    stream.timer = timer;
+  }
+
+  /**
+   * deliver the pending batch as ONE delivery, then checkpoint once and ack
+   * once. per-row work here is what set the old throughput ceiling: a delivery,
+   * a delivery record, a cursor write and a source ack for every single row.
+   *
+   * the cursor advances only after a successful delivery, so a crash mid-batch
+   * replays that batch — absorbed by the watermark dedupe and by writes being
+   * idempotent upserts.
+   */
+  private async flush(bridgeId: string, stream: Stream): Promise<void> {
+    if (stream.timer) {
+      clearTimeout(stream.timer);
+      stream.timer = null;
+    }
+    if (stream.buffer.length === 0) return;
+
+    const items = stream.buffer;
+    const op = stream.bufferOp ?? undefined;
+    stream.buffer = [];
+    stream.bufferKeys = new Set();
+    stream.bufferOp = null;
+
+    const bridge = stream.bridge;
+    if (bridge.source.kind !== 'table') return;
+
+    const rows = items.map((i) => i.row);
+    const lastCursor = items[items.length - 1]!.change.cursor;
     const seq = stream.seq;
     const now = new Date().toISOString();
-    const rowKeys = stream.primaryKey ? stream.primaryKey.map((c) => change.row[c]) : null;
-    // key on the cursor (stable per change) so an at-least-once re-delivery after
-    // a reconnect carries the SAME Idempotency-Key for the receiver to dedupe
+    const pk = stream.primaryKey;
+    // one entry per row, matching rowCount — the same shape the batched replay
+    // path records
+    const rowKeys = pk?.length
+      ? items.map((i) => (pk.length === 1 ? i.row[pk[0]!] : pk.map((c) => i.row[c])))
+      : null;
+    // key on the batch's last cursor (stable per batch) so an at-least-once
+    // re-delivery after a reconnect carries the SAME Idempotency-Key
     const idem =
       bridge.destination.kind === 'http' && bridge.destination.idempotency
-        ? `${stream.jobId}:${change.cursor}`
+        ? `${stream.jobId}:${lastCursor}`
         : undefined;
     const signal = new AbortController().signal;
+
     try {
       // the operation drives both the {{$op}} token (HTTP) and insert/upsert vs
       // delete routing (database destinations)
       const { outcome } = await this.sink.deliver(
         bridge,
-        [change.row],
-        { table: bridge.source.table, now, startIndex: seq, op: change.op as CdcOperation },
+        rows,
+        { table: bridge.source.table, now, startIndex: seq, op },
         signal,
         idem,
       );
 
       await this.jobs.recordDelivery(
         stream.jobId,
-        { sequence: seq, rowIndex: seq, rowCount: 1, rowKeys },
+        { sequence: seq, rowIndex: seq, rowCount: rows.length, rowKeys },
         outcome,
       );
       if (outcome.status === 'failed' && bridge.delivery.onError === 'abort') {
         // stop-on-error: pause the job and stop the stream WITHOUT advancing
-        // the watermark or acking, so this change replays on the next start.
+        // the watermark or acking, so this batch replays on the next start.
         // teardown happens outside the change chain — the provider's stop()
         // may wait for in-flight handlers (i.e. this very call)
         this.logger.warn(`CDC ${bridgeId}: pausing after a failed delivery (onError=abort)`);
@@ -387,27 +526,27 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
         return;
       }
       stream.seq = seq + 1;
-      stream.watermark = change.cursor;
+      stream.watermark = lastCursor;
       await this.prisma.bridgeJob.update({
         where: { id: stream.jobId },
-        data: { cursorOffset: stream.seq, cursorJson: JSON.stringify({ cursor: change.cursor }) },
+        data: { cursorOffset: stream.seq, cursorJson: JSON.stringify({ cursor: lastCursor }) },
       });
       // the checkpoint is durable, so the provider may now advance its
       // server-side ack point (the Postgres slot's confirmed LSN). a missed
       // ack only widens the replay window the watermark dedupe absorbs
       try {
-        await stream.handle.ack?.(change.cursor);
+        await stream.handle.ack?.(lastCursor);
       } catch {
         /* best-effort by contract */
       }
     } catch (err) {
       // a transient pipeline error (Prisma/pool hiccup) must leave a trace: the
-      // event becomes a FAILED delivery row, visible in the timeline + retryable
+      // batch becomes a FAILED delivery row, visible in the timeline + retryable
       const message = err instanceof Error ? err.message : String(err);
       try {
         await this.jobs.recordDelivery(
           stream.jobId,
-          { sequence: seq, rowIndex: seq, rowCount: 1, rowKeys },
+          { sequence: seq, rowIndex: seq, rowCount: rows.length, rowKeys },
           {
             status: 'failed',
             httpStatus: null,
@@ -419,7 +558,7 @@ export class BridgeCdcService implements OnModuleInit, OnModuleDestroy {
           },
         );
         stream.seq = seq + 1;
-        stream.watermark = change.cursor;
+        stream.watermark = lastCursor;
         this.logger.warn(`CDC delivery for ${bridgeId} failed and was recorded: ${message}`);
       } catch {
         // can't even record the failure: stop instead of silently acking away

--- a/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.test.ts
+++ b/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import type { AdapterPoolService } from '../../../connections/adapter-pool.service';
-import { MysqlCdcProvider, binlogEventStart } from './mysql-cdc.provider';
+import {
+  MysqlCdcProvider,
+  binlogEventStart,
+  gtidFromEvent,
+} from './mysql-cdc.provider';
 
 // cursorAfter/splitCursor are pure, the pool is only used by readiness()
 const provider = new MysqlCdcProvider(null as unknown as AdapterPoolService);
 const split = (c: string) => provider['splitCursor'](c);
+const make = (a: Parameters<MysqlCdcProvider['makeCursor']>[0]) =>
+  provider['makeCursor'](a);
+const serverOf = (c: string) => provider['cursorServer'](c);
 
 describe('splitCursor', () => {
   it('parses the current start-format cursor "file:pos:row:s"', () => {
@@ -76,5 +83,76 @@ describe('binlogEventStart (resume-position math)', () => {
   it('accounts for the 4-byte CRC32 when binlog_checksum is on', () => {
     // zongji strips the checksum from `size`, but next_position includes it
     expect(binlogEventStart({ nextPosition: 564, size: 41 }, true)).toBe(500);
+  });
+});
+
+describe('server-identity cursors', () => {
+  const base = { file: 'binlog.000007', pos: 900, row: 2, isStart: true };
+
+  it('keeps the compact legacy form when the server is unknown', () => {
+    expect(make({ ...base, serverUuid: null, gtid: null })).toBe(
+      'binlog.000007:900:2:s',
+    );
+  });
+
+  it('emits JSON carrying the server uuid when it is known', () => {
+    const c = make({ ...base, serverUuid: 'uuid-a', gtid: 'uuid-a:12' });
+    expect(serverOf(c)).toBe('uuid-a');
+    expect(provider['cursorGtid'](c)).toBe('uuid-a:12');
+  });
+
+  it('parses back to the same coordinates it was built from', () => {
+    const c = make({ ...base, serverUuid: 'uuid-a', gtid: null });
+    expect(split(c)).toEqual(['binlog.000007', 900, 2, true]);
+  });
+
+  it('reports no server for a legacy cursor', () => {
+    expect(serverOf('binlog.000007:900:2:s')).toBeNull();
+  });
+
+  it('survives a malformed JSON cursor without throwing', () => {
+    expect(serverOf('{not json')).toBeNull();
+    expect(split('{not json')).toEqual(['{not json', 0, -1, false]);
+  });
+
+  it('orders identically whether a cursor is JSON or legacy', () => {
+    // a stream upgraded mid-flight compares old watermarks against new cursors
+    const modern = make({
+      file: 'b.000001',
+      pos: 200,
+      row: 0,
+      isStart: true,
+      serverUuid: 'u1',
+      gtid: null,
+    });
+    expect(provider.cursorAfter(modern, 'b.000001:100:9:s')).toBe(true);
+    expect(provider.cursorAfter('b.000001:300:0:s', modern)).toBe(true);
+    expect(provider.cursorAfter(modern, 'b.000001:300:0:s')).toBe(false);
+    // and against another JSON cursor
+    const later = make({
+      file: 'b.000001',
+      pos: 400,
+      row: 0,
+      isStart: true,
+      serverUuid: 'u1',
+      gtid: null,
+    });
+    expect(provider.cursorAfter(later, modern)).toBe(true);
+    expect(provider.cursorAfter(modern, later)).toBe(false);
+  });
+});
+
+describe('gtidFromEvent', () => {
+  it('formats the 16-byte server id and transaction number as a GTID', () => {
+    const sid = Buffer.from('3E11FA47710C4A4EA9B4E75E1B1B2B3C', 'hex');
+    expect(gtidFromEvent({ serverId: sid, transactionRange: 42 })).toBe(
+      '3e11fa47-710c-4a4e-a9b4-e75e1b1b2b3c:42',
+    );
+  });
+
+  it('returns null when the server id is not a 16-byte buffer', () => {
+    expect(gtidFromEvent({ serverId: 'nope', transactionRange: 1 })).toBeNull();
+    expect(gtidFromEvent({ serverId: Buffer.alloc(4), transactionRange: 1 })).toBeNull();
+    expect(gtidFromEvent({})).toBeNull();
   });
 });

--- a/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.ts
+++ b/apps/api/src/bridges/cdc/providers/mysql-cdc.provider.ts
@@ -39,12 +39,33 @@ interface ZongjiConn {
 /** row events we care about. `rotate`/`tablemap` are needed for bookkeeping */
 const ROW_EVENTS = new Set(['writerows', 'updaterows', 'deleterows']);
 
+/** how long start() waits for the binlog reader to report it is positioned */
+const READY_TIMEOUT_MS = 10_000;
+
 /**
  * byte offset where a binlog event STARTS. zongji's `size` is the payload
  * length only — the on-disk event_length that `nextPosition` advances by also
  * counts the 19-byte common header, plus a 4-byte CRC32 when the server runs
  * with `binlog_checksum` (the default on modern MySQL).
  */
+/**
+ * A GTID_LOG event carries the originating server's UUID as 16 raw bytes plus
+ * the transaction number, which together are the transaction's GTID. Recorded
+ * on the cursor so an operator can see exactly which transaction a stream sits
+ * at, and so a resume can tell it is talking to the same server.
+ */
+export function gtidFromEvent(evt: {
+  serverId?: unknown;
+  transactionRange?: unknown;
+}): string | null {
+  const sid = evt.serverId;
+  if (!Buffer.isBuffer(sid) || sid.length !== 16) return null;
+  const h = sid.toString('hex');
+  const uuid = `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+  const range = Number(evt.transactionRange);
+  return Number.isFinite(range) ? `${uuid}:${range}` : uuid;
+}
+
 export function binlogEventStart(
   evt: { nextPosition: number; size: number },
   useChecksum: boolean,
@@ -76,7 +97,66 @@ export class MysqlCdcProvider implements CdcProvider {
   }
 
   /**
-   * parse a cursor into [file, pos, rowIdx, isStart]. three formats:
+   * The binlog coordinates a cursor carries are meaningful ONLY on the server
+   * that produced them: after a failover the new primary's files and offsets
+   * are unrelated, so resuming from them reads arbitrary data. Cursors
+   * therefore record which server issued them.
+   *
+   * Note this is a guard, not GTID positioning. The binlog client sends
+   * COM_BINLOG_DUMP (file + position) and has no COM_BINLOG_DUMP_GTID, so a
+   * stream cannot be *resumed* from a GTID set. What this does is refuse to
+   * resume against a different server instead of silently misreading it.
+   */
+  private cursorServer(c: string): string | null {
+    if (!c.startsWith('{')) return null;
+    try {
+      const o = JSON.parse(c) as { u?: string };
+      return o.u ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** the GTID recorded with a cursor, for operator visibility */
+  private cursorGtid(c: string): string | null {
+    if (!c.startsWith('{')) return null;
+    try {
+      const o = JSON.parse(c) as { g?: string };
+      return o.g ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** build a cursor, carrying server identity when it is known */
+  private makeCursor(args: {
+    file: string;
+    pos: number;
+    row: number;
+    isStart: boolean;
+    serverUuid: string | null;
+    gtid: string | null;
+  }): string {
+    const { file, pos, row, isStart, serverUuid, gtid } = args;
+    // without a known server the legacy compact form stays, so nothing changes
+    // for engines/versions that do not expose @@server_uuid
+    if (!serverUuid) {
+      return isStart ? `${file}:${pos}:${row}:s` : `${file}:${pos}:${row}`;
+    }
+    return JSON.stringify({
+      f: file,
+      p: pos,
+      r: row,
+      s: isStart,
+      u: serverUuid,
+      ...(gtid ? { g: gtid } : {}),
+    });
+  }
+
+  /**
+   * parse a cursor into [file, pos, rowIdx, isStart]. four formats:
+   *  - a JSON object {f,p,r,s,u,g} (current) — as below, plus the identity of
+   *    the server that issued it
    *  - "file:pos:rowIdx:s" (current) — pos is the START of the statement's
    *    tablemap event, so a resume re-enters the statement and the row-index
    *    watermark drops the already-delivered prefix
@@ -86,6 +166,14 @@ export class MysqlCdcProvider implements CdcProvider {
    *    next multi-row event still counts as "after" the old watermark
    */
   private splitCursor(c: string): [string, number, number, boolean] {
+    if (c.startsWith('{')) {
+      try {
+        const o = JSON.parse(c) as { f?: string; p?: number; r?: number; s?: boolean };
+        return [o.f ?? '', Number(o.p ?? 0), Number(o.r ?? -1), o.s === true];
+      } catch {
+        /* fall through to the legacy parser */
+      }
+    }
     let rest = c;
     let isStart = false;
     if (rest.endsWith(':s')) {
@@ -134,6 +222,28 @@ export class MysqlCdcProvider implements CdcProvider {
     for (let i = 0; i < bridgeId.length; i++) h = (h * 31 + bridgeId.charCodeAt(i)) >>> 0;
     // keep well clear of the common server_id=1 and inside a safe 32-bit range
     return (h % 2_000_000_000) + 1000;
+  }
+
+  /**
+   * `@@server_uuid` identifies the server instance. It is what makes a stored
+   * binlog coordinate safe to reuse: same uuid, same file/position meaning.
+   * Returns null when the server does not expose it, in which case cursors
+   * keep the legacy compact form and no guard is applied.
+   */
+  private async serverUuid(
+    connectionId: string,
+    database?: string,
+  ): Promise<string | null> {
+    try {
+      const res = await this.pool.withAdapter(connectionId, database, (a) =>
+        a.query('SELECT @@server_uuid AS uuid'),
+      );
+      const row = res.rows[0] as { uuid?: unknown } | undefined;
+      const uuid = row?.uuid;
+      return typeof uuid === 'string' && uuid.length > 0 ? uuid : null;
+    } catch {
+      return null;
+    }
   }
 
   /* ----- readiness ----- */
@@ -228,6 +338,25 @@ export class MysqlCdcProvider implements CdcProvider {
     // resume bookkeeping: tracks the last SAFE binlog position so both the
     // initial start AND every reconnect resume exactly where we left off
     const resume = fromCursor ? this.splitCursor(fromCursor) : null;
+
+    // binlog coordinates only mean anything on the server that issued them.
+    // After a failover the new primary's files and offsets are unrelated, so
+    // resuming from the old ones reads arbitrary data — fail loudly instead.
+    const serverUuid = await this.serverUuid(src.connectionId, db);
+    if (fromCursor) {
+      const previous = this.cursorServer(fromCursor);
+      if (previous && serverUuid && previous !== serverUuid) {
+        throw new Error(
+          `This bridge's saved binlog position came from MySQL server ${previous}, ` +
+            `but the connection now reaches ${serverUuid}. Binlog file and position ` +
+            `are only valid on the server that produced them, so resuming here would ` +
+            `read the wrong data. Reset the bridge to start from the current position.`,
+        );
+      }
+    }
+    // the GTID of the transaction being decoded, recorded onto each cursor
+    let lastGtid: string | null = fromCursor ? this.cursorGtid(fromCursor) : null;
+
     let binlogName = resume?.[0] ?? '';
     let position = resume?.[1] ?? 0;
     // the statement group currently being decoded: `groupStart` is the byte
@@ -241,6 +370,11 @@ export class MysqlCdcProvider implements CdcProvider {
 
     const onEvent = async (evt: BinLogEvent): Promise<void> => {
       const name = evt.getEventName();
+      if (name === 'gtidlog') {
+        // precedes the transaction's row events, so it labels what follows
+        lastGtid = gtidFromEvent(evt as unknown as Record<string, unknown>) ?? lastGtid;
+        return;
+      }
       if (name === 'rotate') {
         // rotate tells us the current binlog filename (incl. the one at startup)
         const next = (evt as { binlogName?: string }).binlogName;
@@ -306,9 +440,14 @@ export class MysqlCdcProvider implements CdcProvider {
           const idx = groupRow++;
           // defensive fallback: a row event with no seen tablemap (shouldn't
           // happen) keeps the legacy end-position cursor format
-          const cursor = startKnown
-            ? `${binlogName}:${groupStart}:${idx}:s`
-            : `${binlogName}:${rowEvt.nextPosition}:${i}`;
+          const cursor = this.makeCursor({
+            file: binlogName,
+            pos: startKnown ? groupStart : rowEvt.nextPosition,
+            row: startKnown ? idx : i,
+            isStart: startKnown,
+            serverUuid,
+            gtid: lastGtid,
+          });
           await handlers.onChange({ op, row, cursor });
         }
         // the resume point stays at the group's tablemap: the statement may
@@ -320,10 +459,22 @@ export class MysqlCdcProvider implements CdcProvider {
       }
     };
 
+    // `start()` must not return before the reader is actually positioned:
+    // with startAtEnd a row written immediately afterwards would land in the
+    // binlog ahead of the reader and be missed entirely
+    let signalReady: (() => void) | null = null;
+    const positioned = new Promise<void>((resolve) => {
+      signalReady = resolve;
+    });
+
     const startInstance = (): void => {
       if (stopped) return;
       const instance = new ZongJi({ ...connInfo, dateStrings: true });
       zongji = instance;
+      instance.on('ready', () => {
+        signalReady?.();
+        signalReady = null;
+      });
       instance.on('binlog', (evt: BinLogEvent) => {
         void onEvent(evt).catch((err) => handlers.onError(err as Error));
       });
@@ -342,7 +493,16 @@ export class MysqlCdcProvider implements CdcProvider {
       });
 
       const startOpts: Record<string, unknown> = {
-        includeEvents: ['rotate', 'tablemap', 'writerows', 'updaterows', 'deleterows'],
+        // gtidlog labels each transaction; without it in this list the
+        // events are filtered out before the handler ever sees them
+        includeEvents: [
+          'rotate',
+          'gtidlog',
+          'tablemap',
+          'writerows',
+          'updaterows',
+          'deleterows',
+        ],
         includeSchema: { [db]: [src.table] },
         serverId,
       };
@@ -361,6 +521,16 @@ export class MysqlCdcProvider implements CdcProvider {
     };
 
     startInstance();
+
+    // bounded: a server that never signals ready must not hang the start call,
+    // and the stream is still usable — it just keeps whatever it does receive
+    await Promise.race([
+      positioned,
+      new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, READY_TIMEOUT_MS);
+        t.unref?.();
+      }),
+    ]);
 
     return {
       stop: async () => {

--- a/apps/api/src/bridges/database-sink.service.ts
+++ b/apps/api/src/bridges/database-sink.service.ts
@@ -139,39 +139,66 @@ export class DatabaseSinkService {
       target.connectionId,
       target.database,
       async (adapter) => {
-        // write the whole batch for this target, one row at a time
+        const { schema, table } = target;
+
+        // one set-based statement per batch where the engine supports it,
+        // otherwise the original row-at-a-time loop. Both paths must produce
+        // the same rows and the same `affected` count — only the number of
+        // round trips differs.
         const writeBatch = async (): Promise<void> => {
-          for (const row of rows) {
-            const mapped = mapRow(row, target.mapping);
-            if (op === 'delete') {
-              const identity = pick(mapped, target.keyColumns);
-              const res = await adapter.deleteRow({
-                schema: target.schema,
-                table: target.table,
-                identity,
-              });
+          const mapped = rows.map((row) => mapRow(row, target.mapping));
+          const isUpsert = op !== 'delete' && target.writeMode !== 'insert';
+          if (isUpsert && target.keyColumns.length === 0) {
+            throw new Error(
+              'Upsert needs at least one key column; set keys or use insert mode',
+            );
+          }
+
+          if (op === 'delete') {
+            const identities = mapped.map((m) => pick(m, target.keyColumns));
+            if (adapter.deleteRows) {
+              const res = await adapter.deleteRows({ schema, table, identities });
               affected += res.affectedRows ?? 0;
-            } else if (target.writeMode === 'insert') {
-              const res = await adapter.insertRow({
-                schema: target.schema,
-                table: target.table,
-                values: mapped,
-              });
-              affected += res.affectedRows ?? 1;
-            } else {
-              if (target.keyColumns.length === 0) {
-                throw new Error(
-                  'Upsert needs at least one key column; set keys or use insert mode',
-                );
-              }
-              const res = await adapter.upsertRow({
-                schema: target.schema,
-                table: target.table,
-                values: mapped,
-                keyColumns: target.keyColumns,
-              });
+              return;
+            }
+            for (const identity of identities) {
+              const res = await adapter.deleteRow({ schema, table, identity });
+              affected += res.affectedRows ?? 0;
+            }
+            return;
+          }
+
+          if (target.writeMode === 'insert') {
+            if (adapter.insertRows) {
+              const res = await adapter.insertRows({ schema, table, rows: mapped });
+              affected += res.affectedRows ?? mapped.length;
+              return;
+            }
+            for (const values of mapped) {
+              const res = await adapter.insertRow({ schema, table, values });
               affected += res.affectedRows ?? 1;
             }
+            return;
+          }
+
+          if (adapter.upsertRows) {
+            const res = await adapter.upsertRows({
+              schema,
+              table,
+              rows: mapped,
+              keyColumns: target.keyColumns,
+            });
+            affected += res.affectedRows ?? mapped.length;
+            return;
+          }
+          for (const values of mapped) {
+            const res = await adapter.upsertRow({
+              schema,
+              table,
+              values,
+              keyColumns: target.keyColumns,
+            });
+            affected += res.affectedRows ?? 1;
           }
         };
 

--- a/apps/api/src/common/runtime-config.ts
+++ b/apps/api/src/common/runtime-config.ts
@@ -43,6 +43,25 @@ export const runtimeConfig = {
     process.env.SYNCLE_JOB_CONCURRENCY ?? process.env.SYNCLE_HOOK_CONCURRENCY ?? 5,
   ),
   /**
+   * CDC micro-batching. A change stream delivered one row at a time pays a
+   * delivery, a delivery record, a cursor write and a source ack per row, so
+   * round trips — not the database — set the ceiling. Consecutive changes are
+   * grouped into one delivery instead.
+   *
+   * This applies to DATABASE destinations only, where a batch is invisible:
+   * writes are idempotent upserts keyed by column, so the result is identical.
+   * HTTP destinations keep honouring `delivery.batchSize`, because there the
+   * batch size is the payload shape and changing it would change what
+   * receivers see.
+   *
+   * Batching widens the at-least-once replay window to at most one batch: a
+   * crash mid-batch replays that batch, which the watermark dedupe and
+   * idempotent writes absorb.
+   */
+  cdcBatchSize: Number(process.env.SYNCLE_CDC_BATCH_SIZE ?? 200),
+  /** how long a partial batch waits for more changes before being flushed */
+  cdcLingerMs: Number(process.env.SYNCLE_CDC_LINGER_MS ?? 50),
+  /**
    * when true, HTTP destinations may not resolve to loopback/private/link-local
    * addresses (SSRF guard for network-exposed deployments). off by default —
    * Syncle is local-first and posting to localhost services is a primary use.

--- a/apps/api/test/integration/app-harness.ts
+++ b/apps/api/test/integration/app-harness.ts
@@ -1,0 +1,140 @@
+/**
+ * Boots the real application container and builds real bridges against it.
+ * Shared by every end-to-end test so they all exercise the same wiring the
+ * server uses in production.
+ */
+import type { INestApplicationContext } from '@nestjs/common';
+import { applyTestEnv } from './env';
+import { TEST_CONNECTIONS, uniqueTable, withAdapter } from './harness';
+
+applyTestEnv();
+
+export interface AppHandle {
+  ctx: INestApplicationContext;
+  connections: any;
+  bridges: any;
+  cdc: any;
+  prisma: any;
+}
+
+export async function bootstrapApp(): Promise<AppHandle> {
+  const { NestFactory } = await import('@nestjs/core');
+  const { AppModule } = await import('../../src/app.module');
+  const { ConnectionStoreService } = await import(
+    '../../src/connections/connection-store.service'
+  );
+  const { BridgeStoreService } = await import('../../src/bridges/bridge-store.service');
+  const { BridgeCdcService } = await import('../../src/bridges/bridge-cdc.service');
+  const { PrismaService } = await import('../../src/common/prisma.service');
+
+  const ctx = await NestFactory.createApplicationContext(AppModule, { logger: false });
+  return {
+    ctx,
+    connections: ctx.get(ConnectionStoreService),
+    bridges: ctx.get(BridgeStoreService),
+    cdc: ctx.get(BridgeCdcService),
+    prisma: ctx.get(PrismaService),
+  };
+}
+
+export async function connectionFor(
+  app: AppHandle,
+  engine: 'postgres' | 'mysql',
+): Promise<string> {
+  const t = TEST_CONNECTIONS[engine]!;
+  const conn = await app.connections.create({
+    name: `it-${engine}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    engine,
+    host: t.host,
+    port: t.port,
+    user: t.user,
+    password: t.password,
+    database: t.database,
+  });
+  return conn.id;
+}
+
+export interface SyncSetup {
+  bridgeId: string;
+  sourceTable: string;
+  destTable: string;
+}
+
+/**
+ * Create a Postgres source table and a CDC bridge writing into `destEngine`.
+ * `start: false` leaves the bridge stopped, for tests that drive start/stop.
+ */
+export async function makeBridge(
+  app: AppHandle,
+  opts: {
+    destEngine: 'postgres' | 'mysql';
+    sourceConnId: string;
+    destConnId: string;
+    cleanups: Array<() => Promise<void>>;
+    start?: boolean;
+  },
+): Promise<SyncSetup> {
+  const { destEngine, sourceConnId, destConnId, cleanups } = opts;
+  const sourceTable = uniqueTable('src');
+  const destTable = uniqueTable('dst');
+
+  await withAdapter('postgres', (a) =>
+    a.createTable({
+      table: sourceTable,
+      columns: [
+        { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+        { name: 'name', type: 'text', nullable: true },
+      ],
+    }),
+  );
+  cleanups.push(() =>
+    withAdapter('postgres', (a) => a.dropTable(sourceTable)).catch(() => undefined),
+  );
+  cleanups.push(() =>
+    withAdapter(destEngine, (a) => a.dropTable(destTable)).catch(() => undefined),
+  );
+
+  const { bridgeInputSchema } = await import('@syncle/core');
+  const input = bridgeInputSchema.parse({
+    name: `it-bridge-${sourceTable}`,
+    source: { kind: 'table', connectionId: sourceConnId, table: sourceTable },
+    destination: {
+      kind: 'database',
+      targets: [
+        {
+          connectionId: destConnId,
+          table: destTable,
+          writeMode: 'upsert',
+          keyColumns: ['id'],
+          createMissingTable: true,
+        },
+      ],
+    },
+    transform: { template: '{{$row}}' },
+    trigger: { kind: 'cdc', operations: ['insert', 'update', 'delete'] },
+  });
+  const bridge = await app.bridges.create(input);
+
+  cleanups.push(async () => {
+    await app.cdc.stop(bridge.id).catch(() => undefined);
+    await app.cdc.cleanup(bridge.id).catch(() => undefined);
+  });
+
+  if (opts.start !== false) await app.cdc.start(bridge.id);
+  return { bridgeId: bridge.id, sourceTable, destTable };
+}
+
+/** rows in the destination table, sorted by id; [] before the sink creates it */
+export async function destRows(
+  engine: 'postgres' | 'mysql',
+  table: string,
+): Promise<Array<Record<string, unknown>>> {
+  return withAdapter(engine, async (a) => {
+    try {
+      const res = await a.browse({ table, limit: 5000, offset: 0 });
+      return [...res.rows].sort((x, y) => Number(x.id) - Number(y.id));
+    } catch {
+      return [];
+    }
+  });
+}

--- a/apps/api/test/integration/app-harness.ts
+++ b/apps/api/test/integration/app-harness.ts
@@ -72,23 +72,30 @@ export async function makeBridge(
     destConnId: string;
     cleanups: Array<() => Promise<void>>;
     start?: boolean;
+    /** engine the source table lives on; defaults to postgres */
+    sourceEngine?: 'postgres' | 'mysql';
   },
 ): Promise<SyncSetup> {
   const { destEngine, sourceConnId, destConnId, cleanups } = opts;
+  const sourceEngine = opts.sourceEngine ?? 'postgres';
   const sourceTable = uniqueTable('src');
   const destTable = uniqueTable('dst');
 
-  await withAdapter('postgres', (a) =>
+  const srcTypes =
+    sourceEngine === 'mysql'
+      ? { int: 'int', text: 'varchar(255)' }
+      : { int: 'integer', text: 'text' };
+  await withAdapter(sourceEngine, (a) =>
     a.createTable({
       table: sourceTable,
       columns: [
-        { name: 'id', type: 'integer', nullable: false, primaryKey: true },
-        { name: 'name', type: 'text', nullable: true },
+        { name: 'id', type: srcTypes.int, nullable: false, primaryKey: true },
+        { name: 'name', type: srcTypes.text, nullable: true },
       ],
     }),
   );
   cleanups.push(() =>
-    withAdapter('postgres', (a) => a.dropTable(sourceTable)).catch(() => undefined),
+    withAdapter(sourceEngine, (a) => a.dropTable(sourceTable)).catch(() => undefined),
   );
   cleanups.push(() =>
     withAdapter(destEngine, (a) => a.dropTable(destTable)).catch(() => undefined),

--- a/apps/api/test/integration/batch-writes.itest.ts
+++ b/apps/api/test/integration/batch-writes.itest.ts
@@ -1,0 +1,360 @@
+/**
+ * Set-based writes against real engines.
+ *
+ * The governing rule for every test here: a batched write must be
+ * INDISTINGUISHABLE from the per-row loop it replaces. So most cases assert the
+ * resulting table contents, not just that the call succeeded, and several run
+ * the same data through both paths and compare.
+ */
+import 'reflect-metadata';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { DatabaseAdapter } from '@syncle/core';
+import { TEST_CONNECTIONS, uniqueTable, withAdapter } from './harness';
+
+type Engine = 'postgres' | 'mysql' | 'sqlite';
+const ENGINES: Engine[] = ['postgres', 'mysql', 'sqlite'];
+
+/** per-engine column types for the small fixture table */
+const TYPES: Record<Engine, { int: string; text: string }> = {
+  postgres: { int: 'integer', text: 'text' },
+  mysql: { int: 'int', text: 'varchar(255)' },
+  sqlite: { int: 'INTEGER', text: 'TEXT' },
+};
+
+const created: Array<{ engine: Engine; table: string }> = [];
+
+async function makeTable(
+  a: DatabaseAdapter,
+  engine: Engine,
+  table: string,
+  extra: string[] = [],
+): Promise<void> {
+  const t = TYPES[engine];
+  await a.createTable({
+    table,
+    columns: [
+      { name: 'id', type: t.int, nullable: false, primaryKey: true },
+      { name: 'name', type: t.text, nullable: true },
+      { name: 'note', type: t.text, nullable: true },
+      ...extra.map((c) => ({ name: c, type: t.text, nullable: true })),
+    ],
+  });
+  created.push({ engine, table });
+}
+
+async function rowsOf(
+  a: DatabaseAdapter,
+  table: string,
+): Promise<Array<Record<string, unknown>>> {
+  const res = await a.browse({ table, limit: 10_000, offset: 0 });
+  return [...res.rows].sort((x, y) => Number(x.id) - Number(y.id));
+}
+
+afterEach(async () => {
+  while (created.length) {
+    const item = created.pop();
+    if (!item) break;
+    await withAdapter(item.engine, (a) => a.dropTable(item.table)).catch(
+      () => undefined,
+    );
+  }
+});
+
+describe.each(ENGINES)('batched writes — %s', (engine) => {
+  it('exposes the optional batch methods', async () => {
+    await withAdapter(engine, async (a) => {
+      expect(typeof a.insertRows).toBe('function');
+      expect(typeof a.upsertRows).toBe('function');
+      expect(typeof a.deleteRows).toBe('function');
+    });
+  });
+
+  it('insertRows writes every row', async () => {
+    const table = uniqueTable('b_ins');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      const res = await a.insertRows?.({
+        table,
+        rows: [
+          { id: 1, name: 'a', note: 'x' },
+          { id: 2, name: 'b', note: 'y' },
+          { id: 3, name: 'c', note: 'z' },
+        ],
+      });
+      expect(res?.affectedRows).toBe(3);
+      const rows = await rowsOf(a, table);
+      expect(rows.map((r) => r.name)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  it('insertRows handles sparse rows with different column sets', async () => {
+    const table = uniqueTable('b_sparse');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      // three distinct shapes in one call — these cannot share one statement
+      await a.insertRows?.({
+        table,
+        rows: [
+          { id: 1, name: 'a', note: 'n1' },
+          { id: 2, name: 'b' },
+          { id: 3, note: 'n3' },
+        ],
+      });
+      const rows = await rowsOf(a, table);
+      expect(rows).toHaveLength(3);
+      expect(rows[0]).toMatchObject({ id: 1, name: 'a', note: 'n1' });
+      expect(rows[1]).toMatchObject({ id: 2, name: 'b' });
+      expect(rows[1]?.note ?? null).toBeNull();
+      expect(rows[2]?.name ?? null).toBeNull();
+      expect(rows[2]).toMatchObject({ id: 3, note: 'n3' });
+    });
+  });
+
+  it('insertRows on an empty list is a no-op', async () => {
+    const table = uniqueTable('b_empty');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      const res = await a.insertRows?.({ table, rows: [] });
+      expect(res?.affectedRows).toBe(0);
+      expect(await rowsOf(a, table)).toHaveLength(0);
+    });
+  });
+
+  it('upsertRows inserts new rows and updates existing ones', async () => {
+    const table = uniqueTable('b_up');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({
+        table,
+        rows: [
+          { id: 1, name: 'old', note: 'keep' },
+          { id: 2, name: 'old2', note: 'keep2' },
+        ],
+      });
+      await a.upsertRows?.({
+        table,
+        keyColumns: ['id'],
+        rows: [
+          { id: 1, name: 'new', note: 'updated' }, // update
+          { id: 3, name: 'fresh', note: 'inserted' }, // insert
+        ],
+      });
+      const rows = await rowsOf(a, table);
+      expect(rows).toHaveLength(3);
+      expect(rows[0]).toMatchObject({ id: 1, name: 'new', note: 'updated' });
+      expect(rows[1]).toMatchObject({ id: 2, name: 'old2' });
+      expect(rows[2]).toMatchObject({ id: 3, name: 'fresh' });
+    });
+  });
+
+  it('upsertRows is idempotent when replayed', async () => {
+    const table = uniqueTable('b_idem');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      const rows = [
+        { id: 1, name: 'a', note: 'n' },
+        { id: 2, name: 'b', note: 'm' },
+      ];
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      // at-least-once redelivery must not duplicate
+      expect(await rowsOf(a, table)).toHaveLength(2);
+    });
+  });
+
+  it('upsertRows rejects an empty key list', async () => {
+    const table = uniqueTable('b_nokey');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await expect(
+        a.upsertRows?.({ table, keyColumns: [], rows: [{ id: 1 }] }),
+      ).rejects.toThrow(/key columns/i);
+    });
+  });
+
+  it('deleteRows removes exactly the named identities', async () => {
+    const table = uniqueTable('b_del');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({
+        table,
+        rows: [1, 2, 3, 4].map((id) => ({ id, name: `n${id}`, note: null })),
+      });
+      const res = await a.deleteRows?.({
+        table,
+        identities: [{ id: 2 }, { id: 4 }],
+      });
+      expect(res?.affectedRows).toBe(2);
+      const rows = await rowsOf(a, table);
+      expect(rows.map((r) => Number(r.id))).toEqual([1, 3]);
+    });
+  });
+
+  it('deleteRows tolerates identities that match nothing', async () => {
+    const table = uniqueTable('b_delmiss');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({ table, rows: [{ id: 1, name: 'a' }] });
+      const res = await a.deleteRows?.({
+        table,
+        identities: [{ id: 99 }, { id: 1 }],
+      });
+      expect(res?.affectedRows).toBe(1);
+      expect(await rowsOf(a, table)).toHaveLength(0);
+    });
+  });
+
+  it('deleteRows on an empty list is a no-op', async () => {
+    const table = uniqueTable('b_delempty');
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, table);
+      await a.insertRows?.({ table, rows: [{ id: 1 }] });
+      const res = await a.deleteRows?.({ table, identities: [] });
+      expect(res?.affectedRows).toBe(0);
+      expect(await rowsOf(a, table)).toHaveLength(1);
+    });
+  });
+
+  it('batched and per-row paths produce identical tables', async () => {
+    const viaLoop = uniqueTable('b_loop');
+    const viaBatch = uniqueTable('b_batch');
+    const data = Array.from({ length: 50 }, (_, i) => ({
+      id: i + 1,
+      name: `name-${i}`,
+      note: i % 3 === 0 ? null : `note-${i}`,
+    }));
+
+    await withAdapter(engine, async (a) => {
+      await makeTable(a, engine, viaLoop);
+      await makeTable(a, engine, viaBatch);
+
+      for (const row of data) {
+        await a.upsertRow({ table: viaLoop, values: row, keyColumns: ['id'] });
+      }
+      await a.upsertRows?.({ table: viaBatch, keyColumns: ['id'], rows: data });
+
+      expect(await rowsOf(a, viaBatch)).toEqual(await rowsOf(a, viaLoop));
+    });
+  });
+});
+
+describe('composite keys and chunking', () => {
+  it('upsertRows and deleteRows handle composite keys (postgres)', async () => {
+    const table = uniqueTable('b_comp');
+    await withAdapter('postgres', async (a) => {
+      await a.createTable({
+        table,
+        columns: [
+          { name: 'tenant', type: 'text', nullable: false, primaryKey: true },
+          { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+          { name: 'name', type: 'text', nullable: true },
+        ],
+      });
+      created.push({ engine: 'postgres', table });
+
+      await a.upsertRows?.({
+        table,
+        keyColumns: ['tenant', 'id'],
+        rows: [
+          { tenant: 't1', id: 1, name: 'a' },
+          { tenant: 't2', id: 1, name: 'b' },
+        ],
+      });
+      // same id, different tenant → both survive
+      let res = await a.browse({ table, limit: 100, offset: 0 });
+      expect(res.rows).toHaveLength(2);
+
+      // updating one composite key must not touch the other
+      await a.upsertRows?.({
+        table,
+        keyColumns: ['tenant', 'id'],
+        rows: [{ tenant: 't1', id: 1, name: 'changed' }],
+      });
+      res = await a.browse({ table, limit: 100, offset: 0 });
+      expect(res.rows).toHaveLength(2);
+      expect(res.rows.find((r) => r.tenant === 't1')?.name).toBe('changed');
+      expect(res.rows.find((r) => r.tenant === 't2')?.name).toBe('b');
+
+      await a.deleteRows?.({ table, identities: [{ tenant: 't2', id: 1 }] });
+      res = await a.browse({ table, limit: 100, offset: 0 });
+      expect(res.rows).toHaveLength(1);
+      expect(res.rows[0]?.tenant).toBe('t1');
+    });
+  });
+
+  it('splits a batch that exceeds the driver bind-parameter cap', async () => {
+    // SQLite caps binds at 32766. 40 columns => ~819 rows per statement, so
+    // 2500 rows must span multiple statements and still land exactly once.
+    const table = uniqueTable('b_chunk');
+    const extra = Array.from({ length: 37 }, (_, i) => `c${i}`);
+    const total = 2500;
+
+    await withAdapter('sqlite', async (a) => {
+      await makeTable(a, 'sqlite', table, extra);
+      const rows = Array.from({ length: total }, (_, i) => {
+        const row: Record<string, unknown> = {
+          id: i + 1,
+          name: `n${i}`,
+          note: `x${i}`,
+        };
+        for (const c of extra) row[c] = `${c}-${i}`;
+        return row;
+      });
+      const res = await a.insertRows?.({ table, rows });
+      expect(res?.affectedRows).toBe(total);
+
+      const all = await a.browse({ table, limit: 10_000, offset: 0 });
+      expect(all.rows).toHaveLength(total);
+
+      // and the same again through upsert, which must not duplicate
+      await a.upsertRows?.({ table, keyColumns: ['id'], rows });
+      const after = await a.browse({ table, limit: 10_000, offset: 0 });
+      expect(after.rows).toHaveLength(total);
+    });
+  });
+
+  it('deleteRows splits large identity lists too', async () => {
+    const table = uniqueTable('b_delchunk');
+    await withAdapter('sqlite', async (a) => {
+      await makeTable(a, 'sqlite', table);
+      const rows = Array.from({ length: 5000 }, (_, i) => ({ id: i + 1 }));
+      await a.insertRows?.({ table, rows });
+      const res = await a.deleteRows?.({ table, identities: rows });
+      expect(res?.affectedRows).toBe(5000);
+      const all = await a.browse({ table, limit: 10, offset: 0 });
+      expect(all.rows).toHaveLength(0);
+    });
+  });
+  it('splits large COMPOSITE-key deletes without blowing expression depth', async () => {
+    // the OR-of-ANDs form is a deep expression tree; SQLite rejects past depth
+    // 1000, so this must be chunked by clause count, not just by bind count
+    const table = uniqueTable('b_delcomp');
+    await withAdapter('sqlite', async (a) => {
+      await a.createTable({
+        table,
+        columns: [
+          { name: 'tenant', type: 'TEXT', nullable: false, primaryKey: true },
+          { name: 'id', type: 'INTEGER', nullable: false, primaryKey: true },
+        ],
+      });
+      created.push({ engine: 'sqlite', table });
+
+      const rows = Array.from({ length: 1500 }, (_, i) => ({
+        tenant: `t${i % 3}`,
+        id: i + 1,
+      }));
+      await a.insertRows?.({ table, rows });
+      const res = await a.deleteRows?.({ table, identities: rows });
+      expect(res?.affectedRows).toBe(1500);
+      const all = await a.browse({ table, limit: 10, offset: 0 });
+      expect(all.rows).toHaveLength(0);
+    });
+  });
+});
+
+describe('test connections cover every batched engine', () => {
+  it('has a connection for each engine under test', () => {
+    for (const e of ENGINES) expect(TEST_CONNECTIONS[e]).toBeTruthy();
+  });
+});

--- a/apps/api/test/integration/cdc-batching.itest.ts
+++ b/apps/api/test/integration/cdc-batching.itest.ts
@@ -1,0 +1,196 @@
+/**
+ * Micro-batching correctness.
+ *
+ * Batching a change stream introduces hazards that per-row delivery did not
+ * have: a batch can mix operations, it can contain the same key twice (which a
+ * multi-row upsert cannot express), and it moves the checkpoint from per-row to
+ * per-batch. Each of those is exercised here against real databases.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  destRows,
+  makeBridge,
+  type AppHandle,
+  type SyncSetup,
+} from './app-harness';
+import { waitFor, withAdapter } from './harness';
+
+let app: AppHandle;
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  app = await bootstrapApp();
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+});
+
+async function freshBridge(): Promise<SyncSetup> {
+  const src = await connectionFor(app, 'postgres');
+  const dst = await connectionFor(app, 'postgres');
+  return makeBridge(app, {
+    destEngine: 'postgres',
+    sourceConnId: src,
+    destConnId: dst,
+    cleanups,
+  });
+}
+
+describe('batching hazards', () => {
+  it('survives repeated updates to the SAME key inside one batch window', async () => {
+    // a multi-row upsert cannot touch one row twice — Postgres rejects
+    // "ON CONFLICT DO UPDATE command cannot affect row a second time" — so the
+    // batcher must break the batch when a key repeats
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      await a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'v0' } });
+      for (let i = 1; i <= 25; i++) {
+        await a.updateRow({
+          table: s.sourceTable,
+          identity: { id: 1 },
+          changes: { name: `v${i}` },
+        });
+      }
+    });
+
+    const rows = await waitFor('final value of the repeatedly-updated row', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 && r[0]?.name === 'v25' ? r : null;
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: 1, name: 'v25' });
+  });
+
+  it('keeps ordering when operations alternate', async () => {
+    // insert/update/delete route differently through the sink, so a change of
+    // operation must close the current batch or rows would be misrouted
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      for (const id of [1, 2, 3, 4]) {
+        await a.insertRow({ table: s.sourceTable, values: { id, name: `n${id}` } });
+      }
+      await a.deleteRow({ table: s.sourceTable, identity: { id: 2 } });
+      await a.insertRow({ table: s.sourceTable, values: { id: 5, name: 'n5' } });
+      await a.deleteRow({ table: s.sourceTable, identity: { id: 4 } });
+    });
+
+    const rows = await waitFor('alternating ops to settle', async () => {
+      const r = await destRows('postgres', s.destTable);
+      const ids = r.map((x) => Number(x.id));
+      return ids.length === 3 && ids.join(',') === '1,3,5' ? r : null;
+    });
+    expect(rows.map((r) => Number(r.id))).toEqual([1, 3, 5]);
+  });
+
+  it('re-inserting a deleted key ends in the inserted state', async () => {
+    const s = await freshBridge();
+    await withAdapter('postgres', async (a) => {
+      await a.insertRow({ table: s.sourceTable, values: { id: 9, name: 'first' } });
+      await a.deleteRow({ table: s.sourceTable, identity: { id: 9 } });
+      await a.insertRow({ table: s.sourceTable, values: { id: 9, name: 'second' } });
+    });
+    const rows = await waitFor('delete-then-insert to settle', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 && r[0]?.name === 'second' ? r : null;
+    });
+    expect(rows[0]).toMatchObject({ id: 9, name: 'second' });
+  });
+
+  it('a partial batch is flushed by the linger timer, not left waiting', async () => {
+    // one row is far below the batch size; it must still arrive promptly
+    const s = await freshBridge();
+    const started = Date.now();
+    await withAdapter('postgres', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 42, name: 'lonely' } }),
+    );
+    await waitFor('single row to arrive', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 ? r : null;
+    });
+    // generous, but proves it is not stuck waiting for a full batch
+    expect(Date.now() - started).toBeLessThan(15_000);
+  });
+
+  it('delivers a large burst exactly once and records batched deliveries', async () => {
+    const s = await freshBridge();
+    const total = 500;
+    await withAdapter('postgres', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: total }, (_, i) => ({ id: i + 1, name: `r${i}` })),
+      }),
+    );
+
+    const rows = await waitFor(
+      `${total} rows to arrive`,
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === total ? r : null;
+      },
+      { timeoutMs: 120_000 },
+    );
+    const ids = rows.map((r) => Number(r.id));
+    expect(new Set(ids).size).toBe(total);
+
+    // the point of batching: far fewer deliveries than rows
+    const job = await app.prisma.bridgeJob.findFirst({
+      where: { bridgeId: s.bridgeId },
+      orderBy: { startedAt: 'desc' },
+    });
+    const deliveries = await app.prisma.bridgeDelivery.count({
+      where: { jobId: job.id },
+    });
+    expect(deliveries).toBeLessThan(total);
+    const summed = await app.prisma.bridgeDelivery.aggregate({
+      where: { jobId: job.id },
+      _sum: { rowCount: true },
+    });
+    // every row is accounted for across the batched deliveries
+    expect(summed._sum.rowCount).toBe(total);
+  });
+});
+
+describe('checkpointing across a restart', () => {
+  it('resumes without losing or duplicating rows', async () => {
+    const s = await freshBridge();
+
+    await withAdapter('postgres', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: 50 }, (_, i) => ({ id: i + 1, name: `a${i}` })),
+      }),
+    );
+    await waitFor('first batch delivered', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 50 ? r : null;
+    });
+
+    // stop the stream, write while it is down, then bring it back
+    await app.cdc.stop(s.bridgeId);
+    await withAdapter('postgres', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: 50 }, (_, i) => ({ id: i + 51, name: `b${i}` })),
+      }),
+    );
+    await app.cdc.start(s.bridgeId);
+
+    const rows = await waitFor(
+      'rows written while stopped to be caught up',
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === 100 ? r : null;
+      },
+      { timeoutMs: 120_000 },
+    );
+    const ids = rows.map((r) => Number(r.id)).sort((x, y) => x - y);
+    expect(new Set(ids).size).toBe(100); // no duplicates
+    expect(ids[0]).toBe(1);
+    expect(ids[99]).toBe(100); // nothing lost
+  });
+});

--- a/apps/api/test/integration/cdc-sync.itest.ts
+++ b/apps/api/test/integration/cdc-sync.itest.ts
@@ -1,0 +1,244 @@
+/**
+ * End-to-end change data capture: a row written to a real source database must
+ * appear in a real destination database, through the actual application.
+ *
+ * This boots the real Nest DI container against the real metadata store and
+ * drives the real services — no stubs anywhere. It is the test that gives the
+ * CDC pipeline's correctness claims any weight, and the safety net for the
+ * throughput work that restructures that pipeline.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { INestApplicationContext } from '@nestjs/common';
+import { applyTestEnv } from './env';
+import { TEST_CONNECTIONS, uniqueTable, waitFor, withAdapter } from './harness';
+
+// env must be in place before the app module is evaluated: runtimeConfig reads
+// process.env at import time, so a static import would bind the real .env
+applyTestEnv();
+
+let ctx: INestApplicationContext;
+let connections: any;
+let bridges: any;
+let cdc: any;
+
+/** ids of things to tear down, newest first */
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  const { NestFactory } = await import('@nestjs/core');
+  const { AppModule } = await import('../../src/app.module');
+  const { ConnectionStoreService } = await import(
+    '../../src/connections/connection-store.service'
+  );
+  const { BridgeStoreService } = await import(
+    '../../src/bridges/bridge-store.service'
+  );
+  const { BridgeCdcService } = await import(
+    '../../src/bridges/bridge-cdc.service'
+  );
+
+  ctx = await NestFactory.createApplicationContext(AppModule, { logger: false });
+  connections = ctx.get(ConnectionStoreService);
+  bridges = ctx.get(BridgeStoreService);
+  cdc = ctx.get(BridgeCdcService);
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await ctx?.close().catch(() => undefined);
+});
+
+/** register a source connection in the app for one of the test engines */
+async function connectionFor(engine: 'postgres' | 'mysql'): Promise<string> {
+  const t = TEST_CONNECTIONS[engine]!;
+  const conn = await connections.create({
+    name: `it-${engine}-${Date.now()}`,
+    engine,
+    host: t.host,
+    port: t.port,
+    user: t.user,
+    password: t.password,
+    database: t.database,
+  });
+  return conn.id;
+}
+
+interface SyncSetup {
+  bridgeId: string;
+  sourceTable: string;
+  destTable: string;
+}
+
+/**
+ * Build a live CDC bridge from a fresh Postgres table into a destination table
+ * on `destEngine`, and start it. Returns once the stream is running.
+ */
+async function startBridge(
+  destEngine: 'postgres' | 'mysql',
+  sourceConnId: string,
+  destConnId: string,
+): Promise<SyncSetup> {
+  const sourceTable = uniqueTable('src');
+  const destTable = uniqueTable('dst');
+
+  await withAdapter('postgres', async (a) => {
+    await a.createTable({
+      table: sourceTable,
+      columns: [
+        { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+        { name: 'name', type: 'text', nullable: true },
+      ],
+    });
+  });
+  cleanups.push(async () => {
+    await withAdapter('postgres', (a) => a.dropTable(sourceTable)).catch(
+      () => undefined,
+    );
+  });
+  cleanups.push(async () => {
+    await withAdapter(destEngine, (a) => a.dropTable(destTable)).catch(
+      () => undefined,
+    );
+  });
+
+  // parse through the real schema so defaults (delivery, transform, write
+  // modes) are applied exactly as the HTTP layer applies them
+  const { bridgeInputSchema } = await import('@syncle/core');
+  const input = bridgeInputSchema.parse({
+    name: `it-bridge-${sourceTable}`,
+    source: { kind: 'table', connectionId: sourceConnId, table: sourceTable },
+    destination: {
+      kind: 'database',
+      targets: [
+        {
+          connectionId: destConnId,
+          table: destTable,
+          writeMode: 'upsert',
+          keyColumns: ['id'],
+          createMissingTable: true,
+        },
+      ],
+    },
+    transform: { template: '{{$row}}' },
+    trigger: { kind: 'cdc', operations: ['insert', 'update', 'delete'] },
+  });
+  const bridge = await bridges.create(input);
+
+  await cdc.start(bridge.id);
+  cleanups.push(async () => {
+    await cdc.stop(bridge.id).catch(() => undefined);
+    await cdc.cleanup(bridge.id).catch(() => undefined);
+  });
+
+  return { bridgeId: bridge.id, sourceTable, destTable };
+}
+
+/** rows currently in the destination table, sorted by id */
+async function destRows(
+  engine: 'postgres' | 'mysql',
+  table: string,
+): Promise<Array<Record<string, unknown>>> {
+  return withAdapter(engine, async (a) => {
+    try {
+      const res = await a.browse({ table, limit: 1000, offset: 0 });
+      return [...res.rows].sort((x, y) => Number(x.id) - Number(y.id));
+    } catch {
+      return []; // table not created yet — the sink creates it on first write
+    }
+  });
+}
+
+describe('postgres -> postgres CDC', () => {
+  let setup: SyncSetup;
+
+  beforeAll(async () => {
+    const src = await connectionFor('postgres');
+    const dst = await connectionFor('postgres');
+    setup = await startBridge('postgres', src, dst);
+  }, 120_000);
+
+  it('propagates an insert', async () => {
+    await withAdapter('postgres', (a) =>
+      a.insertRow({ table: setup.sourceTable, values: { id: 1, name: 'alpha' } }),
+    );
+    const rows = await waitFor('insert to arrive', async () => {
+      const r = await destRows('postgres', setup.destTable);
+      return r.length === 1 ? r : null;
+    });
+    expect(rows[0]).toMatchObject({ id: 1, name: 'alpha' });
+  });
+
+  it('propagates an update', async () => {
+    await withAdapter('postgres', (a) =>
+      a.updateRow({
+        table: setup.sourceTable,
+        identity: { id: 1 },
+        changes: { name: 'alpha-updated' },
+      }),
+    );
+    const rows = await waitFor('update to arrive', async () => {
+      const r = await destRows('postgres', setup.destTable);
+      return r[0]?.name === 'alpha-updated' ? r : null;
+    });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('propagates a delete', async () => {
+    await withAdapter('postgres', (a) =>
+      a.deleteRow({ table: setup.sourceTable, identity: { id: 1 } }),
+    );
+    await waitFor('delete to arrive', async () => {
+      const r = await destRows('postgres', setup.destTable);
+      return r.length === 0 ? true : null;
+    });
+    expect(await destRows('postgres', setup.destTable)).toHaveLength(0);
+  });
+
+  it('propagates a burst of rows, exactly once each', async () => {
+    const total = 200;
+    await withAdapter('postgres', async (a) => {
+      await a.insertRows?.({
+        table: setup.sourceTable,
+        rows: Array.from({ length: total }, (_, i) => ({
+          id: i + 100,
+          name: `burst-${i}`,
+        })),
+      });
+    });
+    const rows = await waitFor(
+      `all ${total} burst rows`,
+      async () => {
+        const r = await destRows('postgres', setup.destTable);
+        return r.length === total ? r : null;
+      },
+      { timeoutMs: 90_000 },
+    );
+    // no duplicates: ids must be unique and complete
+    const ids = rows.map((r) => Number(r.id)).sort((a, b) => a - b);
+    expect(new Set(ids).size).toBe(total);
+    expect(ids[0]).toBe(100);
+    expect(ids[total - 1]).toBe(100 + total - 1);
+  });
+});
+
+describe('postgres -> mysql CDC (cross engine)', () => {
+  let setup: SyncSetup;
+
+  beforeAll(async () => {
+    const src = await connectionFor('postgres');
+    const dst = await connectionFor('mysql');
+    setup = await startBridge('mysql', src, dst);
+  }, 120_000);
+
+  it('moves rows across engines', async () => {
+    await withAdapter('postgres', (a) =>
+      a.insertRow({ table: setup.sourceTable, values: { id: 7, name: 'cross' } }),
+    );
+    const rows = await waitFor('cross-engine row', async () => {
+      const r = await destRows('mysql', setup.destTable);
+      return r.length === 1 ? r : null;
+    });
+    expect(rows[0]).toMatchObject({ id: 7, name: 'cross' });
+  });
+});

--- a/apps/api/test/integration/env.ts
+++ b/apps/api/test/integration/env.ts
@@ -1,0 +1,27 @@
+/**
+ * Environment for the end-to-end tests.
+ *
+ * `runtimeConfig` reads process.env at module-evaluation time, so these must be
+ * set BEFORE anything imports the app. Test files therefore call
+ * `applyTestEnv()` and only then `await import()` the Nest module — a static
+ * import would be hoisted above the assignment and pick up the real .env.
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** metadata store for the app under test — separate from the synced databases */
+export const META_DB_URL =
+  'postgresql://syncle:syncle@127.0.0.1:55432/syncle_meta?schema=public';
+
+export const TEST_REDIS_URL = 'redis://127.0.0.1:56379';
+
+export function applyTestEnv(): void {
+  process.env.DATABASE_URL = META_DB_URL;
+  process.env.REDIS_URL = TEST_REDIS_URL;
+  process.env.SYNCLE_DATA_DIR ??= mkdtempSync(join(tmpdir(), 'syncle-data-'));
+  // a fixed, base64-encoded 32-byte key: deterministic so encrypted
+  // connection secrets round-trip within a run. Test-only value.
+  process.env.SYNCLE_MASTER_KEY ??= 'BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=';
+  process.env.NODE_ENV = 'test';
+}

--- a/apps/api/test/integration/global-setup.ts
+++ b/apps/api/test/integration/global-setup.ts
@@ -6,9 +6,12 @@
  * waits for every engine to accept connections, so a slow container start
  * surfaces as a clear message instead of a pile of connection-refused failures.
  */
+import { execFileSync } from 'node:child_process';
+import { Client } from 'pg';
 import { MongoClient } from 'mongodb';
 import { bootstrapDrivers, createAdapter } from '@syncle/core/adapters';
 import { TEST_CONNECTIONS } from './harness';
+import { META_DB_URL, applyTestEnv } from './env';
 
 const MONGO_DIRECT = 'mongodb://127.0.0.1:57017/?directConnection=true';
 
@@ -71,8 +74,41 @@ async function waitForEngine(name: string): Promise<void> {
   );
 }
 
+/**
+ * The app's own metadata store. Created here rather than by compose so the
+ * schema is migrated with the real Prisma migrations — the same ones production
+ * runs — instead of a hand-written approximation.
+ */
+async function prepareMetadataDatabase(): Promise<void> {
+  const admin = new Client({
+    host: '127.0.0.1',
+    port: 55432,
+    user: 'syncle',
+    password: 'syncle',
+    database: 'syncle_test',
+  });
+  await admin.connect();
+  try {
+    const exists = await admin.query(
+      'select 1 from pg_database where datname = $1',
+      ['syncle_meta'],
+    );
+    if (exists.rowCount === 0) await admin.query('create database syncle_meta');
+  } finally {
+    await admin.end().catch(() => undefined);
+  }
+
+  execFileSync('npx', ['prisma', 'migrate', 'deploy'], {
+    cwd: new URL('../..', import.meta.url).pathname,
+    env: { ...process.env, DATABASE_URL: META_DB_URL },
+    stdio: 'pipe',
+  });
+}
+
 export async function setup(): Promise<void> {
+  applyTestEnv();
   bootstrapDrivers();
   await initReplicaSet();
   for (const name of Object.keys(TEST_CONNECTIONS)) await waitForEngine(name);
+  await prepareMetadataDatabase();
 }

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -7,6 +7,9 @@
  * touch a developer's real database, the dev stack, or an installed app stack.
  */
 import { randomUUID } from 'node:crypto';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { bootstrapDrivers, createAdapter } from '@syncle/core/adapters';
 import type { ConnectionConfig, DatabaseAdapter, DatabaseEngine } from '@syncle/core';
 
@@ -47,6 +50,10 @@ export const TEST_CONNECTIONS: Record<string, ConnectionConfig> = {
     database: 'syncle_test',
   }),
   redis: base('redis', { host: '127.0.0.1', port: 56379 }),
+  // file-backed, so it needs no container; a fresh temp file per run
+  sqlite: base('sqlite', {
+    database: join(mkdtempSync(join(tmpdir(), 'syncle-it-')), 'test.db'),
+  }),
 };
 
 /** open a real adapter, run `fn`, always disconnect */

--- a/apps/api/test/integration/mysql-cdc.itest.ts
+++ b/apps/api/test/integration/mysql-cdc.itest.ts
@@ -1,0 +1,191 @@
+/**
+ * MySQL binlog CDC against a real MySQL 8.0 with GTID mode on.
+ *
+ * Beyond propagation, this covers the server-identity guard. Binlog file and
+ * position are only meaningful on the server that issued them, so a cursor
+ * carries the server's uuid and a resume against a DIFFERENT server must fail
+ * loudly rather than silently read the wrong offsets — which is what would
+ * happen after a failover.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  destRows,
+  makeBridge,
+  type AppHandle,
+  type SyncSetup,
+} from './app-harness';
+import { waitFor, withAdapter } from './harness';
+
+let app: AppHandle;
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  app = await bootstrapApp();
+}, 120_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+});
+
+async function mysqlSourceBridge(): Promise<SyncSetup> {
+  const src = await connectionFor(app, 'mysql');
+  const dst = await connectionFor(app, 'postgres');
+  return makeBridge(app, {
+    sourceEngine: 'mysql',
+    destEngine: 'postgres',
+    sourceConnId: src,
+    destConnId: dst,
+    cleanups,
+  });
+}
+
+/** the newest job row for a bridge, which carries the persisted cursor */
+async function latestJob(bridgeId: string): Promise<any> {
+  return app.prisma.bridgeJob.findFirst({
+    where: { bridgeId },
+    orderBy: { startedAt: 'desc' },
+  });
+}
+
+describe('mysql binlog -> postgres', () => {
+  let s: SyncSetup;
+
+  beforeAll(async () => {
+    s = await mysqlSourceBridge();
+  }, 120_000);
+
+  it('propagates insert, update and delete', async () => {
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'alpha' } }),
+    );
+    await waitFor('insert', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 && r[0]?.name === 'alpha' ? r : null;
+    });
+
+    await withAdapter('mysql', (a) =>
+      a.updateRow({
+        table: s.sourceTable,
+        identity: { id: 1 },
+        changes: { name: 'beta' },
+      }),
+    );
+    await waitFor('update', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r[0]?.name === 'beta' ? r : null;
+    });
+
+    await withAdapter('mysql', (a) =>
+      a.deleteRow({ table: s.sourceTable, identity: { id: 1 } }),
+    );
+    await waitFor('delete', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 0 ? true : null;
+    });
+    expect(await destRows('postgres', s.destTable)).toHaveLength(0);
+  });
+
+  it('delivers a burst exactly once', async () => {
+    const total = 300;
+    await withAdapter('mysql', (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: total }, (_, i) => ({
+          id: i + 1000,
+          name: `b${i}`,
+        })),
+      }),
+    );
+    const rows = await waitFor(
+      `${total} rows`,
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === total ? r : null;
+      },
+      { timeoutMs: 120_000 },
+    );
+    expect(new Set(rows.map((r) => Number(r.id))).size).toBe(total);
+  });
+
+  it('records the server uuid and a real GTID on the cursor', async () => {
+    const job = await latestJob(s.bridgeId);
+    expect(job.cursorJson).toBeTruthy();
+    const cursor = JSON.parse(job.cursorJson).cursor as string;
+    // the identity-carrying form is JSON
+    expect(cursor.startsWith('{')).toBe(true);
+    const parsed = JSON.parse(cursor);
+    expect(typeof parsed.u).toBe('string');
+    expect(parsed.u.length).toBeGreaterThan(0);
+    // matches what the server reports for itself
+    const live = await withAdapter('mysql', (a) =>
+      a.query('SELECT @@server_uuid AS uuid'),
+    );
+    expect(parsed.u).toBe((live.rows[0] as { uuid: string }).uuid);
+    // GTID mode is on in the test server, so a GTID must have been captured
+    expect(typeof parsed.g).toBe('string');
+    expect(parsed.g).toMatch(/^[0-9a-f-]{36}:\d+$/);
+  });
+});
+
+describe('server-identity guard', () => {
+  it('refuses to resume when the cursor came from another server', async () => {
+    const s = await mysqlSourceBridge();
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'x' } }),
+    );
+    await waitFor('first row', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 ? r : null;
+    });
+
+    await app.cdc.stop(s.bridgeId);
+
+    // rewrite the stored cursor as if it had been produced by a different
+    // server — exactly the state a failover leaves behind
+    const job = await latestJob(s.bridgeId);
+    const cursor = JSON.parse(job.cursorJson).cursor as string;
+    const tampered = JSON.stringify({
+      ...JSON.parse(cursor),
+      u: '00000000-1111-2222-3333-444444444444',
+    });
+    await app.prisma.bridgeJob.update({
+      where: { id: job.id },
+      data: { cursorJson: JSON.stringify({ cursor: tampered }) },
+    });
+
+    await expect(app.cdc.start(s.bridgeId)).rejects.toThrow(
+      /came from MySQL server .* but the connection now reaches/i,
+    );
+  });
+
+  it('resumes normally when the server is unchanged', async () => {
+    const s = await mysqlSourceBridge();
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 1, name: 'one' } }),
+    );
+    await waitFor('first row', async () => {
+      const r = await destRows('postgres', s.destTable);
+      return r.length === 1 ? r : null;
+    });
+
+    await app.cdc.stop(s.bridgeId);
+    await withAdapter('mysql', (a) =>
+      a.insertRow({ table: s.sourceTable, values: { id: 2, name: 'two' } }),
+    );
+    await app.cdc.start(s.bridgeId);
+
+    const rows = await waitFor(
+      'row written while stopped',
+      async () => {
+        const r = await destRows('postgres', s.destTable);
+        return r.length === 2 ? r : null;
+      },
+      { timeoutMs: 60_000 },
+    );
+    expect(rows.map((r) => Number(r.id))).toEqual([1, 2]);
+  });
+});

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config';
+import swc from 'unplugin-swc';
 
 /**
  * Integration suite: runs against the REAL databases in docker-compose.test.yml.
@@ -10,10 +11,15 @@ import { defineConfig } from 'vitest/config';
  * (which has no config and uses vitest's default `*.test.ts` glob) never picks
  * these up and never needs Docker.
  *
+ * Compiled with SWC rather than vitest's default esbuild: Nest resolves
+ * constructor dependencies from `emitDecoratorMetadata`, which esbuild does
+ * not emit. Without this every injected dependency arrives as undefined.
+ *
  * Single-threaded and serial: these tests create replication slots, hold binlog
  * readers open and write to shared tables, so parallel files would interfere.
  */
 export default defineConfig({
+  plugins: [swc.vite({ module: { type: 'es6' } })],
   test: {
     include: ['test/integration/**/*.itest.ts'],
     globalSetup: ['test/integration/global-setup.ts'],

--- a/packages/core/src/adapters/sql/base-sql-adapter.ts
+++ b/packages/core/src/adapters/sql/base-sql-adapter.ts
@@ -23,13 +23,16 @@ import type {
   DatabaseEngine,
   DatabaseSchema,
   DeleteRowParams,
+  DeleteRowsParams,
   FilterSpec,
   InsertRowParams,
+  InsertRowsParams,
   QueryResult,
   RestoreResult,
   TableSchema,
   UpdateRowParams,
   UpsertRowParams,
+  UpsertRowsParams,
 } from '../types';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { BadRequestError } from '../../errors';
@@ -502,6 +505,164 @@ export abstract class BaseSqlAdapter implements DatabaseAdapter {
       sql,
       cols.map((c) => p.values[c]),
     );
+  }
+
+  /* ----- set-based writes ----------------------------------------------- */
+
+  /**
+   * Group rows by the exact set of columns they carry. A change stream can emit
+   * sparse rows, and one multi-row INSERT needs a single uniform column list,
+   * so rows with different shapes go into separate statements. Insertion order
+   * is preserved within each group.
+   */
+  private groupByColumns(
+    rows: Array<Record<string, unknown>>,
+  ): Array<{ columns: string[]; rows: Array<Record<string, unknown>> }> {
+    const groups = new Map<
+      string,
+      { columns: string[]; rows: Array<Record<string, unknown>> }
+    >();
+    for (const row of rows) {
+      const columns = Object.keys(row);
+      if (columns.length === 0) continue;
+      // the signature must not collide across different column sets, so it is
+      // built from the sorted names; the emitted column order stays as-written
+      const key = JSON.stringify([...columns].sort());
+      const existing = groups.get(key);
+      if (existing) existing.rows.push(row);
+      else groups.set(key, { columns, rows: [row] });
+    }
+    return [...groups.values()];
+  }
+
+  /** rows per statement so `rows × columns` stays under the driver's bind cap */
+  private chunkSize(columnCount: number): number {
+    return Math.max(1, Math.floor(this.maxBindParams() / Math.max(1, columnCount)));
+  }
+
+  /**
+   * One INSERT per column-shape and bind-limit chunk. `tail` appends the
+   * dialect's upsert clause when this is an upsert.
+   *
+   * Values are bound exactly as {@link insertRow} binds them, so a batched
+   * write and the per-row loop it replaces are indistinguishable to the engine.
+   */
+  private async insertGrouped(
+    table: string,
+    schema: string | undefined,
+    rows: Array<Record<string, unknown>>,
+    tail: (columns: string[]) => string,
+  ): Promise<QueryResult> {
+    const target = this.qualify(table, schema);
+    let affected = 0;
+    for (const group of this.groupByColumns(rows)) {
+      const { columns } = group;
+      const colSql = columns.map((c) => this.quoteIdent(c)).join(', ');
+      const size = this.chunkSize(columns.length);
+      for (let i = 0; i < group.rows.length; i += size) {
+        const chunk = group.rows.slice(i, i + size);
+        const params: unknown[] = [];
+        let ph = 1;
+        const tuples = chunk.map((row) => {
+          const placeholders = columns.map((c) => {
+            params.push(row[c]);
+            return this.placeholder(ph++);
+          });
+          return `(${placeholders.join(', ')})`;
+        });
+        const res = await this.runSql(
+          `INSERT INTO ${target} (${colSql}) VALUES ${tuples.join(', ')} ${tail(columns)}`.trim(),
+          params,
+        );
+        // engines report affected rows inconsistently for multi-row upserts
+        // (MySQL counts an update as 2); fall back to the rows we sent
+        affected += res.affectedRows ?? chunk.length;
+      }
+    }
+    return { affectedRows: affected, rowCount: affected, rows: [], columns: [], executionMs: 0 };
+  }
+
+  async insertRows(p: InsertRowsParams): Promise<QueryResult> {
+    if (p.rows.length === 0) {
+      return { affectedRows: 0, rowCount: 0, rows: [], columns: [], executionMs: 0 };
+    }
+    return this.insertGrouped(p.table, p.schema, p.rows, () => '');
+  }
+
+  async upsertRows(p: UpsertRowsParams): Promise<QueryResult> {
+    if (p.rows.length === 0) {
+      return { affectedRows: 0, rowCount: 0, rows: [], columns: [], executionMs: 0 };
+    }
+    if (p.keyColumns.length === 0) {
+      throw new BadRequestError('Cannot upsert without key columns to match on');
+    }
+    return this.insertGrouped(p.table, p.schema, p.rows, (columns) =>
+      this.upsertClause(p.keyColumns, columns),
+    );
+  }
+
+  /**
+   * Upper bound on OR-ed clauses in one DELETE. Staying under the bind cap is
+   * not sufficient: SQLite also limits expression-tree DEPTH (1000 by default),
+   * and a long chain of ORs is a deep tree, so a batch well within the bind
+   * budget can still be rejected. Single-column keys avoid the issue entirely
+   * by using a flat IN list; this cap covers the composite-key form.
+   */
+  protected maxOrClauses(): number {
+    return 200;
+  }
+
+  /**
+   * Deletes many identities. A single key column becomes `k IN (?, ?, …)`,
+   * which is flat and cheap; composite keys fall back to
+   * `(a = ? AND b = ?) OR (…)`, since an IN over tuples is not portable.
+   */
+  async deleteRows(p: DeleteRowsParams): Promise<QueryResult> {
+    if (p.identities.length === 0) {
+      return { affectedRows: 0, rowCount: 0, rows: [], columns: [], executionMs: 0 };
+    }
+    const target = this.qualify(p.table, p.schema);
+    let affected = 0;
+    for (const group of this.groupByColumns(p.identities)) {
+      const { columns } = group;
+      const single = columns.length === 1 ? columns[0] : undefined;
+      // a flat IN list has no depth problem, so it is only bind-capped
+      const size =
+        single !== undefined
+          ? this.chunkSize(1)
+          : Math.min(this.chunkSize(columns.length), this.maxOrClauses());
+
+      for (let i = 0; i < group.rows.length; i += size) {
+        const chunk = group.rows.slice(i, i + size);
+        const params: unknown[] = [];
+        let ph = 1;
+        let where: string;
+
+        if (single !== undefined) {
+          const list = chunk.map((identity) => {
+            params.push(identity[single]);
+            return this.placeholder(ph++);
+          });
+          where = `${this.quoteIdent(single)} IN (${list.join(', ')})`;
+        } else {
+          const clauses = chunk.map((identity) => {
+            const conds = columns.map((c) => {
+              params.push(identity[c]);
+              return `${this.quoteIdent(c)} = ${this.placeholder(ph++)}`;
+            });
+            return `(${conds.join(' AND ')})`;
+          });
+          where = clauses.join(' OR ');
+        }
+
+        const res = await this.runSql(
+          `DELETE FROM ${target} WHERE ${where}`,
+          params,
+        );
+        affected += res.affectedRows ?? 0;
+      }
+    }
+    return { affectedRows: affected, rowCount: affected, rows: [], columns: [], executionMs: 0 };
   }
 
   /* ----- schema management (DDL) ----- */

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -300,6 +300,44 @@ export interface UpsertRowParams {
 }
 
 /* -------------------------------------------------------------------------- */
+/* batched writes                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Batched variants of the single-row writes. A sink handling a stream of
+ * changes would otherwise pay a full round trip per row, which dominates
+ * throughput once the database is anywhere but localhost.
+ *
+ * These are OPTIONAL on {@link DatabaseAdapter}: an engine that cannot express
+ * a set-based write simply omits them and callers fall back to looping the
+ * single-row methods. Callers MUST therefore guard with
+ * `adapter.upsertRows?.(...)` rather than assuming availability.
+ *
+ * Rows are NOT required to share a column set — implementations group by the
+ * columns actually present, since a change stream can emit sparse rows.
+ */
+export interface InsertRowsParams {
+  schema?: string;
+  table: string;
+  rows: Array<Record<string, unknown>>;
+}
+
+export interface UpsertRowsParams {
+  schema?: string;
+  table: string;
+  rows: Array<Record<string, unknown>>;
+  /** columns that uniquely identify a row (must be a unique/primary key) */
+  keyColumns: string[];
+}
+
+export interface DeleteRowsParams {
+  schema?: string;
+  table: string;
+  /** one identity per row to remove; all must use the same key columns */
+  identities: RowIdentity[];
+}
+
+/* -------------------------------------------------------------------------- */
 /* schema management (DDL)                                                     */
 /* -------------------------------------------------------------------------- */
 
@@ -390,6 +428,11 @@ export interface DatabaseAdapter {
   deleteRow(params: DeleteRowParams): Promise<QueryResult>;
   /** insert-or-update keyed by `keyColumns`, atomic in the engine's dialect */
   upsertRow(params: UpsertRowParams): Promise<QueryResult>;
+
+  /* ----- optional set-based writes; see InsertRowsParams for the contract ----- */
+  insertRows?(params: InsertRowsParams): Promise<QueryResult>;
+  upsertRows?(params: UpsertRowsParams): Promise<QueryResult>;
+  deleteRows?(params: DeleteRowsParams): Promise<QueryResult>;
 
   /* schema management, guarded by `capabilities.ddl` / `manageDatabases` */
   createDatabase(name: string): Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,10 +80,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.4.7
-        version: 10.4.9(@swc/core@1.15.46)
+        version: 10.4.9(@swc/core@1.16.2)(esbuild@0.21.5)
       '@nestjs/schematics':
         specifier: ^10.2.3
         version: 10.2.3(chokidar@3.6.0)(typescript@5.9.3)
+      '@swc/core':
+        specifier: ^1.16.2
+        version: 1.16.2
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -99,6 +102,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      unplugin-swc:
+        specifier: ^1.5.11
+        version: 1.5.11(@swc/core@1.16.2)(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
       vitest:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@22.19.19)(terser@5.48.0)
@@ -736,6 +742,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -1510,6 +1519,15 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.61.0':
     resolution: {integrity: sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==}
     cpu: [arm]
@@ -1663,8 +1681,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@swc/core-darwin-arm64@1.16.2':
+    resolution: {integrity: sha512-i/j0HNbnn79qnTVPicvay92Nark8fW8NQqn1e2mGERjUXNpBV0+SwQxlRpk2zBhn6laJ8PDI6Kn1nHZhnz3LCA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@swc/core-darwin-x64@1.15.46':
     resolution: {integrity: sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.16.2':
+    resolution: {integrity: sha512-HrwqHyEyHVXO3qTk8EkNK7/b6sOZSEoNh+pot6RdE5x0LbNqfo8LtJUvi3UTXr+5ja/o5HbJdW80eCXo+NjbiA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -1675,8 +1705,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@swc/core-linux-arm-gnueabihf@1.16.2':
+    resolution: {integrity: sha512-MdXi83Z/gGp1LIrg+h7HKxiul/z/Bty/ZJSvYAFqDl9zteC1XLSAZdScquKtXPp50rdyXqritTDCqQBhwVfZKA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
   '@swc/core-linux-arm64-gnu@1.15.46':
     resolution: {integrity: sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-gnu@1.16.2':
+    resolution: {integrity: sha512-/jcTmK6Ktz3owM3YtiKvjofV6p3VpHnYzTIrOGwDIOsDigRAAVuZ8east33wYO/7UTdKYFlyHNnJNT0WJqOA3Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1689,8 +1732,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@swc/core-linux-arm64-musl@1.16.2':
+    resolution: {integrity: sha512-4gFarKaFnlJTSlJYKmMhV4u+3YE4uYfiydpBoYjmgQhCf9lAieOq+WilZaK9vVSHeqLuQpTEiGULZqAdsRX5Dw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@swc/core-linux-ppc64-gnu@1.15.46':
     resolution: {integrity: sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-ppc64-gnu@1.16.2':
+    resolution: {integrity: sha512-syqSLGd6KlZ1PciNzs6bIUlhOuFztZufebOHaERjc4N4SqNZxyqYd4I+jj/EfOYnpe0kNjccn9HJLN1p5dz3+w==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
@@ -1703,8 +1760,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@swc/core-linux-s390x-gnu@1.16.2':
+    resolution: {integrity: sha512-ZBBLK+ewGyXLzWeMS7wbKtWBdnif6etn7xvPY/iOfbdsjX/+bgkp1pQt2lWF2wlu2hXYZuhJ/tHZE/QR8/apzg==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@swc/core-linux-x64-gnu@1.15.46':
     resolution: {integrity: sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.16.2':
+    resolution: {integrity: sha512-LyHJgxCA4Tje0ysBMbEb0tt/ie8kgUKoFE3JAKFhpevmTmhYEoC0H9s47WuDsqiFckF1ITUguZIXJG6K5e0dvg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1717,8 +1788,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@swc/core-linux-x64-musl@1.16.2':
+    resolution: {integrity: sha512-PghXJlVM1cgtLfNUR1vxFo1z+PDRAe8cWAJlZZ7spmeiN7BospGXg/MHUg7oNSgwSX7Zo//YKv9P5yD9apsFJQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@swc/core-win32-arm64-msvc@1.15.46':
     resolution: {integrity: sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-arm64-msvc@1.16.2':
+    resolution: {integrity: sha512-StTOSefYBxemvNYYUI3UmO1a8y+hSPjjfHogC2TEHL+Z1PlEBim/XtLas5rS04jAzT9RrNmbtX911SZ42H9jSQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -1729,14 +1813,35 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@swc/core-win32-ia32-msvc@1.16.2':
+    resolution: {integrity: sha512-fycER209DYIzsibpTMC+chND05OfOjgztWL9U8OE6/uUlsOUZH3eh98isBLEnOymYUhlJLEt5++W1+KL/FOh5Q==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
   '@swc/core-win32-x64-msvc@1.15.46':
     resolution: {integrity: sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
+  '@swc/core-win32-x64-msvc@1.16.2':
+    resolution: {integrity: sha512-cSd1z6ivSrJPVr+moVwOHWjeKy6TpO4/Shwcv5KCrKYXCccxwh4pRy1C3fDioNx2PF1jPZWHKZjtXt+Be9VbaQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
   '@swc/core@1.15.46':
     resolution: {integrity: sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/core@1.16.2':
+    resolution: {integrity: sha512-95I4kiSMeveI/Mhi+tE4fiWcWLUMfzfKrk0jtr8LRMqHgOgq+xHS+zExkDqoO4b5OeeuXHMWVdD5MeP3X6sULw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'
@@ -1752,6 +1857,9 @@ packages:
 
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tanstack/query-core@5.100.14':
     resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
@@ -2969,6 +3077,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -3528,6 +3639,10 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
@@ -4896,6 +5011,44 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin-swc@1.5.11:
+    resolution: {integrity: sha512-R7U4GbfrESPnYLn3nXREZrwhKQk3BAmTBoKJ5lmo7btTc/yJpNsDzavBWo+XpQTjDSIogiZEAxC5ig/vfMWxWg==}
+    peerDependencies:
+      '@swc/core': ^1.2.108
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -5031,6 +5184,9 @@ packages:
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   webpack@5.97.1:
     resolution: {integrity: sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==}
@@ -5510,6 +5666,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.11':
@@ -5584,7 +5745,7 @@ snapshots:
       bullmq: 5.78.0
       tslib: 2.8.1
 
-  '@nestjs/cli@10.4.9(@swc/core@1.15.46)':
+  '@nestjs/cli@10.4.9(@swc/core@1.16.2)(esbuild@0.21.5)':
     dependencies:
       '@angular-devkit/core': 17.3.11(chokidar@3.6.0)
       '@angular-devkit/schematics': 17.3.11(chokidar@3.6.0)
@@ -5594,7 +5755,7 @@ snapshots:
       chokidar: 3.6.0
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.15.46))
+      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
       glob: 10.4.5
       inquirer: 8.2.6
       node-emoji: 1.11.0
@@ -5603,10 +5764,10 @@ snapshots:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.7.2
-      webpack: 5.97.1(@swc/core@1.15.46)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/core': 1.15.46
+      '@swc/core': 1.16.2
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -6271,6 +6432,14 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rollup/pluginutils@5.4.0(rollup@4.61.0)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.61.0
+
   '@rollup/rollup-android-arm-eabi@4.61.0':
     optional: true
 
@@ -6355,37 +6524,73 @@ snapshots:
   '@swc/core-darwin-arm64@1.15.46':
     optional: true
 
+  '@swc/core-darwin-arm64@1.16.2':
+    optional: true
+
   '@swc/core-darwin-x64@1.15.46':
+    optional: true
+
+  '@swc/core-darwin-x64@1.16.2':
     optional: true
 
   '@swc/core-linux-arm-gnueabihf@1.15.46':
     optional: true
 
+  '@swc/core-linux-arm-gnueabihf@1.16.2':
+    optional: true
+
   '@swc/core-linux-arm64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.16.2':
     optional: true
 
   '@swc/core-linux-arm64-musl@1.15.46':
     optional: true
 
+  '@swc/core-linux-arm64-musl@1.16.2':
+    optional: true
+
   '@swc/core-linux-ppc64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.16.2':
     optional: true
 
   '@swc/core-linux-s390x-gnu@1.15.46':
     optional: true
 
+  '@swc/core-linux-s390x-gnu@1.16.2':
+    optional: true
+
   '@swc/core-linux-x64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.16.2':
     optional: true
 
   '@swc/core-linux-x64-musl@1.15.46':
     optional: true
 
+  '@swc/core-linux-x64-musl@1.16.2':
+    optional: true
+
   '@swc/core-win32-arm64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.16.2':
     optional: true
 
   '@swc/core-win32-ia32-msvc@1.15.46':
     optional: true
 
+  '@swc/core-win32-ia32-msvc@1.16.2':
+    optional: true
+
   '@swc/core-win32-x64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.16.2':
     optional: true
 
   '@swc/core@1.15.46':
@@ -6406,6 +6611,24 @@ snapshots:
       '@swc/core-win32-ia32-msvc': 1.15.46
       '@swc/core-win32-x64-msvc': 1.15.46
 
+  '@swc/core@1.16.2':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.16.2
+      '@swc/core-darwin-x64': 1.16.2
+      '@swc/core-linux-arm-gnueabihf': 1.16.2
+      '@swc/core-linux-arm64-gnu': 1.16.2
+      '@swc/core-linux-arm64-musl': 1.16.2
+      '@swc/core-linux-ppc64-gnu': 1.16.2
+      '@swc/core-linux-s390x-gnu': 1.16.2
+      '@swc/core-linux-x64-gnu': 1.16.2
+      '@swc/core-linux-x64-musl': 1.16.2
+      '@swc/core-win32-arm64-msvc': 1.16.2
+      '@swc/core-win32-ia32-msvc': 1.16.2
+      '@swc/core-win32-x64-msvc': 1.16.2
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -6413,6 +6636,10 @@ snapshots:
       tslib: 2.8.1
 
   '@swc/types@0.1.27':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  '@swc/types@0.1.28':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -7858,6 +8085,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -8008,7 +8237,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.15.46)):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -8023,7 +8252,7 @@ snapshots:
       semver: 7.8.1
       tapable: 2.3.3
       typescript: 5.7.2
-      webpack: 5.97.1(@swc/core@1.15.46)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
 
   forwarded@0.2.0: {}
 
@@ -8504,6 +8733,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.2: {}
 
@@ -9689,15 +9920,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.46)(webpack@5.97.1(@swc/core@1.15.46)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.16.2)(esbuild@0.21.5)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.97.1(@swc/core@1.15.46)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
     optionalDependencies:
-      '@swc/core': 1.15.46
+      '@swc/core': 1.16.2
+      esbuild: 0.21.5
 
   terser@5.48.0:
     dependencies:
@@ -9866,6 +10098,34 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-swc@1.5.11(@swc/core@1.16.2)(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
+      '@swc/core': 1.16.2
+      load-tsconfig: 0.2.5
+      unplugin: 3.3.0(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  unplugin@3.3.0(esbuild@0.21.5)(rollup@4.61.0)(vite@5.4.21(@types/node@22.19.19)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.21.5
+      rollup: 4.61.0
+      vite: 5.4.21(@types/node@22.19.19)(terser@5.48.0)
+      webpack: 5.97.1(@swc/core@1.16.2)(esbuild@0.21.5)
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -10016,7 +10276,9 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.97.1(@swc/core@1.15.46):
+  webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -10038,7 +10300,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.46)(webpack@5.97.1(@swc/core@1.15.46))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.16.2)(esbuild@0.21.5)(webpack@5.97.1(@swc/core@1.16.2)(esbuild@0.21.5))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
Correctness, not performance.

Binlog file and position mean something only on the server that issued them. After a failover the new primary's files and offsets are unrelated — so the saved cursor pointed at an arbitrary place and the stream read whatever was there. Silently.

Cursors now record the issuing server's `@@server_uuid`, and a resume against a different server **fails with an explicit message**. Each cursor also carries the GTID of the transaction it sits at, decoded from the binlog's `GTID_LOG` event.

**This is a guard, not GTID positioning.** The binlog client sends `COM_BINLOG_DUMP` — command `0x12`, I checked the packet — and implements no `COM_BINLOG_DUMP_GTID`. Resuming *from* a GTID set needs a fork of the client. What changes is that a post-failover resume is refused rather than silently wrong.

Cursors stay backward compatible: the identity form is JSON, legacy `file:pos:row[:s]` still parses, and the two orderings are interchangeable.

**Two real bugs found against live MySQL 8.0:**
- `GTID_LOG` was not in the client's `includeEvents`, so those events were filtered out and no GTID was ever captured.
- `startStream` returned as soon as the reader was *told* to start, not once positioned. On a fresh bridge — which starts at the tip of the binlog — a row written immediately after `start()` landed ahead of the reader and was **lost**. That is a data-loss bug in normal use, not a test artifact.

8 new unit tests and 5 integration tests against real MySQL.

---

*Re-opened against `main`. The original PR merged into its stack base rather than into `main`, so the commit never reached it. Same commit, same review — this one targets `main` directly. Merge the set in numeric order.*