### PR TITLE
docs: changelog for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,80 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
+## [1.3.0] - 2026-09-08
 
-- MySQL CDC refuses to resume when the connection reaches a different server
-  than the one that issued its stored binlog position. File and position are
-  only meaningful on the issuing server, so after a failover the old cursor
-  pointed somewhere unrelated and the stream read it anyway. Cursors now carry
-  the server's `@@server_uuid`, and the transaction's GTID alongside it.
-- A MySQL bridge no longer starts reporting itself as running before the binlog
-  reader is positioned. On a fresh bridge that races the first writes, and rows
-  written immediately after starting were lost.
+Syncing got about four times faster, and there are now real numbers for it.
+
+### Added
+
+- **Benchmarks**, measured against real databases with a million rows per
+  scenario and published at [syncle.dev/benchmarks](https://syncle.dev/benchmarks).
+  The runner lives in the repository and writes `benchmarks/results.json`; the
+  page renders that file and nothing else, so every figure shown can be
+  reproduced with `pnpm benchmark`. The recorded run states the machine, the
+  engine versions, the configuration used, and what else was running.
+- An **optional durable spool** between the change reader and the destination
+  (`SYNCLE_CDC_SPOOL=on`), backed by a Redis stream. With it on, the source is
+  acknowledged as soon as changes are spooled, so a slow or unreachable
+  destination no longer holds the source's log open — the failure mode where a
+  Postgres replication slot stops advancing and WAL fills the source's disk.
+  Off by default: while a change sits in the spool, Redis is the only copy of
+  it, so it is safe only where Redis has persistence.
+- **Italian localization** for the web app. Thanks to @albanobattistella.
+- A new language now needs only its message file. Locales are derived from
+  `src/messages/`, so adding `<code>.json` is the whole job — no allowlist to
+  update, and the toggle labels itself.
+- A **Docs** link in the header.
+- An integration suite that runs against real PostgreSQL, MySQL, MongoDB and
+  Redis, including end-to-end syncing through the real application.
 
 ### Changed
 
+- **Change data capture is roughly four times faster.** A million rows
+  PostgreSQL to PostgreSQL takes about 16 seconds where it took 52. Changes are
+  grouped into batches rather than delivered a row at a time, so one delivery,
+  one delivery record, one cursor write and one source acknowledgement now
+  cover a whole batch. PostgreSQL bulk writes go as a single json parameter
+  rather than one parameter per value, which removes the 65,535 bound-parameter
+  ceiling; and reading now overlaps with writing instead of waiting for it.
+- Database destinations receive rows in one statement per batch instead of one
+  statement per row. Deliveries in the timeline are therefore fewer and larger:
+  the same rows, recorded at coarser granularity.
+- Batch size and behaviour are tunable — `SYNCLE_CDC_BATCH_SIZE` (100,000),
+  `SYNCLE_CDC_BATCH_BYTES` (64 MB), `SYNCLE_CDC_LINGER_MS` (50). The row
+  default is the measured peak across five runs of a million rows on both
+  PostgreSQL and MySQL; the byte ceiling is what actually bounds memory, so
+  wide rows flush early on their own.
+- HTTP destinations are unchanged: they keep honouring the bridge's own
+  `batchSize`, where the batch size is the payload the receiver sees.
 - Documentation no longer claims MariaDB support. Connections, replay and watch
   bridges work through `mysql2`, but CDC reads the binlog with a client that
   targets MySQL and has not been verified against MariaDB. The 1.0.0 notes
-  below listed it; that was the claim being corrected here, not a regression.
+  below listed it; that was the claim being corrected, not a regression.
 - `binlog_transaction_compression` is documented as unsupported. MySQL 8.0.20+
   can wrap row events in a compressed payload event that the binlog reader
-  cannot decode, so those rows are not seen.
+  cannot decode, so those rows are not seen. Leave it off on a source you
+  stream from.
+
+### Fixed
+
+- **MongoDB destinations were never indexed on the column they upsert on.** A
+  collection indexes `_id` and nothing else, so every upsert was a collection
+  scan — which degrades as the collection grows and made a large sync
+  effectively unable to finish. The index is now created, and MongoDB
+  destinations are several times faster as a result. An index appears on
+  existing targets the first time a bridge writes to them.
+- **MySQL CDC refuses to resume against a different server** than the one that
+  issued its stored binlog position. File and position mean something only on
+  the issuing server, so after a failover the old cursor pointed somewhere
+  unrelated and the stream read it anyway. Cursors now carry the server's
+  `@@server_uuid`, and the transaction's GTID alongside it.
+- **A MySQL bridge no longer reports itself running before the binlog reader is
+  positioned.** On a fresh bridge that raced the first writes, and rows written
+  immediately after starting were lost.
+- Batched deletes on SQLite no longer fail on large batches. Staying under the
+  bound-parameter limit is not sufficient there — SQLite also caps expression
+  tree depth, which a long chain of `OR` clauses exceeds.
 
 ## [1.2.0] - 2026-08-21
 


### PR DESCRIPTION
63 commits since 1.2.0, described. Ready to tag once this merges.

**Headline:** change data capture is about four times faster — a million rows PostgreSQL to PostgreSQL takes roughly 16 seconds where it took 52 — and there are now published benchmarks behind that claim rather than an assertion.

## Also recorded: three correctness fixes that came out of measuring

- **MongoDB destinations were never indexed** on the column they upsert on, so every upsert was a collection scan
- **MySQL CDC would resume against a different server** after a failover and read unrelated binlog positions
- **A fresh MySQL bridge reported itself running before its reader was positioned**, losing rows written immediately after start

## Called out for upgraders — visible, not breaking

- The deliveries timeline now shows **fewer, larger deliveries** for database destinations. Same rows, coarser granularity.
- An **index appears on existing MongoDB targets** the first time a bridge writes to them.
- **HTTP destinations are explicitly unchanged** — they still honour the bridge's own `batchSize`.

I checked for breaking changes and found none: MySQL cursors stay backward compatible with the old `file:pos:row` format, and every new environment variable is defaulted.

## Ordering note

`website/lib/release.ts` reads the newest version out of this file at build time, so **merging this is what makes the site say 1.3.0**. If the site redeploys before the `v1.3.0` tag is pushed, it will briefly advertise a version whose image has not published yet — the release build is multi-arch and takes a while. Worth tagging promptly after merge.

Website builds and reports `1.3.0 from 2026-09-08`. Main is green: 186 unit tests, typecheck clean.