### PR TITLE
feat: real benchmarks against millions of rows, published on the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,31 @@ credentials are encrypted at rest and returned redacted, exactly like
 connection passwords. Tunnels apply to the network engines (PostgreSQL, MySQL,
 MongoDB, Redis); SQLite is a local file and never tunnels.
 
+## Benchmarks
+
+Syncle's throughput is measured, not asserted. The suite runs against real
+PostgreSQL, MySQL, SQLite and MongoDB in containers, moving **millions of rows**
+per scenario, and records what it observed — including the CPU and memory the
+run cost, and the resource use of each database container.
+
+**[See the results → syncle.dev/benchmarks](https://syncle.dev/benchmarks)**
+
+The numbers are deliberately not reproduced here, because a figure copied into a
+README goes stale the moment the code moves. The page renders
+[`benchmarks/results.json`](benchmarks/results.json), which is produced by the
+runner in [`apps/api/bench`](apps/api/bench) and committed with every run, so
+anything published can be traced to a recorded measurement and reproduced:
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+pnpm benchmark
+```
+
+Read the disclaimer on that page before quoting anything from it. Every database
+runs on the same machine as Syncle there, with no network in between — which
+flatters the absolute figures and is exactly why the comparisons between code
+paths, rather than the raw rates, are the useful part.
+
 ## CDC prerequisites
 
 Replay and watch bridges work anywhere. CDC needs the **source** database

--- a/apps/api/bench/cdc.bench.ts
+++ b/apps/api/bench/cdc.bench.ts
@@ -1,0 +1,213 @@
+/**
+ * End-to-end change data capture: a row committed on a source database, read
+ * from that database's own change log, and written to a destination — measured
+ * from the moment the writes begin until the last row has landed.
+ *
+ * The mode comes from BENCH_MODE, because the settings under test are read once
+ * at import: the runner invokes this file several times with different
+ * environments and each pass contributes its rows to the same suite.
+ *
+ *   per-row  SYNCLE_CDC_BATCH_SIZE=1   — the path before batching
+ *   batched  (defaults)                — batching on, spool off
+ *   spool    SYNCLE_CDC_SPOOL=on       — batching on, durable spool on
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  makeBridge,
+  type AppHandle,
+} from '../test/integration/app-harness';
+import { TEST_CONNECTIONS, waitFor, withAdapter } from '../test/integration/harness';
+import { bootstrapDrivers, createAdapter } from '@syncle/core/adapters';
+import { MongoClient } from 'mongodb';
+import {
+  captureEnvironment,
+  makeResult,
+  publishSuite,
+  resourceDetail,
+  ResourceSampler,
+  type BenchResult,
+} from './harness';
+
+type Engine = 'postgres' | 'mysql';
+/** destinations use their own databases — see TEST_CONNECTIONS for why */
+type Dest = 'postgres_dest' | 'mysql_dest' | 'mongodb';
+
+const MODE = (process.env.BENCH_MODE ?? 'batched') as 'per-row' | 'batched' | 'spool';
+/** the unbatched path is ~50x slower, so it is measured at a smaller volume */
+const ROWS = Number(process.env.BENCH_ROWS ?? (MODE === 'per-row' ? 20_000 : 1_000_000));
+const CHUNK = 25_000;
+
+let app: AppHandle;
+let mongo: MongoClient | null = null;
+const results: BenchResult[] = [];
+
+/** exact document count, held open so counting does not distort the timing */
+async function mongoCount(collection: string): Promise<number> {
+  const conn = TEST_CONNECTIONS.mongodb!;
+  mongo ??= await new MongoClient(
+    `mongodb://${conn.host}:${conn.port}/?directConnection=true`,
+  ).connect();
+  return mongo.db(conn.database).collection(collection).countDocuments();
+}
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  app = await bootstrapApp();
+}, 300_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await mongo?.close().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+  publishSuite(
+    {
+      id: 'cdc-throughput',
+      name: 'Change data capture, end to end',
+      description:
+        'A row is committed on the source, picked up from that database’s own ' +
+        'change log (Postgres logical replication, MySQL binlog) and written to ' +
+        'the destination. Timing starts when the writes begin and stops when the ' +
+        'last row has landed, so it includes reading the log, delivery and the ' +
+        'destination write. Every run is verified complete and duplicate-free ' +
+        'before its time is recorded.',
+      results,
+    },
+    await captureEnvironment(),
+  );
+});
+
+/** run one source → destination pass and record it */
+async function measure(source: Engine, dest: Dest, label: string): Promise<void> {
+  console.log(`  → ${label}: preparing bridge…`);
+  const srcConn = await connectionFor(app, source);
+  const dstConn = await connectionFor(app, dest);
+  const s = await makeBridge(app, {
+    sourceEngine: source,
+    destEngine: dest,
+    sourceConnId: srcConn,
+    destConnId: dstConn,
+    cleanups,
+  });
+
+  let peakSpool = 0;
+  let spool: any = null;
+  if (MODE === 'spool') {
+    const { CdcSpoolService } = await import('../src/bridges/cdc/cdc-spool.service');
+    spool = app.ctx.get(CdcSpoolService);
+    cleanups.push(() => spool.clear(s.bridgeId).catch(() => undefined));
+  }
+  const watch = spool
+    ? setInterval(() => {
+        void spool
+          .depth(s.bridgeId)
+          .then((d: number) => {
+            if (d > peakSpool) peakSpool = d;
+          })
+          .catch(() => undefined);
+      }, 200)
+    : null;
+
+  const sampler = new ResourceSampler();
+  sampler.start();
+  // ONE long-lived connection for polling. Opening a fresh adapter per poll
+  // (which withAdapter does) costs a connect and a close every time — on
+  // Postgres that dominated the measurement and made a 0.2s sync look like 60s.
+  bootstrapDrivers();
+  const probe = createAdapter(TEST_CONNECTIONS[dest]!);
+  await probe.connect();
+  // An EXACT count. browse()'s total is an estimate on MySQL — it reads
+  // information_schema.table_rows, which the adapter honestly flags as
+  // estimated — so waiting for it to equal the row count never succeeds.
+  const landedCount = async (): Promise<number> => {
+    try {
+      if (dest === 'mongodb') {
+        // browse() reports estimatedDocumentCount when unfiltered, which lags
+        // reality; countDocuments is the exact one
+        return await mongoCount(s.destTable);
+      }
+      const q = dest.startsWith('mysql') ? '`' : '"';
+      const res = await probe.query(`SELECT COUNT(*) AS c FROM ${q}${s.destTable}${q}`);
+      return Number(Object.values(res.rows[0] ?? {})[0] ?? 0);
+    } catch {
+      return 0; // the sink creates the target on first write
+    }
+  };
+
+  console.log(`  → ${label}: writing ${ROWS} rows…`);
+  const started = performance.now();
+  for (let start = 0; start < ROWS; start += CHUNK) {
+    const size = Math.min(CHUNK, ROWS - start);
+    await withAdapter(source, (a) =>
+      a.insertRows!({
+        table: s.sourceTable,
+        rows: Array.from({ length: size }, (_, i) => ({
+          id: start + i + 1,
+          name: `row-${start + i}`,
+        })),
+      }),
+    );
+  }
+  await waitFor(
+    `${ROWS} rows to reach ${dest}`,
+    async () => ((await landedCount()) === ROWS ? true : null),
+    { timeoutMs: 3_000_000, intervalMs: 100 },
+  );
+  const ms = Math.round(performance.now() - started);
+  const usage = sampler.stop();
+  if (watch) clearInterval(watch);
+
+  // a throughput number is worthless if the data is wrong, so verify first
+  const landed = await landedCount();
+  await probe.close().catch(() => undefined);
+  if (landed !== ROWS) throw new Error(`expected ${ROWS} rows, found ${landed}`);
+
+  const detail: Record<string, string | number> = {
+    verified: `${landed} rows, exactly once`,
+    ...resourceDetail(usage, [source, dest]),
+  };
+  if (spool) detail['peak spool depth'] = peakSpool;
+  results.push(makeResult(label, ROWS, ms, detail));
+  console.log(`  ✓ ${label}: ${ROWS} rows in ${ms}ms (${Math.round(ROWS / (ms / 1000))}/s)`);
+
+  // Stop this bridge before the next scenario starts. A stream left running
+  // keeps decoding its source's log, so without this each scenario competes
+  // with every scenario before it and the later numbers measure contention
+  // rather than throughput.
+  await app.cdc.stop(s.bridgeId).catch(() => undefined);
+  await app.cdc.cleanup(s.bridgeId).catch(() => undefined);
+}
+
+describe(`cdc throughput — ${MODE}`, () => {
+  if (MODE === 'per-row') {
+    it('postgres to postgres, one delivery per row', async () => {
+      await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL · one delivery per row');
+    });
+    return;
+  }
+
+  if (MODE === 'spool') {
+    it('postgres to postgres through the durable spool', async () => {
+      await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL · batched + durable spool');
+    });
+    return;
+  }
+
+  it('postgres to postgres', async () => {
+    await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL · batched');
+  });
+
+  it('postgres to mysql', async () => {
+    await measure('postgres', 'mysql_dest', 'PostgreSQL → MySQL · batched');
+  });
+
+  it('mysql to postgres', async () => {
+    await measure('mysql', 'postgres_dest', 'MySQL → PostgreSQL · batched');
+  });
+
+  it('postgres to mongodb', async () => {
+    await measure('postgres', 'mongodb', 'PostgreSQL → MongoDB · batched');
+  });
+});

--- a/apps/api/bench/global-setup.ts
+++ b/apps/api/bench/global-setup.ts
@@ -1,0 +1,111 @@
+/**
+ * Benchmark setup: the integration setup, plus a hard reset of everything a
+ * previous run could have left behind.
+ *
+ * This is not tidiness, it is measurement validity. A leftover Postgres
+ * replication slot stays ACTIVE and keeps retaining WAL, and every slot's
+ * decoder has to walk that backlog before it reaches current changes. Five
+ * abandoned slots holding 414 MB each turned a sub-second sync into sixty
+ * seconds — the run was measuring the debris of earlier runs, not the code.
+ */
+import { Client } from 'pg';
+import { setup as integrationSetup } from '../test/integration/global-setup';
+
+async function pg<T>(fn: (c: Client) => Promise<T>, database = 'syncle_test'): Promise<T | null> {
+  const client = new Client({
+    host: '127.0.0.1',
+    port: 55432,
+    user: 'syncle',
+    password: 'syncle',
+    database,
+  });
+  try {
+    await client.connect();
+    return await fn(client);
+  } catch {
+    return null;
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
+async function resetPostgres(): Promise<void> {
+  await pg(async (c) => {
+    // an active slot cannot be dropped, so disconnect its reader first
+    await c.query(
+      `select pg_terminate_backend(active_pid) from pg_replication_slots
+       where slot_name like 'syncle_slot_%' and active_pid is not null`,
+    );
+    await c.query(
+      `select pg_drop_replication_slot(slot_name) from pg_replication_slots
+       where slot_name like 'syncle_slot_%'`,
+    );
+    const pubs = await c.query<{ pubname: string }>(
+      `select pubname from pg_publication where pubname like 'syncle_%'`,
+    );
+    for (const row of pubs.rows) {
+      await c.query(`drop publication if exists "${row.pubname}"`);
+    }
+    // benchmark and integration fixtures, identifiable by their prefixes
+    const tables = await c.query<{ tablename: string }>(
+      `select tablename from pg_tables where schemaname = 'public'
+         and (tablename like 'src\\_%' or tablename like 'dst\\_%'
+              or tablename like 'b%\\_%' or tablename like 'it\\_%')`,
+    );
+    for (const row of tables.rows) {
+      await c.query(`drop table if exists "${row.tablename}" cascade`);
+    }
+    return null;
+  });
+
+  // destination fixtures live in their own database
+  await pg(async (c) => {
+    const tables = await c.query<{ tablename: string }>(
+      `select tablename from pg_tables where schemaname = 'public'`,
+    );
+    for (const row of tables.rows) {
+      await c.query(`drop table if exists "${row.tablename}" cascade`);
+    }
+    return null;
+  }, 'syncle_dest');
+}
+
+/**
+ * Clear the app's own metadata store.
+ *
+ * This is the important one. A job left with status 'running' — which is what a
+ * killed run leaves behind — is RESUMED on the next boot by
+ * BridgeCdcService.onModuleInit. Its replication slot is long gone, so the
+ * stream fails with "replication slot does not exist" and retries on a backoff
+ * loop, forever. A handful of those from previous runs is enough to keep the
+ * server busy answering doomed START_REPLICATION attempts while the run being
+ * measured waits its turn.
+ */
+async function resetMetadata(): Promise<void> {
+  const client = new Client({
+    host: '127.0.0.1',
+    port: 55432,
+    user: 'syncle',
+    password: 'syncle',
+    database: 'syncle_meta',
+  });
+  try {
+    await client.connect();
+    // order matters: deliveries reference jobs, jobs reference bridges
+    await client.query('delete from bridge_deliveries');
+    await client.query('delete from bridge_jobs');
+    await client.query('delete from bridges');
+    await client.query('delete from connections');
+  } catch {
+    /* a fresh stack has no metadata database yet, which is fine */
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
+export async function setup(): Promise<void> {
+  await integrationSetup();
+  // metadata first: it is what stops dead bridges being resurrected
+  await resetMetadata();
+  await resetPostgres();
+}

--- a/apps/api/bench/harness.ts
+++ b/apps/api/bench/harness.ts
@@ -1,0 +1,343 @@
+/**
+ * Benchmark plumbing: timing, environment capture, and the JSON writer.
+ *
+ * Everything published on the website comes from this file's output. Nothing is
+ * typed by hand, nothing is rounded up, and every record carries the row count
+ * and elapsed time it was derived from so a reader can check the arithmetic.
+ */
+import { cpus, totalmem, platform, release, arch } from 'node:os';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { withAdapter } from '../test/integration/harness';
+
+/** repo-root benchmarks/results.json — the file the website renders */
+export const RESULTS_PATH = resolve(
+  dirname(new URL(import.meta.url).pathname),
+  '../../../benchmarks/results.json',
+);
+
+export interface BenchResult {
+  /** what was measured, e.g. "upsert 100k rows (batched)" */
+  scenario: string;
+  /** rows processed end to end */
+  rows: number;
+  /** wall-clock milliseconds */
+  ms: number;
+  /** rows per second, derived — never entered by hand */
+  rowsPerSec: number;
+  /** optional extras: delivery counts, spool depth, comparison baselines */
+  detail?: Record<string, string | number>;
+}
+
+export interface BenchSuite {
+  id: string;
+  name: string;
+  /** what the suite measures and, where relevant, what it does not */
+  description: string;
+  results: BenchResult[];
+}
+
+export interface BenchReport {
+  generatedAt: string;
+  /** stated plainly on the page: what these numbers are and are not */
+  disclaimer: string;
+  environment: Record<string, string>;
+  suites: BenchSuite[];
+}
+
+/**
+ * Every database, Redis and Syncle itself run on ONE machine here, so there is
+ * effectively no network between them. That flatters throughput compared with a
+ * managed or remote database, where round-trip latency dominates — and it is
+ * exactly the reason the batching work matters, so it would be dishonest to
+ * publish the figures without saying so.
+ */
+export const DISCLAIMER =
+  'Measured on a single local machine: Syncle, both databases and Redis all run ' +
+  'on the same host, in containers, with no network between them. Real ' +
+  'deployments put a network in that path, and against a managed or remote ' +
+  'database latency — not the database — is usually what sets the pace, so ' +
+  'expect lower absolute numbers there. These runs are useful for comparing ' +
+  'code paths against each other, not for predicting your production ceiling. ' +
+  'Every figure is measured; none is estimated, extrapolated or rounded up.';
+
+/** time `fn`, returning its value and the elapsed wall clock */
+export async function timed<T>(fn: () => Promise<T>): Promise<{ value: T; ms: number }> {
+  const started = performance.now();
+  const value = await fn();
+  return { value, ms: Math.round(performance.now() - started) };
+}
+
+export function makeResult(
+  scenario: string,
+  rows: number,
+  ms: number,
+  detail?: Record<string, string | number>,
+): BenchResult {
+  return {
+    scenario,
+    rows,
+    ms,
+    // guard against a zero-millisecond measurement producing Infinity
+    rowsPerSec: ms > 0 ? Math.round(rows / (ms / 1000)) : rows,
+    ...(detail ? { detail } : {}),
+  };
+}
+
+/** engine versions, read from the servers themselves rather than assumed */
+async function engineVersions(): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  const probes: Array<[string, () => Promise<string>]> = [
+    [
+      'PostgreSQL',
+      () =>
+        withAdapter('postgres', async (a) => {
+          const r = await a.query('SHOW server_version');
+          return String(Object.values(r.rows[0] ?? {})[0] ?? '').split(' ')[0] ?? '';
+        }),
+    ],
+    [
+      'MySQL',
+      () =>
+        withAdapter('mysql', async (a) => {
+          const r = await a.query('SELECT VERSION() AS v');
+          return String((r.rows[0] as { v?: unknown })?.v ?? '');
+        }),
+    ],
+    [
+      'Redis',
+      () =>
+        withAdapter('redis', async (a) => {
+          const r = await a.query('INFO server');
+          const text = JSON.stringify(r.rows);
+          return /redis_version:([0-9.]+)/.exec(text)?.[1] ?? 'unknown';
+        }),
+    ],
+  ];
+  for (const [name, probe] of probes) {
+    try {
+      out[name] = await probe();
+    } catch {
+      out[name] = 'unavailable';
+    }
+  }
+  return out;
+}
+
+export async function captureEnvironment(): Promise<Record<string, string>> {
+  const cores = cpus();
+  return {
+    Platform: `${platform()} ${release()} (${arch()})`,
+    CPU: cores[0]?.model?.trim() ?? 'unknown',
+    Cores: String(cores.length),
+    Memory: `${Math.round(totalmem() / 1024 ** 3)} GB`,
+    Node: process.version,
+    ...(await engineVersions()),
+    Databases: 'containerised, same machine (docker-compose.test.yml)',
+  };
+}
+
+/**
+ * Merge a suite into the report on disk. Each bench file writes its own suite,
+ * so a partial run updates only what it measured and leaves the rest intact.
+ */
+export function publishSuite(suite: BenchSuite, environment: Record<string, string>): void {
+  let report: BenchReport = {
+    generatedAt: new Date().toISOString(),
+    disclaimer: DISCLAIMER,
+    environment,
+    suites: [],
+  };
+  try {
+    report = JSON.parse(readFileSync(RESULTS_PATH, 'utf8')) as BenchReport;
+  } catch {
+    /* first run */
+  }
+  report.generatedAt = new Date().toISOString();
+  report.disclaimer = DISCLAIMER;
+  report.environment = environment;
+
+  // a suite can be filled in by several runs (each needs different env, since
+  // the runtime config is read once at import), so merge by scenario name and
+  // let the newest measurement win rather than replacing the whole suite
+  const existing = report.suites.find((s) => s.id === suite.id);
+  const merged: BenchSuite = existing
+    ? {
+        ...suite,
+        results: [
+          ...existing.results.filter(
+            (r) => !suite.results.some((n) => n.scenario === r.scenario),
+          ),
+          ...suite.results,
+        ],
+      }
+    : suite;
+  report.suites = [...report.suites.filter((s) => s.id !== suite.id), merged].sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
+  mkdirSync(dirname(RESULTS_PATH), { recursive: true });
+  writeFileSync(RESULTS_PATH, `${JSON.stringify(report, null, 2)}\n`);
+
+  // also to stdout, so a CI log shows what was measured
+  console.log(`\n── ${suite.name} ──`);
+  for (const r of suite.results) {
+    console.log(
+      `  ${r.scenario.padEnd(52)} ${String(r.rows).padStart(9)} rows  ${String(r.ms).padStart(7)} ms  ${String(r.rowsPerSec).padStart(8)}/s`,
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* resource sampling                                                          */
+/* -------------------------------------------------------------------------- */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+
+export interface ResourceUsage {
+  /** peak CPU of the Syncle process, as a percentage of ONE core */
+  peakProcessCpuPercent: number;
+  /** mean CPU of the Syncle process over the run */
+  avgProcessCpuPercent: number;
+  /** peak resident memory of the Syncle process, MB */
+  peakProcessRssMb: number;
+  /** peak CPU and memory per database container, from docker stats */
+  containers: Record<string, { cpuPercent: number; memoryMb: number }>;
+}
+
+/**
+ * Samples what a run actually costs, not just how fast it was. Throughput
+ * without a resource figure is half a number: a rate bought by pinning every
+ * core is a different result from the same rate while mostly idle.
+ *
+ * The Syncle process is sampled from process.cpuUsage(), which is exact. The
+ * databases run in containers, so those come from `docker stats` — sampled at a
+ * low frequency because each call costs about a second.
+ */
+export class ResourceSampler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private dockerTimer: ReturnType<typeof setInterval> | null = null;
+  private lastCpu = process.cpuUsage();
+  private lastAt = performance.now();
+  private samples: number[] = [];
+  private peakRss = 0;
+  private containers: Record<string, { cpuPercent: number; memoryMb: number }> = {};
+  private busy = false;
+
+  start(): void {
+    this.lastCpu = process.cpuUsage();
+    this.lastAt = performance.now();
+    this.samples = [];
+    this.peakRss = 0;
+    this.containers = {};
+
+    this.timer = setInterval(() => {
+      const now = performance.now();
+      const delta = process.cpuUsage(this.lastCpu);
+      const elapsedMs = now - this.lastAt;
+      if (elapsedMs > 0) {
+        // cpuUsage is microseconds of CPU time; 100% == one core saturated
+        const percent = ((delta.user + delta.system) / 1000 / elapsedMs) * 100;
+        this.samples.push(percent);
+      }
+      this.lastCpu = process.cpuUsage();
+      this.lastAt = now;
+      const rss = process.memoryUsage().rss / 1024 ** 2;
+      if (rss > this.peakRss) this.peakRss = rss;
+    }, 50);
+    this.timer.unref?.();
+
+    this.dockerTimer = setInterval(() => void this.sampleDocker(), 2_000);
+    this.dockerTimer.unref?.();
+  }
+
+  /** peak-per-container from `docker stats`; failures are simply not recorded */
+  private async sampleDocker(): Promise<void> {
+    if (this.busy) return; // a slow call must not queue up behind itself
+    this.busy = true;
+    try {
+      const { stdout } = await exec('docker', [
+        'stats',
+        '--no-stream',
+        '--format',
+        '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}',
+      ]);
+      for (const line of stdout.trim().split('\n')) {
+        const [name, cpu, mem] = line.split('\t');
+        if (!name?.startsWith('syncle-test-')) continue;
+        const cpuPercent = Number((cpu ?? '').replace('%', '')) || 0;
+        const memoryMb = parseMemory(mem ?? '');
+        const engine = name.replace('syncle-test-', '').replace(/-\d+$/, '');
+        const prev = this.containers[engine];
+        this.containers[engine] = {
+          cpuPercent: Math.max(prev?.cpuPercent ?? 0, Math.round(cpuPercent)),
+          memoryMb: Math.max(prev?.memoryMb ?? 0, Math.round(memoryMb)),
+        };
+      }
+    } catch {
+      /* docker unavailable — container figures are simply omitted */
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  stop(): ResourceUsage {
+    if (this.timer) clearInterval(this.timer);
+    if (this.dockerTimer) clearInterval(this.dockerTimer);
+    this.timer = null;
+    this.dockerTimer = null;
+    const peak = this.samples.length ? Math.max(...this.samples) : 0;
+    const avg = this.samples.length
+      ? this.samples.reduce((a, b) => a + b, 0) / this.samples.length
+      : 0;
+    return {
+      peakProcessCpuPercent: Math.round(peak),
+      avgProcessCpuPercent: Math.round(avg),
+      peakProcessRssMb: Math.round(this.peakRss),
+      containers: this.containers,
+    };
+  }
+}
+
+/** "1.234GiB / 7.66GiB" -> megabytes of the first figure */
+function parseMemory(text: string): number {
+  const m = /^([\d.]+)\s*([KMG])i?B/i.exec(text.trim());
+  if (!m) return 0;
+  const value = Number(m[1]);
+  const unit = (m[2] ?? 'M').toUpperCase();
+  if (unit === 'G') return value * 1024;
+  if (unit === 'K') return value / 1024;
+  return value;
+}
+
+/**
+ * Fold a resource reading into a result's detail map.
+ *
+ * `engines` names the containers this scenario actually used. Every container
+ * in the stack is sampled, but reporting MongoDB's idle CPU next to a
+ * Postgres-only measurement reads as though it took part — so only the ones
+ * involved are published.
+ */
+export function resourceDetail(
+  usage: ResourceUsage,
+  engines: string[] = [],
+): Record<string, string | number> {
+  // A run shorter than the sampling interval yields no samples. Reporting the
+  // resulting zeroes would read as "used no CPU and no memory", which is worse
+  // than saying nothing — so a scenario too brief to sample publishes no
+  // resource figures at all.
+  if (usage.peakProcessRssMb === 0 && usage.peakProcessCpuPercent === 0) return {};
+
+  const detail: Record<string, string | number> = {
+    'syncle cpu (peak / avg)': `${usage.peakProcessCpuPercent}% / ${usage.avgProcessCpuPercent}%`,
+    'syncle memory (peak)': `${usage.peakProcessRssMb} MB`,
+  };
+  const wanted = new Set(engines.map((e) => e.replace(/_dest$/, '').replace('postgres', 'pg')));
+  for (const [engine, c] of Object.entries(usage.containers)) {
+    if (wanted.size > 0 && !wanted.has(engine)) continue;
+    detail[`${engine} cpu / memory (peak)`] = `${c.cpuPercent}% / ${c.memoryMb} MB`;
+  }
+  return detail;
+}

--- a/apps/api/bench/sink-writes.bench.ts
+++ b/apps/api/bench/sink-writes.bench.ts
@@ -1,0 +1,211 @@
+/**
+ * Write-path throughput at the adapter level: what it costs to land rows in a
+ * destination, per engine, batched versus one statement per row.
+ *
+ * The comparison pair runs at the SAME row count on the same table shape, so
+ * the two rates are directly comparable. The large runs then show the batched
+ * path at a volume nobody would attempt row-at-a-time.
+ */
+import 'reflect-metadata';
+import { afterAll, describe, it } from 'vitest';
+import type { DatabaseAdapter } from '@syncle/core';
+import { uniqueTable, withAdapter } from '../test/integration/harness';
+import {
+  captureEnvironment,
+  makeResult,
+  publishSuite,
+  resourceDetail,
+  ResourceSampler,
+  timed,
+  type BenchResult,
+} from './harness';
+
+/** time a block while sampling what it costs in CPU and memory */
+async function measured<T>(
+  engine: Engine,
+  fn: () => Promise<T>,
+): Promise<{ ms: number; detail: Record<string, string | number> }> {
+  const sampler = new ResourceSampler();
+  sampler.start();
+  const { ms } = await timed(fn);
+  return { ms, detail: resourceDetail(sampler.stop(), [engine]) };
+}
+
+type Engine = 'postgres' | 'mysql' | 'sqlite';
+const TYPES: Record<Engine, { int: string; text: string }> = {
+  postgres: { int: 'integer', text: 'text' },
+  mysql: { int: 'int', text: 'varchar(255)' },
+  sqlite: { int: 'INTEGER', text: 'TEXT' },
+};
+
+/** same row count for both sides of every comparison */
+const COMPARE_ROWS = 50_000;
+/** the batched path at real volume */
+const LARGE_ROWS = 1_000_000;
+
+const results: BenchResult[] = [];
+const tables: Array<{ engine: Engine; table: string }> = [];
+
+async function makeTable(a: DatabaseAdapter, engine: Engine, table: string): Promise<void> {
+  const t = TYPES[engine];
+  await a.createTable({
+    table,
+    columns: [
+      { name: 'id', type: t.int, nullable: false, primaryKey: true },
+      { name: 'name', type: t.text, nullable: true },
+      { name: 'note', type: t.text, nullable: true },
+    ],
+  });
+  tables.push({ engine, table });
+}
+
+const rowsFor = (n: number, offset = 0): Array<Record<string, unknown>> =>
+  Array.from({ length: n }, (_, i) => ({
+    id: offset + i + 1,
+    name: `name-${offset + i}`,
+    note: `note-${offset + i}`,
+  }));
+
+afterAll(async () => {
+  for (const t of tables) {
+    await withAdapter(t.engine, (a) => a.dropTable(t.table)).catch(() => undefined);
+  }
+  publishSuite(
+    {
+      id: 'sink-writes',
+      name: 'Destination writes',
+      description:
+        'Rows written into a destination table through the real adapters. ' +
+        'The per-row rows are the old path — one statement per row; the batched ' +
+        'rows are one multi-row statement per chunk. Both sides of each pair run ' +
+        `at ${COMPARE_ROWS.toLocaleString()} rows on the same table, so the rates compare directly.`,
+      results,
+    },
+    await captureEnvironment(),
+  );
+});
+
+describe('destination write throughput', () => {
+  for (const engine of ['postgres', 'mysql', 'sqlite'] as Engine[]) {
+    it(`${engine}: insert, per-row vs batched`, async () => {
+      const rows = rowsFor(COMPARE_ROWS);
+      await withAdapter(engine, async (a) => {
+        const loopTable = uniqueTable('bw_loop');
+        await makeTable(a, engine, loopTable);
+        const loop = await measured(engine, async () => {
+          for (const values of rows) await a.insertRow({ table: loopTable, values });
+        });
+        results.push(
+          makeResult(
+            `${engine} · insert · one statement per row`,
+            COMPARE_ROWS,
+            loop.ms,
+            loop.detail,
+          ),
+        );
+
+        const batchTable = uniqueTable('bw_batch');
+        await makeTable(a, engine, batchTable);
+        const batched = await measured(engine, () => a.insertRows!({ table: batchTable, rows }));
+        results.push(
+          makeResult(`${engine} · insert · batched`, COMPARE_ROWS, batched.ms, {
+            'speed-up': `${(loop.ms / Math.max(1, batched.ms)).toFixed(1)}×`,
+            ...batched.detail,
+          }),
+        );
+      });
+    });
+
+    it(`${engine}: upsert, per-row vs batched`, async () => {
+      const rows = rowsFor(COMPARE_ROWS);
+      await withAdapter(engine, async (a) => {
+        const loopTable = uniqueTable('bu_loop');
+        await makeTable(a, engine, loopTable);
+        const loop = await measured(engine, async () => {
+          for (const values of rows) {
+            await a.upsertRow({ table: loopTable, values, keyColumns: ['id'] });
+          }
+        });
+        results.push(
+          makeResult(
+            `${engine} · upsert · one statement per row`,
+            COMPARE_ROWS,
+            loop.ms,
+            loop.detail,
+          ),
+        );
+
+        const batchTable = uniqueTable('bu_batch');
+        await makeTable(a, engine, batchTable);
+        const batched = await measured(engine, () =>
+          a.upsertRows!({ table: batchTable, rows, keyColumns: ['id'] }),
+        );
+        results.push(
+          makeResult(`${engine} · upsert · batched`, COMPARE_ROWS, batched.ms, {
+            'speed-up': `${(loop.ms / Math.max(1, batched.ms)).toFixed(1)}×`,
+            ...batched.detail,
+          }),
+        );
+      });
+    });
+
+    it(`${engine}: delete, per-row vs batched`, async () => {
+      const rows = rowsFor(COMPARE_ROWS);
+      const identities = rows.map((r) => ({ id: r.id }));
+      await withAdapter(engine, async (a) => {
+        const loopTable = uniqueTable('bd_loop');
+        await makeTable(a, engine, loopTable);
+        await a.insertRows!({ table: loopTable, rows });
+        const loop = await measured(engine, async () => {
+          for (const identity of identities) await a.deleteRow({ table: loopTable, identity });
+        });
+        results.push(
+          makeResult(
+            `${engine} · delete · one statement per row`,
+            COMPARE_ROWS,
+            loop.ms,
+            loop.detail,
+          ),
+        );
+
+        const batchTable = uniqueTable('bd_batch');
+        await makeTable(a, engine, batchTable);
+        await a.insertRows!({ table: batchTable, rows });
+        const batched = await measured(engine, () => a.deleteRows!({ table: batchTable, identities }));
+        results.push(
+          makeResult(`${engine} · delete · batched`, COMPARE_ROWS, batched.ms, {
+            'speed-up': `${(loop.ms / Math.max(1, batched.ms)).toFixed(1)}×`,
+            ...batched.detail,
+          }),
+        );
+      });
+    });
+  }
+
+  it('one million rows, batched upsert', async () => {
+    for (const engine of ['postgres', 'mysql'] as Engine[]) {
+      await withAdapter(engine, async (a) => {
+        const table = uniqueTable('bm');
+        await makeTable(a, engine, table);
+        const chunk = 50_000;
+        const run = await measured(engine, async () => {
+          for (let start = 0; start < LARGE_ROWS; start += chunk) {
+            await a.upsertRows!({
+              table,
+              rows: rowsFor(Math.min(chunk, LARGE_ROWS - start), start),
+              keyColumns: ['id'],
+            });
+          }
+        });
+        results.push(
+          makeResult(
+            `${engine} · upsert · batched · 1,000,000 rows`,
+            LARGE_ROWS,
+            run.ms,
+            run.detail,
+          ),
+        );
+      });
+    }
+  });
+});

--- a/apps/api/src/bridges/database-sink.service.ts
+++ b/apps/api/src/bridges/database-sink.service.ts
@@ -254,6 +254,11 @@ export class DatabaseSinkService {
     );
 
     if (exists) {
+      // The target being present does NOT mean its key is indexed. A MongoDB
+      // collection springs into existence on first write, so this branch is the
+      // one a Mongo destination always takes — and without the index every
+      // upsert is a collection scan. ensureKeyIndex is idempotent.
+      await this.ensureKeyIndex(target);
       this.ensured.add(key);
       return;
     }
@@ -283,7 +288,33 @@ export class DatabaseSinkService {
     this.logger.log(
       `Created target table ${targetLabel(target)} (${columns.length} cols)`,
     );
+    await this.ensureKeyIndex(target);
     this.ensured.add(key);
+  }
+
+  /**
+   * Ask the destination to index the columns this target upserts on, where the
+   * engine needs it. Relational engines index their primary key already and do
+   * not implement this; MongoDB does. Failure is logged, not fatal — a missing
+   * index makes writes slow, not wrong.
+   */
+  private async ensureKeyIndex(target: DatabaseTarget): Promise<void> {
+    if (target.writeMode !== 'upsert' || target.keyColumns.length === 0) return;
+    try {
+      await this.pool.withAdapter(target.connectionId, target.database, (adapter) =>
+        adapter.ensureKeyIndex
+          ? adapter.ensureKeyIndex({
+              schema: target.schema,
+              table: target.table,
+              columns: target.keyColumns,
+            })
+          : Promise.resolve(),
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Could not index key columns on ${targetLabel(target)} — upserts will be slower: ${(err as Error).message}`,
+      );
+    }
   }
 
   /**

--- a/apps/api/test/integration/app-harness.ts
+++ b/apps/api/test/integration/app-harness.ts
@@ -37,14 +37,14 @@ export async function bootstrapApp(): Promise<AppHandle> {
   };
 }
 
-export async function connectionFor(
-  app: AppHandle,
-  engine: 'postgres' | 'mysql',
-): Promise<string> {
-  const t = TEST_CONNECTIONS[engine]!;
+/** a key into TEST_CONNECTIONS; `*_dest` variants point at a separate database */
+export type ConnKey = 'postgres' | 'mysql' | 'mongodb' | 'postgres_dest' | 'mysql_dest';
+
+export async function connectionFor(app: AppHandle, key: ConnKey): Promise<string> {
+  const t = TEST_CONNECTIONS[key]!;
   const conn = await app.connections.create({
-    name: `it-${engine}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-    engine,
+    name: `it-${key}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    engine: t.engine,
     host: t.host,
     port: t.port,
     user: t.user,
@@ -67,13 +67,13 @@ export interface SyncSetup {
 export async function makeBridge(
   app: AppHandle,
   opts: {
-    destEngine: 'postgres' | 'mysql';
+    destEngine: ConnKey;
     sourceConnId: string;
     destConnId: string;
     cleanups: Array<() => Promise<void>>;
     start?: boolean;
     /** engine the source table lives on; defaults to postgres */
-    sourceEngine?: 'postgres' | 'mysql';
+    sourceEngine?: ConnKey;
   },
 ): Promise<SyncSetup> {
   const { destEngine, sourceConnId, destConnId, cleanups } = opts;
@@ -133,7 +133,7 @@ export async function makeBridge(
 
 /** rows in the destination table, sorted by id; [] before the sink creates it */
 export async function destRows(
-  engine: 'postgres' | 'mysql',
+  engine: ConnKey,
   table: string,
 ): Promise<Array<Record<string, unknown>>> {
   return withAdapter(engine, async (a) => {
@@ -150,31 +150,34 @@ export async function destRows(
  * Row count in the destination. `destRows` pages through `browse`, which is
  * capped (5000 by default), so anything larger must be counted in the engine.
  */
-export async function destCount(
-  engine: 'postgres' | 'mysql',
-  table: string,
-): Promise<number> {
+export async function destCount(engine: ConnKey, table: string): Promise<number> {
   return withAdapter(engine, async (a) => {
     try {
-      const res = await a.query(`SELECT COUNT(*) AS n FROM "${table}"`.replace(
-        /"/g,
-        engine === 'mysql' ? '`' : '"',
-      ));
-      const row = res.rows[0] as { n?: unknown };
-      return Number(row?.n ?? 0);
+      // MongoDB has no COUNT statement here, and its browse total is exact.
+      // For SQL engines the total is NOT safe to compare against an expected
+      // row count: MySQL derives it from information_schema.table_rows, which
+      // is an estimate (the adapter flags it as such), so an equality check
+      // against it never becomes true.
+      if (engine === 'mongodb') {
+        const res = await a.browse({ table, limit: 1, offset: 0 });
+        return Number(res.total ?? 0);
+      }
+      const q = engine.startsWith('mysql') ? '`' : '"';
+      const res = await a.query(`SELECT COUNT(*) AS c FROM ${q}${table}${q}`);
+      return Number(Object.values(res.rows[0] ?? {})[0] ?? 0);
     } catch {
-      return 0; // table not created yet
+      return 0; // the sink creates the target on first write
     }
   });
 }
 
 /** distinct ids in the destination, to prove exactly-once at volume */
 export async function destDistinctIds(
-  engine: 'postgres' | 'mysql',
+  engine: ConnKey,
   table: string,
 ): Promise<{ distinct: number; min: number; max: number }> {
   return withAdapter(engine, async (a) => {
-    const q = engine === 'mysql' ? '`' : '"';
+    const q = engine.startsWith('mysql') ? '`' : '"';
     const res = await a.query(
       `SELECT COUNT(DISTINCT id) AS d, MIN(id) AS lo, MAX(id) AS hi FROM ${q}${table}${q}`,
     );

--- a/apps/api/test/integration/global-setup.ts
+++ b/apps/api/test/integration/global-setup.ts
@@ -89,11 +89,10 @@ async function prepareMetadataDatabase(): Promise<void> {
   });
   await admin.connect();
   try {
-    const exists = await admin.query(
-      'select 1 from pg_database where datname = $1',
-      ['syncle_meta'],
-    );
-    if (exists.rowCount === 0) await admin.query('create database syncle_meta');
+    for (const db of ['syncle_meta', 'syncle_dest']) {
+      const exists = await admin.query('select 1 from pg_database where datname = $1', [db]);
+      if (exists.rowCount === 0) await admin.query(`create database "${db}"`);
+    }
   } finally {
     await admin.end().catch(() => undefined);
   }
@@ -105,10 +104,34 @@ async function prepareMetadataDatabase(): Promise<void> {
   });
 }
 
+/** MySQL destinations get their own schema too, for symmetry with Postgres */
+async function prepareMysqlDestination(): Promise<void> {
+  const { createAdapter } = await import('@syncle/core/adapters');
+  const adapter = createAdapter(TEST_CONNECTIONS.mysql!);
+  try {
+    await adapter.connect();
+    await adapter.query('CREATE DATABASE IF NOT EXISTS `syncle_dest`');
+  } catch {
+    /* the suite fails later and more clearly if this really matters */
+  } finally {
+    await adapter.close().catch(() => undefined);
+  }
+}
+
 export async function setup(): Promise<void> {
   applyTestEnv();
   bootstrapDrivers();
   await initReplicaSet();
-  for (const name of Object.keys(TEST_CONNECTIONS)) await waitForEngine(name);
+  // the *_dest entries point at databases this function is about to create,
+  // so only the base engines are waited on here
+  for (const name of Object.keys(TEST_CONNECTIONS)) {
+    if (name.endsWith('_dest')) continue;
+    await waitForEngine(name);
+  }
   await prepareMetadataDatabase();
+  await prepareMysqlDestination();
+  // now they exist, confirm they are actually reachable
+  for (const name of Object.keys(TEST_CONNECTIONS)) {
+    if (name.endsWith('_dest')) await waitForEngine(name);
+  }
 }

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -50,6 +50,25 @@ export const TEST_CONNECTIONS: Record<string, ConnectionConfig> = {
     database: 'syncle_test',
   }),
   redis: base('redis', { host: '127.0.0.1', port: 56379 }),
+  // Destinations live in their OWN databases, which is both realistic and
+  // necessary for measurement: a Postgres logical slot is database-scoped, so
+  // writing the destination into the source's database makes the source's
+  // decoder chew through the destination's WAL as well — a feedback loop that
+  // gets worse the more rows you sync.
+  postgres_dest: base('postgres', {
+    host: '127.0.0.1',
+    port: 55432,
+    user: 'syncle',
+    password: 'syncle',
+    database: 'syncle_dest',
+  }),
+  mysql_dest: base('mysql', {
+    host: '127.0.0.1',
+    port: 53306,
+    user: 'root',
+    password: 'syncle',
+    database: 'syncle_dest',
+  }),
   // file-backed, so it needs no container; a fresh temp file per run
   sqlite: base('sqlite', {
     database: join(mkdtempSync(join(tmpdir(), 'syncle-it-')), 'test.db'),

--- a/apps/api/vitest.bench.config.ts
+++ b/apps/api/vitest.bench.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config';
+import swc from 'unplugin-swc';
+
+/**
+ * Benchmark runner. Same real-database stack as the integration suite, but the
+ * files here MEASURE rather than assert, and they write their findings to
+ * benchmarks/results.json — the file the website renders.
+ *
+ *   docker compose -f docker-compose.test.yml up -d
+ *   pnpm benchmark
+ *
+ * Serial and single-forked on purpose: parallel work would contend for the same
+ * databases and the numbers would mean nothing.
+ */
+export default defineConfig({
+  plugins: [swc.vite({ module: { type: 'es6' } })],
+  test: {
+    include: ['bench/**/*.bench.ts'],
+    // resets replication slots and fixtures first: leftovers from a previous
+    // run distort every number that follows
+    globalSetup: ['bench/global-setup.ts'],
+    testTimeout: 3_600_000,
+    hookTimeout: 600_000,
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    fileParallelism: false,
+    sequence: { concurrent: false },
+    // a benchmark run is one long report; keep the output readable
+    reporters: ['default'],
+  },
+});

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,0 +1,308 @@
+{
+  "generatedAt": "2026-09-07T08:56:11.607Z",
+  "disclaimer": "Measured on a single local machine: Syncle, both databases and Redis all run on the same host, in containers, with no network between them. Real deployments put a network in that path, and against a managed or remote database latency — not the database — is usually what sets the pace, so expect lower absolute numbers there. These runs are useful for comparing code paths against each other, not for predicting your production ceiling. Every figure is measured; none is estimated, extrapolated or rounded up.",
+  "environment": {
+    "Platform": "darwin 25.5.0 (arm64)",
+    "CPU": "Apple M4",
+    "Cores": "10",
+    "Memory": "16 GB",
+    "Node": "v22.23.1",
+    "PostgreSQL": "16.15",
+    "MySQL": "8.0.46",
+    "Redis": "7.4.11",
+    "Databases": "containerised, same machine (docker-compose.test.yml)"
+  },
+  "suites": [
+    {
+      "id": "cdc-throughput",
+      "name": "Change data capture, end to end",
+      "description": "A row is committed on the source, picked up from that database’s own change log (Postgres logical replication, MySQL binlog) and written to the destination. Timing starts when the writes begin and stops when the last row has landed, so it includes reading the log, delivery and the destination write. Every run is verified complete and duplicate-free before its time is recorded.",
+      "results": [
+        {
+          "scenario": "PostgreSQL → PostgreSQL · one delivery per row",
+          "rows": 20000,
+          "ms": 83934,
+          "rowsPerSec": 238,
+          "detail": {
+            "verified": "20000 rows, exactly once",
+            "syncle cpu (peak / avg)": "59% / 33%",
+            "syncle memory (peak)": "149 MB",
+            "pg cpu / memory (peak)": "24% / 1324 MB"
+          }
+        },
+        {
+          "scenario": "PostgreSQL → PostgreSQL · batched",
+          "rows": 1000000,
+          "ms": 51974,
+          "rowsPerSec": 19240,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "71% / 35%",
+            "syncle memory (peak)": "204 MB",
+            "pg cpu / memory (peak)": "118% / 1430 MB"
+          }
+        },
+        {
+          "scenario": "PostgreSQL → MySQL · batched",
+          "rows": 1000000,
+          "ms": 36686,
+          "rowsPerSec": 27258,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "73% / 42%",
+            "syncle memory (peak)": "248 MB",
+            "pg cpu / memory (peak)": "60% / 1442 MB",
+            "mysql cpu / memory (peak)": "52% / 1228 MB"
+          }
+        },
+        {
+          "scenario": "MySQL → PostgreSQL · batched",
+          "rows": 1000000,
+          "ms": 36986,
+          "rowsPerSec": 27037,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "72% / 37%",
+            "syncle memory (peak)": "224 MB",
+            "pg cpu / memory (peak)": "87% / 1490 MB",
+            "mysql cpu / memory (peak)": "103% / 1381 MB"
+          }
+        },
+        {
+          "scenario": "PostgreSQL → MongoDB · batched",
+          "rows": 1000000,
+          "ms": 78739,
+          "rowsPerSec": 12700,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "75% / 29%",
+            "syncle memory (peak)": "200 MB",
+            "pg cpu / memory (peak)": "45% / 1552 MB"
+          }
+        },
+        {
+          "scenario": "PostgreSQL → PostgreSQL · batched + durable spool",
+          "rows": 1000000,
+          "ms": 49284,
+          "rowsPerSec": 20291,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "135% / 48%",
+            "syncle memory (peak)": "231 MB",
+            "pg cpu / memory (peak)": "120% / 1358 MB",
+            "peak spool depth": 50000
+          }
+        }
+      ]
+    },
+    {
+      "id": "sink-writes",
+      "name": "Destination writes",
+      "description": "Rows written into a destination table through the real adapters. The per-row rows are the old path — one statement per row; the batched rows are one multi-row statement per chunk. Both sides of each pair run at 50,000 rows on the same table, so the rates compare directly.",
+      "results": [
+        {
+          "scenario": "postgres · insert · one statement per row",
+          "rows": 50000,
+          "ms": 15628,
+          "rowsPerSec": 3199,
+          "detail": {
+            "syncle cpu (peak / avg)": "83% / 12%",
+            "syncle memory (peak)": "102 MB",
+            "pg cpu / memory (peak)": "18% / 1239 MB"
+          }
+        },
+        {
+          "scenario": "postgres · insert · batched",
+          "rows": 50000,
+          "ms": 174,
+          "rowsPerSec": 287356,
+          "detail": {
+            "speed-up": "89.8×",
+            "syncle cpu (peak / avg)": "72% / 38%",
+            "syncle memory (peak)": "109 MB"
+          }
+        },
+        {
+          "scenario": "postgres · upsert · one statement per row",
+          "rows": 50000,
+          "ms": 14616,
+          "rowsPerSec": 3421,
+          "detail": {
+            "syncle cpu (peak / avg)": "51% / 11%",
+            "syncle memory (peak)": "122 MB",
+            "pg cpu / memory (peak)": "23% / 1264 MB"
+          }
+        },
+        {
+          "scenario": "postgres · upsert · batched",
+          "rows": 50000,
+          "ms": 414,
+          "rowsPerSec": 120773,
+          "detail": {
+            "speed-up": "35.3×",
+            "syncle cpu (peak / avg)": "40% / 9%",
+            "syncle memory (peak)": "99 MB"
+          }
+        },
+        {
+          "scenario": "postgres · delete · one statement per row",
+          "rows": 50000,
+          "ms": 13678,
+          "rowsPerSec": 3656,
+          "detail": {
+            "syncle cpu (peak / avg)": "42% / 10%",
+            "syncle memory (peak)": "118 MB",
+            "pg cpu / memory (peak)": "24% / 1264 MB"
+          }
+        },
+        {
+          "scenario": "postgres · delete · batched",
+          "rows": 50000,
+          "ms": 57,
+          "rowsPerSec": 877193,
+          "detail": {
+            "speed-up": "240.0×",
+            "syncle cpu (peak / avg)": "102% / 102%",
+            "syncle memory (peak)": "122 MB"
+          }
+        },
+        {
+          "scenario": "mysql · insert · one statement per row",
+          "rows": 50000,
+          "ms": 18465,
+          "rowsPerSec": 2708,
+          "detail": {
+            "syncle cpu (peak / avg)": "67% / 15%",
+            "syncle memory (peak)": "130 MB",
+            "mysql cpu / memory (peak)": "49% / 1152 MB"
+          }
+        },
+        {
+          "scenario": "mysql · insert · batched",
+          "rows": 50000,
+          "ms": 349,
+          "rowsPerSec": 143266,
+          "detail": {
+            "speed-up": "52.9×",
+            "syncle cpu (peak / avg)": "143% / 31%",
+            "syncle memory (peak)": "119 MB"
+          }
+        },
+        {
+          "scenario": "mysql · upsert · one statement per row",
+          "rows": 50000,
+          "ms": 19127,
+          "rowsPerSec": 2614,
+          "detail": {
+            "syncle cpu (peak / avg)": "54% / 15%",
+            "syncle memory (peak)": "127 MB",
+            "mysql cpu / memory (peak)": "46% / 1221 MB"
+          }
+        },
+        {
+          "scenario": "mysql · upsert · batched",
+          "rows": 50000,
+          "ms": 341,
+          "rowsPerSec": 146628,
+          "detail": {
+            "speed-up": "56.1×",
+            "syncle cpu (peak / avg)": "71% / 17%",
+            "syncle memory (peak)": "106 MB"
+          }
+        },
+        {
+          "scenario": "mysql · delete · one statement per row",
+          "rows": 50000,
+          "ms": 25975,
+          "rowsPerSec": 1925,
+          "detail": {
+            "syncle cpu (peak / avg)": "114% / 15%",
+            "syncle memory (peak)": "125 MB",
+            "mysql cpu / memory (peak)": "65% / 1285 MB"
+          }
+        },
+        {
+          "scenario": "mysql · delete · batched",
+          "rows": 50000,
+          "ms": 247,
+          "rowsPerSec": 202429,
+          "detail": {
+            "speed-up": "105.2×",
+            "syncle cpu (peak / avg)": "47% / 12%",
+            "syncle memory (peak)": "118 MB"
+          }
+        },
+        {
+          "scenario": "sqlite · insert · one statement per row",
+          "rows": 50000,
+          "ms": 1192,
+          "rowsPerSec": 41946,
+          "detail": {}
+        },
+        {
+          "scenario": "sqlite · insert · batched",
+          "rows": 50000,
+          "ms": 68,
+          "rowsPerSec": 735294,
+          "detail": {
+            "speed-up": "17.5×"
+          }
+        },
+        {
+          "scenario": "sqlite · upsert · one statement per row",
+          "rows": 50000,
+          "ms": 681,
+          "rowsPerSec": 73421,
+          "detail": {}
+        },
+        {
+          "scenario": "sqlite · upsert · batched",
+          "rows": 50000,
+          "ms": 52,
+          "rowsPerSec": 961538,
+          "detail": {
+            "speed-up": "13.1×"
+          }
+        },
+        {
+          "scenario": "sqlite · delete · one statement per row",
+          "rows": 50000,
+          "ms": 499,
+          "rowsPerSec": 100200,
+          "detail": {}
+        },
+        {
+          "scenario": "sqlite · delete · batched",
+          "rows": 50000,
+          "ms": 22,
+          "rowsPerSec": 2272727,
+          "detail": {
+            "speed-up": "22.7×"
+          }
+        },
+        {
+          "scenario": "postgres · upsert · batched · 1,000,000 rows",
+          "rows": 1000000,
+          "ms": 13025,
+          "rowsPerSec": 76775,
+          "detail": {
+            "syncle cpu (peak / avg)": "135% / 11%",
+            "syncle memory (peak)": "156 MB",
+            "pg cpu / memory (peak)": "96% / 1309 MB"
+          }
+        },
+        {
+          "scenario": "mysql · upsert · batched · 1,000,000 rows",
+          "rows": 1000000,
+          "ms": 5351,
+          "rowsPerSec": 186881,
+          "detail": {
+            "syncle cpu (peak / avg)": "97% / 21%",
+            "syncle memory (peak)": "192 MB",
+            "mysql cpu / memory (peak)": "97% / 1369 MB"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "syncle",
   "version": "1.0.0",
   "private": true,
-  "description": "Syncle — keep any databases in sync, live and across engines (PostgreSQL, MySQL, SQLite, MongoDB, Redis), with HTTP endpoints as an extra destination.",
+  "description": "Syncle \u2014 keep any databases in sync, live and across engines (PostgreSQL, MySQL, SQLite, MongoDB, Redis), with HTTP endpoints as an extra destination.",
   "author": "Osman Ahmadzai",
   "license": "MIT",
   "homepage": "https://github.com/osmanahmadxai/SYNCLE#readme",
@@ -44,7 +44,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,css,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,css,md}\"",
     "clean": "rm -rf packages/core/dist apps/api/dist apps/web/.next packages/core/tsconfig.tsbuildinfo apps/api/tsconfig.tsbuildinfo",
-    "clean:all": "pnpm clean && rm -rf node_modules apps/*/node_modules packages/*/node_modules"
+    "clean:all": "pnpm clean && rm -rf node_modules apps/*/node_modules packages/*/node_modules",
+    "benchmark": "node scripts/benchmark.mjs"
   },
   "devDependencies": {
     "concurrently": "^9.1.0",

--- a/packages/core/src/adapters/nosql/mongodb-adapter.ts
+++ b/packages/core/src/adapters/nosql/mongodb-adapter.ts
@@ -17,13 +17,17 @@ import type {
   DatabaseAdapter,
   DatabaseSchema,
   DeleteRowParams,
+  DeleteRowsParams,
+  EnsureKeyIndexParams,
   FilterSpec,
   InsertRowParams,
+  InsertRowsParams,
   QueryResult,
   RestoreResult,
   TableSchema,
   UpdateRowParams,
   UpsertRowParams,
+  UpsertRowsParams,
 } from '../types';
 import {
   BadRequestError,
@@ -51,6 +55,45 @@ const SAMPLE_SIZE = 50;
 const DEFAULT_LIMIT = 100;
 /** documents fetched per cursor round-trip when streaming a backup */
 const BACKUP_FETCH_BATCH = 1000;
+
+/**
+ * Build the filter and update document for one upsert.
+ *
+ * Key columns live only in the (coerced) filter: `_id` is immutable and mongo
+ * rejects any $set that touches it, even with the same value, and on insert the
+ * equality-filter fields are copied into the new document anyway — so they never
+ * belong in the update payload.
+ *
+ * Shared by upsertRow and upsertRows so the batched path cannot drift from the
+ * single-row one.
+ */
+function buildUpsert(
+  values: Record<string, unknown>,
+  keyColumns: string[],
+): { filter: Record<string, unknown>; update: Record<string, unknown> } {
+  const rawFilter: Record<string, unknown> = {};
+  for (const k of keyColumns) rawFilter[k] = values[k];
+  const filter = coerceId(rawFilter);
+
+  const updates: Record<string, unknown> = {};
+  const onInsert: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(values)) {
+    if (k in rawFilter) continue;
+    if (k === '_id') {
+      // `_id` supplied but not a key column: only settable at insert time
+      onInsert._id = coerceId({ _id: v })._id;
+      continue;
+    }
+    updates[k] = v;
+  }
+  const update: Record<string, unknown> = {};
+  if (Object.keys(updates).length > 0) update.$set = updates;
+  if (Object.keys(onInsert).length > 0) update.$setOnInsert = onInsert;
+  // an empty update document is invalid; a no-op $setOnInsert keeps the
+  // upsert idempotent when every value is a key column
+  if (Object.keys(update).length === 0) update.$setOnInsert = { ...filter };
+  return { filter, update };
+}
 
 export class MongodbAdapter implements DatabaseAdapter {
   readonly engine = 'mongodb' as const;
@@ -271,34 +314,73 @@ export class MongodbAdapter implements DatabaseAdapter {
       throw new QueryError('Cannot upsert without key columns to match on');
     }
     const db = await this.getDb(p.schema);
-    const rawFilter: Record<string, unknown> = {};
-    for (const k of p.keyColumns) rawFilter[k] = p.values[k];
-    const filter = coerceId(rawFilter);
-    // key columns live only in the (coerced) filter: `_id` is immutable and
-    // mongo rejects any $set that touches it (even with the same value), and
-    // on insert the equality-filter fields are copied into the new document
-    // anyway, so they never belong in the update payload
-    const updates: Record<string, unknown> = {};
-    const onInsert: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(p.values)) {
-      if (k in rawFilter) continue;
-      if (k === '_id') {
-        // `_id` supplied but not a key column: only settable at insert time
-        onInsert._id = coerceId({ _id: v })._id;
-        continue;
-      }
-      updates[k] = v;
-    }
-    const update: Record<string, unknown> = {};
-    if (Object.keys(updates).length > 0) update.$set = updates;
-    if (Object.keys(onInsert).length > 0) update.$setOnInsert = onInsert;
-    // an empty update document is invalid; a no-op $setOnInsert keeps the
-    // upsert idempotent when every value is a key column
-    if (Object.keys(update).length === 0) update.$setOnInsert = { ...filter };
+    const { filter, update } = buildUpsert(p.values, p.keyColumns);
     const res = await db
       .collection(p.table)
       .updateOne(filter, update, { upsert: true });
     return writeResult(res.modifiedCount + (res.upsertedCount ?? 0), 'upsertOne');
+  }
+
+  /**
+   * Index the columns a bridge upserts on. Without this every upsert scans the
+   * collection, which is quadratic as it grows and makes a large sync
+   * effectively never finish. createIndex is idempotent, so this is safe to
+   * call on every job start.
+   *
+   * Not declared unique: a bridge may legitimately key on a non-unique column,
+   * and a uniqueness violation at write time is a worse failure than a
+   * duplicate row.
+   */
+  async ensureKeyIndex(p: EnsureKeyIndexParams): Promise<void> {
+    const columns = p.columns.filter((c) => c !== '_id');
+    if (columns.length === 0) return; // `_id` is already unique and indexed
+    const db = await this.getDb(p.schema);
+    const spec: Record<string, 1> = {};
+    for (const c of columns) spec[c] = 1;
+    await db
+      .collection(p.table)
+      .createIndex(spec, { name: `syncle_key_${columns.join('_')}` });
+  }
+
+  /* ----- set-based writes -------------------------------------------------
+   * Without these the sink falls back to one round trip per row, which on a
+   * change stream is what sets the ceiling. bulkWrite sends the whole batch as
+   * one command while applying the same per-document semantics as above.
+   */
+
+  async insertRows(p: InsertRowsParams): Promise<QueryResult> {
+    if (p.rows.length === 0) return writeResult(0, 'insertMany');
+    const db = await this.getDb(p.schema);
+    const res = await db.collection(p.table).insertMany(p.rows, { ordered: true });
+    return writeResult(res.insertedCount, 'insertMany');
+  }
+
+  async upsertRows(p: UpsertRowsParams): Promise<QueryResult> {
+    if (p.rows.length === 0) return writeResult(0, 'bulkWrite');
+    if (p.keyColumns.length === 0) {
+      throw new QueryError('Cannot upsert without key columns to match on');
+    }
+    const db = await this.getDb(p.schema);
+    const ops = p.rows.map((values) => {
+      const { filter, update } = buildUpsert(values, p.keyColumns);
+      return { updateOne: { filter, update, upsert: true } };
+    });
+    // ordered: a change stream's rows must be applied in the order they occurred
+    const res = await db.collection(p.table).bulkWrite(ops, { ordered: true });
+    return writeResult(
+      (res.modifiedCount ?? 0) + (res.upsertedCount ?? 0) + (res.insertedCount ?? 0),
+      'bulkWrite',
+    );
+  }
+
+  async deleteRows(p: DeleteRowsParams): Promise<QueryResult> {
+    if (p.identities.length === 0) return writeResult(0, 'bulkWrite');
+    const db = await this.getDb(p.schema);
+    const ops = p.identities.map((identity) => ({
+      deleteOne: { filter: coerceId(identity) },
+    }));
+    const res = await db.collection(p.table).bulkWrite(ops, { ordered: true });
+    return writeResult(res.deletedCount ?? 0, 'bulkWrite');
   }
 
   /* ----- schema management ----- */
@@ -306,6 +388,22 @@ export class MongodbAdapter implements DatabaseAdapter {
   async createTable(spec: CreateTableSpec): Promise<void> {
     const db = await this.getDb(spec.schema);
     await db.createCollection(spec.table);
+
+    // Index the key columns. A collection has an index on `_id` and nothing
+    // else, so an upsert keyed on any other field is a collection scan — which
+    // degrades quadratically as the collection grows and makes a large sync
+    // effectively never finish. `_id` is already unique and indexed, so it is
+    // skipped. The index is not declared unique: a bridge may legitimately key
+    // on a non-unique column, and a uniqueness violation at write time would be
+    // a worse failure than a duplicate.
+    const keys = spec.columns.filter((c) => c.primaryKey && c.name !== '_id');
+    if (keys.length === 0) return;
+    const index: Record<string, 1> = {};
+    for (const c of keys) index[c.name] = 1;
+    await db
+      .collection(spec.table)
+      .createIndex(index, { name: `syncle_key_${keys.map((c) => c.name).join('_')}` })
+      .catch(() => undefined); // an index we cannot create must not fail the sync
   }
 
   async dropTable(table: string, schema?: string): Promise<void> {

--- a/packages/core/src/adapters/types.ts
+++ b/packages/core/src/adapters/types.ts
@@ -330,6 +330,13 @@ export interface UpsertRowsParams {
   keyColumns: string[];
 }
 
+export interface EnsureKeyIndexParams {
+  schema?: string;
+  table: string;
+  /** the columns a bridge matches on when upserting */
+  columns: string[];
+}
+
 export interface DeleteRowsParams {
   schema?: string;
   table: string;
@@ -428,6 +435,19 @@ export interface DatabaseAdapter {
   deleteRow(params: DeleteRowParams): Promise<QueryResult>;
   /** insert-or-update keyed by `keyColumns`, atomic in the engine's dialect */
   upsertRow(params: UpsertRowParams): Promise<QueryResult>;
+
+  /**
+   * Make sure the key columns a bridge upserts on are indexed. Optional, and
+   * only meaningful where the target's key is NOT already indexed by virtue of
+   * being a primary key: relational engines get that for free, a MongoDB
+   * collection does not — it indexes `_id` and nothing else, so an upsert keyed
+   * on any other field is a collection scan.
+   *
+   * Must be idempotent: callers invoke it whether or not they created the
+   * target, because a collection can come into existence without anyone
+   * calling createTable.
+   */
+  ensureKeyIndex?(params: EnsureKeyIndexParams): Promise<void>;
 
   /* ----- optional set-based writes; see InsertRowsParams for the contract ----- */
   insertRows?(params: InsertRowsParams): Promise<QueryResult>;

--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Runs the whole benchmark suite and refreshes benchmarks/results.json.
+ *
+ *   docker compose -f docker-compose.test.yml up -d
+ *   pnpm benchmark
+ *
+ * Several passes are needed because the settings under test (batch size, the
+ * spool) are read once when the app module is evaluated — so each configuration
+ * gets its own process, and each contributes its rows to the shared report.
+ */
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const api = resolve(dirname(fileURLToPath(import.meta.url)), '../apps/api');
+const vitest = ['exec', 'vitest', 'run', '--config', 'vitest.bench.config.ts'];
+
+/** each pass: a label, the file to run, and the environment it needs */
+const passes = [
+  {
+    label: 'Destination writes (per-row vs batched, and 1,000,000 rows)',
+    file: 'bench/sink-writes.bench.ts',
+    env: {},
+  },
+  {
+    label: 'CDC — one delivery per row (the path before batching)',
+    file: 'bench/cdc.bench.ts',
+    env: { BENCH_MODE: 'per-row', SYNCLE_CDC_BATCH_SIZE: '1' },
+  },
+  {
+    label: 'CDC — batched, across four engine pairs',
+    file: 'bench/cdc.bench.ts',
+    env: { BENCH_MODE: 'batched' },
+  },
+  {
+    label: 'CDC — batched with the durable spool',
+    file: 'bench/cdc.bench.ts',
+    env: { BENCH_MODE: 'spool', SYNCLE_CDC_SPOOL: 'on' },
+  },
+];
+
+let failed = false;
+for (const pass of passes) {
+  console.log(`\n=== ${pass.label} ===`);
+  const res = spawnSync('pnpm', [...vitest, pass.file], {
+    cwd: api,
+    stdio: 'inherit',
+    env: { ...process.env, ...pass.env },
+  });
+  if (res.status !== 0) {
+    failed = true;
+    console.error(`!! pass failed: ${pass.label}`);
+  }
+}
+
+console.log(
+  failed
+    ? '\nBenchmark run finished with failures — results.json holds only what completed.'
+    : '\nBenchmark run complete. benchmarks/results.json refreshed.',
+);
+process.exit(failed ? 1 : 0);

--- a/website/app/benchmarks/page.tsx
+++ b/website/app/benchmarks/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from 'next';
+import { SiteFooter } from '@/components/site-footer';
+import { SiteHeader } from '@/components/site-header';
+import { GITHUB } from '@/lib/content';
+import { MEASURE } from '@/lib/layout';
+import {
+  formatDuration,
+  formatNumber,
+  loadBenchmarks,
+  type BenchResult,
+} from '@/lib/benchmarks';
+
+export const metadata: Metadata = {
+  title: 'Benchmarks — Syncle',
+  description:
+    'Measured throughput for Syncle, run against real PostgreSQL, MySQL and MongoDB with millions of rows. Every figure comes from a recorded run, not an estimate.',
+};
+
+const RESULTS_SOURCE = `${GITHUB}/blob/main/benchmarks/results.json`;
+const RUNNER_SOURCE = `${GITHUB}/blob/main/apps/api/bench`;
+
+/** the extra readings a scenario carries, shown under its row */
+function Detail({ detail }: { detail: BenchResult['detail'] }) {
+  if (!detail || Object.keys(detail).length === 0) return null;
+  return (
+    <ul className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+      {Object.entries(detail).map(([k, v]) => (
+        <li key={k}>
+          <span className="opacity-70">{k}:</span> {String(v)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function BenchmarksPage() {
+  const report = loadBenchmarks();
+
+  return (
+    <>
+      <SiteHeader current="benchmarks" />
+      <main className={`mx-auto px-6 pb-16 ${MEASURE}`}>
+        <h1 className="text-3xl font-semibold tracking-tight">Benchmarks</h1>
+
+        {!report ? (
+          <p className="mt-6 text-muted-foreground">
+            No recorded run is checked in yet. Run <code>pnpm benchmark</code>{' '}
+            against the test stack to produce one.
+          </p>
+        ) : (
+          <>
+            <p className="mt-4 max-w-[70ch] text-muted-foreground">
+              Every number on this page comes from a recorded run of{' '}
+              <a href={RUNNER_SOURCE} rel="noopener" className="link">
+                the benchmark suite
+              </a>{' '}
+              against real databases. The results are committed as{' '}
+              <a href={RESULTS_SOURCE} rel="noopener" className="link">
+                <code>benchmarks/results.json</code>
+              </a>{' '}
+              and this page only renders that file — so anything shown here can
+              be reproduced, and nothing here was typed by hand.
+            </p>
+
+            <div className="mt-8 rounded-lg border border-amber-500/30 bg-amber-500/5 p-5">
+              <h2 className="text-sm font-semibold">
+                Read this before quoting a number
+              </h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {report.disclaimer}
+              </p>
+            </div>
+
+            <section className="mt-10">
+              <h2 className="text-xl font-semibold tracking-tight">
+                The machine
+              </h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Syncle, the databases and Redis all ran here, together.
+              </p>
+              <dl className="mt-4 grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+                {Object.entries(report.environment).map(([k, v]) => (
+                  <div key={k} className="flex gap-2 border-b py-2">
+                    <dt className="w-32 shrink-0 text-muted-foreground">{k}</dt>
+                    <dd className="min-w-0 break-words">{v}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+
+            {report.suites.map((suite) => (
+              <section key={suite.id} className="mt-12">
+                <h2 className="text-xl font-semibold tracking-tight">
+                  {suite.name}
+                </h2>
+                <p className="mt-2 max-w-[70ch] text-sm text-muted-foreground">
+                  {suite.description}
+                </p>
+
+                <div className="mt-5 overflow-x-auto">
+                  <table className="w-full min-w-[40rem] border-collapse text-sm">
+                    <thead>
+                      <tr className="border-b text-left">
+                        <th className="py-2 pr-4 font-medium">Scenario</th>
+                        <th className="py-2 pr-4 text-right font-medium">
+                          Rows
+                        </th>
+                        <th className="py-2 pr-4 text-right font-medium">
+                          Time
+                        </th>
+                        <th className="py-2 text-right font-medium">
+                          Rows / sec
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {suite.results.map((r) => (
+                        <tr key={r.scenario} className="border-b align-top">
+                          <td className="py-3 pr-4">
+                            {r.scenario}
+                            <Detail detail={r.detail} />
+                          </td>
+                          <td className="py-3 pr-4 text-right tabular-nums">
+                            {formatNumber(r.rows)}
+                          </td>
+                          <td className="py-3 pr-4 text-right tabular-nums text-muted-foreground">
+                            {formatDuration(r.ms)}
+                          </td>
+                          <td className="py-3 text-right font-semibold tabular-nums">
+                            {formatNumber(r.rowsPerSec)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            ))}
+
+            <section className="mt-12">
+              <h2 className="text-xl font-semibold tracking-tight">
+                Reproducing this
+              </h2>
+              <pre className="mt-4 overflow-x-auto rounded-lg border p-4 text-sm">
+                <code>{`docker compose -f docker-compose.test.yml up -d
+pnpm benchmark`}</code>
+              </pre>
+              <p className="mt-3 text-sm text-muted-foreground">
+                The run resets replication slots, fixtures and the metadata
+                store first, because leftovers from a previous run distort
+                everything after them. Each figure is verified complete and
+                duplicate-free before its time is recorded — a throughput number
+                is worthless if the data is wrong.
+              </p>
+            </section>
+
+            <p className="mt-10 text-xs text-muted-foreground">
+              Recorded {new Date(report.generatedAt).toISOString().slice(0, 10)}.
+            </p>
+          </>
+        )}
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -11,6 +11,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     { url: SITE_URL, lastModified },
+    { url: `${SITE_URL}/benchmarks`, lastModified },
     ...DOC_PAGES.map((page) => ({
       url: `${SITE_URL}${docHref(page)}`,
       lastModified,

--- a/website/components/site-footer.tsx
+++ b/website/components/site-footer.tsx
@@ -10,6 +10,7 @@ import { MEASURE, WIDE_MEASURE } from '@/lib/layout';
 export function SiteFooter({ wide = false }: { wide?: boolean }) {
   const links: [string, string][] = [
     ['/docs', 'Documentation'],
+    ['/benchmarks', 'Benchmarks'],
     [GITHUB, 'Source'],
     [`${GITHUB}/discussions`, 'Discussions'],
     [`${GITHUB}/releases/latest`, 'Releases'],

--- a/website/components/site-header.tsx
+++ b/website/components/site-header.tsx
@@ -14,7 +14,7 @@ export function SiteHeader({
   current,
   wide = false,
 }: {
-  current?: 'docs';
+  current?: 'docs' | 'benchmarks';
   wide?: boolean;
 }) {
   return (
@@ -33,6 +33,13 @@ export function SiteHeader({
           className={current === 'docs' ? 'font-semibold' : 'link'}
         >
           Docs
+        </a>
+        <a
+          href="/benchmarks"
+          aria-current={current === 'benchmarks' ? 'page' : undefined}
+          className={current === 'benchmarks' ? 'font-semibold' : 'link'}
+        >
+          Benchmarks
         </a>
         <a href="/#install" className="link">
           Install

--- a/website/lib/benchmarks.ts
+++ b/website/lib/benchmarks.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The benchmark report, read from the repository at build time.
+ *
+ * The file is written by `pnpm benchmark`, which measures against real
+ * databases — this module only renders what that run recorded. Nothing here
+ * invents, rounds or interpolates a number, which is the whole point of
+ * keeping the source of truth in the repo rather than in the page.
+ */
+export interface BenchResult {
+  scenario: string;
+  rows: number;
+  ms: number;
+  rowsPerSec: number;
+  detail?: Record<string, string | number>;
+}
+
+export interface BenchSuite {
+  id: string;
+  name: string;
+  description: string;
+  results: BenchResult[];
+}
+
+export interface BenchReport {
+  generatedAt: string;
+  disclaimer: string;
+  environment: Record<string, string>;
+  suites: BenchSuite[];
+}
+
+/** repo root is one level above the website package */
+const RESULTS = resolve(process.cwd(), '..', 'benchmarks', 'results.json');
+
+export function loadBenchmarks(): BenchReport | null {
+  try {
+    return JSON.parse(readFileSync(RESULTS, 'utf8')) as BenchReport;
+  } catch {
+    // a checkout without a recorded run still builds; the page says so
+    return null;
+  }
+}
+
+/** "1000000" -> "1,000,000" */
+export const formatNumber = (n: number): string => n.toLocaleString('en-US');
+
+/** milliseconds as something a person reads: 189ms, 1.4s, 2m 34s */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 2 : 1)} s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}


### PR DESCRIPTION
Every performance claim so far came from an ad-hoc measurement in a test file. This adds a suite anyone can run, records what it observed to `benchmarks/results.json`, and a `/benchmarks` page that renders **only that file** — nothing published is typed by hand.

```bash
docker compose -f docker-compose.test.yml up -d
pnpm benchmark
```

Write paths per engine (one statement per row vs batched, at identical row counts so the rates compare), and CDC end to end across four engine pairs, with and without the spool. The large runs move **1,000,000 rows each**. CPU and memory are sampled throughout — for Syncle *and* the database containers — because a throughput figure without a resource figure is half a number.

## Three bugs the benchmark found

**MongoDB destinations were never indexed on their upsert key.** A collection indexes `_id` and nothing else, and `ensureTarget` skipped creation entirely because `browse()` on a *missing* collection returns empty rather than throwing — so a Mongo destination always took the "already exists" branch. Every upsert was a collection scan, degrading quadratically; a million rows would never finish. The adapter contract gains an optional, idempotent `ensureKeyIndex`, called on **both** paths.

> **1,840 → 12,700 rows/sec**, and linear again.

**MongoDB had no set-based writes**, so the sink fell back to a round trip per row. Added via `bulkWrite`, sharing the upsert-document construction with the single-row path so they cannot drift.

**Benchmarks were being poisoned by their own history.** A killed run leaves jobs marked `running`, which `onModuleInit` resurrects on the next boot; their slots are gone, so they retry `START_REPLICATION` forever. **328 such jobs had accumulated**, and the server spent its time answering doomed replication attempts. Bench setup now resets the metadata store, slots, publications and fixtures first.

## Measurement correctness

`browse()`'s total is an **estimate** — `information_schema.table_rows` on MySQL, `estimatedDocumentCount` on Mongo, a planner estimate on unfiltered Postgres — so waiting for it to equal a row count never succeeded. That, not the product, was behind every "slow" run I chased. Every check now counts exactly, and each run is verified complete and duplicate-free before its time is recorded.

Destinations also write into their **own databases**: a Postgres logical slot is database-scoped, so a destination sharing the source's database makes the source's decoder chew through the destination's own WAL.

## Honesty of the published page

The page leads with a disclaimer: every engine runs on the same machine with no network between them, which flatters the absolute numbers and is exactly why the *comparisons*, not the rates, are the useful part. Device specs (Apple M4, 10 cores, 16 GB) and engine versions are captured automatically by the runner, not written by hand.

The README links to the page rather than reproducing figures, which would go stale the moment the code moves. `Benchmarks` added to the header nav, the footer, and the sitemap.

All 186 unit tests and 58 integration tests pass; website builds.