### PR TITLE
bench: drop the unbatched baseline, record the configuration instead

### DIFF
--- a/apps/api/bench/cdc.bench.ts
+++ b/apps/api/bench/cdc.bench.ts
@@ -4,12 +4,11 @@
  * from the moment the writes begin until the last row has landed.
  *
  * The mode comes from BENCH_MODE, because the settings under test are read once
- * at import: the runner invokes this file several times with different
- * environments and each pass contributes its rows to the same suite.
+ * at import: the runner invokes this file twice with different environments and
+ * each pass contributes its rows to the same suite.
  *
- *   per-row  SYNCLE_CDC_BATCH_SIZE=1   — the path before batching
- *   batched  (defaults)                — batching on, spool off
- *   spool    SYNCLE_CDC_SPOOL=on       — batching on, durable spool on
+ *   batched  (defaults)                — the shipped configuration
+ *   spool    SYNCLE_CDC_SPOOL=on       — the same, with the durable spool on
  */
 import 'reflect-metadata';
 import { afterAll, beforeAll, describe, it } from 'vitest';
@@ -35,9 +34,8 @@ type Engine = 'postgres' | 'mysql';
 /** destinations use their own databases — see TEST_CONNECTIONS for why */
 type Dest = 'postgres_dest' | 'mysql_dest' | 'mongodb';
 
-const MODE = (process.env.BENCH_MODE ?? 'batched') as 'per-row' | 'batched' | 'spool';
-/** the unbatched path is ~50x slower, so it is measured at a smaller volume */
-const ROWS = Number(process.env.BENCH_ROWS ?? (MODE === 'per-row' ? 20_000 : 1_000_000));
+const MODE = (process.env.BENCH_MODE ?? 'batched') as 'batched' | 'spool';
+const ROWS = Number(process.env.BENCH_ROWS ?? 1_000_000);
 const CHUNK = 25_000;
 
 let app: AppHandle;
@@ -188,13 +186,6 @@ async function measure(source: Engine, dest: Dest, label: string): Promise<void>
 }
 
 describe(`cdc throughput — ${MODE}`, () => {
-  if (MODE === 'per-row') {
-    it('postgres to postgres, one delivery per row', async () => {
-      await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL · one delivery per row');
-    });
-    return;
-  }
-
   if (MODE === 'spool') {
     it('postgres to postgres through the durable spool', async () => {
       await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL · batched + durable spool');

--- a/apps/api/bench/harness.ts
+++ b/apps/api/bench/harness.ts
@@ -9,6 +9,7 @@ import { cpus, totalmem, platform, release, arch } from 'node:os';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { withAdapter } from '../test/integration/harness';
+import { runtimeConfig } from '../src/common/runtime-config';
 
 /** repo-root benchmarks/results.json — the file the website renders */
 export const RESULTS_PATH = resolve(
@@ -39,6 +40,8 @@ export interface BenchSuite {
 
 export interface BenchReport {
   generatedAt: string;
+  /** the settings that produced these figures, read from the running config */
+  configuration: Record<string, string>;
   /** stated plainly on the page: what these numbers are and are not */
   disclaimer: string;
   environment: Record<string, string>;
@@ -125,6 +128,23 @@ async function engineVersions(): Promise<Record<string, string>> {
 }
 
 /**
+ * The configuration the run used, read from the live runtime config rather than
+ * written down here — so the page can never claim settings the run did not use.
+ * These are the shipped defaults unless a scenario says otherwise.
+ */
+export function captureConfiguration(): Record<string, string> {
+  return {
+    'Rows per delivery': `${runtimeConfig.cdcBatchSize.toLocaleString('en-US')} (SYNCLE_CDC_BATCH_SIZE)`,
+    'Batch byte ceiling': `${Math.round(runtimeConfig.cdcBatchBytes / 1024 / 1024)} MB (SYNCLE_CDC_BATCH_BYTES)`,
+    'Partial-batch linger': `${runtimeConfig.cdcLingerMs} ms (SYNCLE_CDC_LINGER_MS)`,
+    'Durable spool': runtimeConfig.cdcSpool
+      ? 'on (SYNCLE_CDC_SPOOL=on)'
+      : 'off — the default; one scenario below enables it',
+    'Write mode': 'idempotent upsert, keyed on the primary key',
+  };
+}
+
+/**
  * What else was running. A benchmark shares the machine with whatever else is
  * up, and containers outside the test stack compete for the same CPU and the
  * same Docker VM memory — enough to halve a result. Recording it means a
@@ -169,6 +189,7 @@ export async function captureEnvironment(): Promise<Record<string, string>> {
 export function publishSuite(suite: BenchSuite, environment: Record<string, string>): void {
   let report: BenchReport = {
     generatedAt: new Date().toISOString(),
+    configuration: captureConfiguration(),
     disclaimer: DISCLAIMER,
     environment,
     suites: [],
@@ -179,6 +200,10 @@ export function publishSuite(suite: BenchSuite, environment: Record<string, stri
     /* first run */
   }
   report.generatedAt = new Date().toISOString();
+  // the spool pass runs with the spool on; keep the defaults the page shows
+  if (!runtimeConfig.cdcSpool || !report.configuration) {
+    report.configuration = captureConfiguration();
+  }
   report.disclaimer = DISCLAIMER;
   report.environment = environment;
 

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,5 +1,12 @@
 {
-  "generatedAt": "2026-09-07T10:50:44.094Z",
+  "generatedAt": "2026-09-07T11:01:33.287Z",
+  "configuration": {
+    "Rows per delivery": "100,000 (SYNCLE_CDC_BATCH_SIZE)",
+    "Batch byte ceiling": "64 MB (SYNCLE_CDC_BATCH_BYTES)",
+    "Partial-batch linger": "50 ms (SYNCLE_CDC_LINGER_MS)",
+    "Durable spool": "off — the default; one scenario below enables it",
+    "Write mode": "idempotent upsert, keyed on the primary key"
+  },
   "disclaimer": "Measured on a single local machine: Syncle, both databases and Redis all run on the same host, in containers, with no network between them. Real deployments put a network in that path, and against a managed or remote database latency — not the database — is usually what sets the pace, so expect lower absolute numbers there. These runs are useful for comparing code paths against each other, not for predicting your production ceiling. Every figure is measured; none is estimated, extrapolated or rounded up.",
   "environment": {
     "Platform": "darwin 25.5.0 (arm64)",
@@ -20,78 +27,66 @@
       "description": "A row is committed on the source, picked up from that database’s own change log (Postgres logical replication, MySQL binlog) and written to the destination. Timing starts when the writes begin and stops when the last row has landed, so it includes reading the log, delivery and the destination write. Every run is verified complete and duplicate-free before its time is recorded.",
       "results": [
         {
-          "scenario": "PostgreSQL → PostgreSQL · one delivery per row",
-          "rows": 20000,
-          "ms": 62557,
-          "rowsPerSec": 320,
-          "detail": {
-            "verified": "20000 rows, exactly once",
-            "syncle cpu (peak / avg)": "140% / 34%",
-            "syncle memory (peak)": "157 MB",
-            "pg cpu / memory (peak)": "21% / 1251 MB"
-          }
-        },
-        {
           "scenario": "PostgreSQL → PostgreSQL · batched",
           "rows": 1000000,
-          "ms": 17936,
-          "rowsPerSec": 55754,
+          "ms": 15938,
+          "rowsPerSec": 62743,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "226% / 24%",
-            "syncle memory (peak)": "237 MB",
-            "pg cpu / memory (peak)": "154% / 1378 MB"
+            "syncle cpu (peak / avg)": "221% / 26%",
+            "syncle memory (peak)": "249 MB",
+            "pg cpu / memory (peak)": "176% / 1335 MB"
           }
         },
         {
           "scenario": "PostgreSQL → MySQL · batched",
           "rows": 1000000,
-          "ms": 11028,
-          "rowsPerSec": 90678,
+          "ms": 11130,
+          "rowsPerSec": 89847,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "225% / 45%",
-            "syncle memory (peak)": "248 MB",
-            "pg cpu / memory (peak)": "124% / 1457 MB",
-            "mysql cpu / memory (peak)": "82% / 1918 MB"
+            "syncle cpu (peak / avg)": "205% / 46%",
+            "syncle memory (peak)": "287 MB",
+            "pg cpu / memory (peak)": "88% / 1420 MB",
+            "mysql cpu / memory (peak)": "53% / 1760 MB"
           }
         },
         {
           "scenario": "MySQL → PostgreSQL · batched",
           "rows": 1000000,
-          "ms": 11943,
-          "rowsPerSec": 83731,
+          "ms": 11391,
+          "rowsPerSec": 87789,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "322% / 31%",
-            "syncle memory (peak)": "350 MB",
-            "pg cpu / memory (peak)": "112% / 1511 MB",
-            "mysql cpu / memory (peak)": "90% / 2052 MB"
+            "syncle cpu (peak / avg)": "224% / 29%",
+            "syncle memory (peak)": "369 MB",
+            "pg cpu / memory (peak)": "127% / 1609 MB",
+            "mysql cpu / memory (peak)": "82% / 1838 MB"
           }
         },
         {
           "scenario": "PostgreSQL → MongoDB · batched",
           "rows": 1000000,
-          "ms": 36905,
-          "rowsPerSec": 27097,
+          "ms": 46893,
+          "rowsPerSec": 21325,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "253% / 12%",
-            "syncle memory (peak)": "281 MB",
-            "pg cpu / memory (peak)": "35% / 1579 MB"
+            "syncle cpu (peak / avg)": "258% / 10%",
+            "syncle memory (peak)": "288 MB",
+            "pg cpu / memory (peak)": "105% / 1820 MB"
           }
         },
         {
           "scenario": "PostgreSQL → PostgreSQL · batched + durable spool",
           "rows": 1000000,
-          "ms": 19549,
-          "rowsPerSec": 51154,
+          "ms": 21108,
+          "rowsPerSec": 47375,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "259% / 55%",
-            "syncle memory (peak)": "454 MB",
-            "pg cpu / memory (peak)": "147% / 1357 MB",
-            "peak spool depth": 69629
+            "syncle cpu (peak / avg)": "266% / 51%",
+            "syncle memory (peak)": "527 MB",
+            "pg cpu / memory (peak)": "138% / 1616 MB",
+            "peak spool depth": 83789
           }
         }
       ]
@@ -104,23 +99,23 @@
         {
           "scenario": "PostgreSQL · upsert",
           "rows": 1000000,
-          "ms": 9311,
-          "rowsPerSec": 107400,
+          "ms": 8503,
+          "rowsPerSec": 117606,
           "detail": {
-            "syncle cpu (peak / avg)": "131% / 6%",
-            "syncle memory (peak)": "129 MB",
-            "pg cpu / memory (peak)": "94% / 1292 MB"
+            "syncle cpu (peak / avg)": "86% / 8%",
+            "syncle memory (peak)": "130 MB",
+            "pg cpu / memory (peak)": "98% / 1227 MB"
           }
         },
         {
           "scenario": "MySQL · upsert",
           "rows": 1000000,
-          "ms": 4143,
-          "rowsPerSec": 241371,
+          "ms": 3622,
+          "rowsPerSec": 276091,
           "detail": {
-            "syncle cpu (peak / avg)": "116% / 21%",
-            "syncle memory (peak)": "175 MB",
-            "mysql cpu / memory (peak)": "126% / 1904 MB"
+            "syncle cpu (peak / avg)": "82% / 22%",
+            "syncle memory (peak)": "176 MB",
+            "mysql cpu / memory (peak)": "110% / 1811 MB"
           }
         }
       ]

--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -24,11 +24,6 @@ const passes = [
     env: {},
   },
   {
-    label: 'CDC — one delivery per row (the path before batching)',
-    file: 'bench/cdc.bench.ts',
-    env: { BENCH_MODE: 'per-row', SYNCLE_CDC_BATCH_SIZE: '1' },
-  },
-  {
     label: 'CDC — batched, across four engine pairs',
     file: 'bench/cdc.bench.ts',
     env: { BENCH_MODE: 'batched' },

--- a/website/app/benchmarks/page.tsx
+++ b/website/app/benchmarks/page.tsx
@@ -73,6 +73,25 @@ export default function BenchmarksPage() {
 
             <section className="mt-10">
               <h2 className="text-xl font-semibold tracking-tight">
+                The configuration
+              </h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                The shipped defaults — these are not tuned for the benchmark.
+                Read from the running configuration, so this cannot claim
+                settings the run did not use.
+              </p>
+              <dl className="mt-4 grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+                {Object.entries(report.configuration ?? {}).map(([k, v]) => (
+                  <div key={k} className="flex gap-2 border-b py-2">
+                    <dt className="w-40 shrink-0 text-muted-foreground">{k}</dt>
+                    <dd className="min-w-0 break-words">{v}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+
+            <section className="mt-10">
+              <h2 className="text-xl font-semibold tracking-tight">
                 The machine
               </h2>
               <p className="mt-2 text-sm text-muted-foreground">

--- a/website/lib/benchmarks.ts
+++ b/website/lib/benchmarks.ts
@@ -26,6 +26,8 @@ export interface BenchSuite {
 
 export interface BenchReport {
   generatedAt: string;
+  /** the settings that produced these figures */
+  configuration?: Record<string, string>;
   disclaimer: string;
   environment: Record<string, string>;
   suites: BenchSuite[];


### PR DESCRIPTION
The suite carried a `PostgreSQL → PostgreSQL · one delivery per row` scenario, measured with `SYNCLE_CDC_BATCH_SIZE=1`, to show what the pipeline used to cost. It sat in the same table as the real figures and read as a Postgres-to-Postgres *result* rather than a historical contrast — so **320 rows/sec looked like a current number**. That misreading happened in practice, which is reason enough. It's gone.

## What replaces it is more useful

The report now records **the configuration that produced the figures**:

| | |
|---|---|
| Rows per delivery | 100,000 (`SYNCLE_CDC_BATCH_SIZE`) |
| Batch byte ceiling | 64 MB (`SYNCLE_CDC_BATCH_BYTES`) |
| Partial-batch linger | 50 ms (`SYNCLE_CDC_LINGER_MS`) |
| Durable spool | off — the default; one scenario enables it |
| Write mode | idempotent upsert, keyed on the primary key |

Read from the **live runtime config**, not written down — so the page cannot claim settings a run did not actually use. These are the shipped defaults; nothing is tuned for the benchmark.

## The comparison is still there, and better made

Each destination's **own write ceiling** sits beside the sync figures. That says how much of the achievable throughput the pipeline captures — a more honest and more useful comparison than how much better it is than a version nobody runs.

## Current figures (1,000,000 rows each, machine to itself)

| | rows/sec |
|---|---|
| PostgreSQL → PostgreSQL | 62,743 |
| PostgreSQL → MySQL | 89,847 |
| MySQL → PostgreSQL | 87,789 |
| PostgreSQL → MongoDB | 21,325 |
| PostgreSQL → PostgreSQL + spool | 47,375 |
| *Postgres write ceiling* | *117,606* |
| *MySQL write ceiling* | *276,091* |

`results.json` is a clean run — the app and demo stacks were stopped for it and restored afterwards.

186 unit tests, 60 integration tests, lint and website build all pass.