### PR TITLE
bench: every engine pair, and pipelined writes for Redis

### DIFF
--- a/apps/api/bench/cdc.bench.ts
+++ b/apps/api/bench/cdc.bench.ts
@@ -16,6 +16,8 @@ import {
   bootstrapApp,
   connectionFor,
   makeBridge,
+  rowsFor,
+  writeSourceRows,
   type AppHandle,
 } from '../test/integration/app-harness';
 import { TEST_CONNECTIONS, waitFor, withAdapter } from '../test/integration/harness';
@@ -30,9 +32,20 @@ import {
   type BenchResult,
 } from './harness';
 
-type Engine = 'postgres' | 'mysql';
+type Engine = 'postgres' | 'mysql' | 'mongodb' | 'redis';
 /** destinations use their own databases — see TEST_CONNECTIONS for why */
-type Dest = 'postgres_dest' | 'mysql_dest' | 'mongodb';
+type Dest = 'postgres_dest' | 'mysql_dest' | 'mongodb' | 'sqlite' | 'redis_dest';
+
+const LABEL: Record<string, string> = {
+  postgres: 'PostgreSQL',
+  postgres_dest: 'PostgreSQL',
+  mysql: 'MySQL',
+  mysql_dest: 'MySQL',
+  mongodb: 'MongoDB',
+  sqlite: 'SQLite',
+  redis: 'Redis',
+  redis_dest: 'Redis',
+};
 
 const MODE = (process.env.BENCH_MODE ?? 'batched') as 'batched' | 'spool';
 const ROWS = Number(process.env.BENCH_ROWS ?? 1_000_000);
@@ -69,7 +82,18 @@ afterAll(async () => {
   await mongo?.close().catch(() => undefined);
   await app?.ctx.close().catch(() => undefined);
   publishSuite(
-    {
+    MODE === 'spool'
+      ? {
+          id: 'cdc-spool',
+          name: 'With the durable spool',
+          description:
+            'The same sync, with SYNCLE_CDC_SPOOL=on. Changes go to a Redis ' +
+            'stream first and the source is acknowledged as soon as they are ' +
+            'durably spooled, so a slow destination cannot hold the source’s ' +
+            'log open. It costs throughput; that is the trade it exists to make.',
+          results,
+        }
+      : {
       id: 'cdc-throughput',
       name: 'Change data capture, end to end',
       description:
@@ -86,7 +110,12 @@ afterAll(async () => {
 });
 
 /** run one source → destination pass and record it */
-async function measure(source: Engine, dest: Dest, label: string): Promise<void> {
+async function measure(
+  source: Engine,
+  dest: Dest,
+  label: string,
+  rowCount: number = ROWS,
+): Promise<void> {
   console.log(`  → ${label}: preparing bridge…`);
   const srcConn = await connectionFor(app, source);
   const dstConn = await connectionFor(app, dest);
@@ -130,6 +159,12 @@ async function measure(source: Engine, dest: Dest, label: string): Promise<void>
   const landedCount = async (): Promise<number> => {
     try {
       if (dest === 'mongodb') return await mongoCount(s.destTable);
+      if (dest === 'redis_dest') {
+        // { command, reply } — the count is the reply, not the first value
+        const res = await probe.query('DBSIZE');
+        const row = res.rows[0] as { reply?: unknown } | undefined;
+        return Number(row?.reply ?? 0);
+      }
       const q = dest.startsWith('mysql') ? '`' : '"';
       const res = await probe.query(`SELECT COUNT(*) AS c FROM ${q}${s.destTable}${q}`);
       return Number(Object.values(res.rows[0] ?? {})[0] ?? 0);
@@ -138,23 +173,21 @@ async function measure(source: Engine, dest: Dest, label: string): Promise<void>
     }
   };
 
-  console.log(`  → ${label}: writing ${ROWS} rows…`);
+  // Redis rows land as bare keys, so the key count is the row count — flush
+  // first or a previous scenario's keys would be counted as this one's
+  if (dest === 'redis_dest') {
+    await withAdapter('redis_dest', (a) => a.query('FLUSHDB'));
+  }
+
+  console.log(`  → ${label}: writing ${rowCount} rows…`);
   const started = performance.now();
-  for (let start = 0; start < ROWS; start += CHUNK) {
-    const size = Math.min(CHUNK, ROWS - start);
-    await withAdapter(source, (a) =>
-      a.insertRows!({
-        table: s.sourceTable,
-        rows: Array.from({ length: size }, (_, i) => ({
-          id: start + i + 1,
-          name: `row-${start + i}`,
-        })),
-      }),
-    );
+  for (let start = 0; start < rowCount; start += CHUNK) {
+    const size = Math.min(CHUNK, rowCount - start);
+    await writeSourceRows(source, s.sourceTable, rowsFor(source, size, start));
   }
   await waitFor(
-    `${ROWS} rows to reach ${dest}`,
-    async () => ((await landedCount()) === ROWS ? true : null),
+    `${rowCount} rows to reach ${dest}`,
+    async () => ((await landedCount()) === rowCount ? true : null),
     // Mongo's estimate updates lazily, and every poll is a round trip; a
     // slower cadence measures the pipeline rather than the polling
     { timeoutMs: 3_000_000, intervalMs: dest === 'mongodb' ? 1_000 : 100 },
@@ -167,15 +200,15 @@ async function measure(source: Engine, dest: Dest, label: string): Promise<void>
   const landed =
     dest === 'mongodb' ? await mongoCount(s.destTable, true) : await landedCount();
   await probe.close().catch(() => undefined);
-  if (landed !== ROWS) throw new Error(`expected ${ROWS} rows, found ${landed}`);
+  if (landed !== rowCount) throw new Error(`expected ${rowCount} rows, found ${landed}`);
 
   const detail: Record<string, string | number> = {
     verified: `${landed} rows, exactly once`,
     ...resourceDetail(usage, [source, dest]),
   };
   if (spool) detail['peak spool depth'] = peakSpool;
-  results.push(makeResult(label, ROWS, ms, detail));
-  console.log(`  ✓ ${label}: ${ROWS} rows in ${ms}ms (${Math.round(ROWS / (ms / 1000))}/s)`);
+  results.push(makeResult(label, rowCount, ms, detail));
+  console.log(`  ✓ ${label}: ${rowCount} rows in ${ms}ms (${Math.round(rowCount / (ms / 1000))}/s)`);
 
   // Stop this bridge before the next scenario starts. A stream left running
   // keeps decoding its source's log, so without this each scenario competes
@@ -183,29 +216,61 @@ async function measure(source: Engine, dest: Dest, label: string): Promise<void>
   // rather than throughput.
   await app.cdc.stop(s.bridgeId).catch(() => undefined);
   await app.cdc.cleanup(s.bridgeId).catch(() => undefined);
+
+  // And drop the data. Twenty scenarios of a million rows each, all left in
+  // place until the end of the run, is tens of millions of rows sitting in
+  // engines that share one host — it exhausted MongoDB's memory and had it
+  // OOM-killed mid-run. Dropping here also keeps each measurement independent
+  // of how much the scenarios before it left behind.
+  await withAdapter(source, (a) => a.dropTable(s.sourceTable)).catch(() => undefined);
+  if (dest === 'redis_dest') {
+    await withAdapter(dest, (a) => a.query('FLUSHDB')).catch(() => undefined);
+  } else {
+    await withAdapter(dest, (a) => a.dropTable(s.destTable)).catch(() => undefined);
+  }
 }
 
 describe(`cdc throughput — ${MODE}`, () => {
   if (MODE === 'spool') {
     it('postgres to postgres through the durable spool', async () => {
-      await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL · batched + durable spool');
+      await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL');
     });
     return;
   }
 
-  it('postgres to postgres', async () => {
-    await measure('postgres', 'postgres_dest', 'PostgreSQL → PostgreSQL · batched');
-  });
+  /**
+   * Every source engine against every destination engine.
+   *
+   * SQLite is a destination only: it has no change-capture path for external
+   * writers, so it cannot drive a bridge.
+   *
+   * Redis as a SOURCE rides keyspace notifications, which are fire-and-forget
+   * pub/sub with no backlog — under a firehose the server drops what the
+   * subscriber has not taken yet. It is therefore measured at a lower volume,
+   * and the figure says what that path can carry rather than pretending it is
+   * comparable to a durable log.
+   */
+  const SOURCES: Engine[] = ['postgres', 'mysql', 'mongodb', 'redis'];
+  const DESTS: Dest[] = [
+    'postgres_dest',
+    'mysql_dest',
+    'mongodb',
+    'sqlite',
+    'redis_dest',
+  ];
 
-  it('postgres to mysql', async () => {
-    await measure('postgres', 'mysql_dest', 'PostgreSQL → MySQL · batched');
-  });
+  for (const source of SOURCES) {
+    for (const dest of DESTS) {
+      it(`${source} to ${dest}`, async () => {
+        const rows = source === 'redis' ? Math.min(ROWS, 100_000) : ROWS;
+        await measure(
+          source,
+          dest,
+          `${LABEL[source]} → ${LABEL[dest]}`,
+          rows,
+        );
+      });
+    }
+  }
 
-  it('mysql to postgres', async () => {
-    await measure('mysql', 'postgres_dest', 'MySQL → PostgreSQL · batched');
-  });
-
-  it('postgres to mongodb', async () => {
-    await measure('postgres', 'mongodb', 'PostgreSQL → MongoDB · batched');
-  });
 });

--- a/apps/api/bench/cdc.bench.ts
+++ b/apps/api/bench/cdc.bench.ts
@@ -50,6 +50,13 @@ const LABEL: Record<string, string> = {
 const MODE = (process.env.BENCH_MODE ?? 'batched') as 'batched' | 'spool';
 const ROWS = Number(process.env.BENCH_ROWS ?? 1_000_000);
 const CHUNK = 25_000;
+/**
+ * Redis as a source is capped separately. Keyspace notifications are
+ * fire-and-forget with no backlog, so beyond some rate the server discards what
+ * the subscriber has not taken yet — and a benchmark that silently loses events
+ * is measuring nothing. Raise it to find where that point is on your hardware.
+ */
+const REDIS_SOURCE_ROWS = Number(process.env.BENCH_REDIS_ROWS ?? 1_000_000);
 
 let app: AppHandle;
 let mongo: MongoClient | null = null;
@@ -262,7 +269,8 @@ describe(`cdc throughput — ${MODE}`, () => {
   for (const source of SOURCES) {
     for (const dest of DESTS) {
       it(`${source} to ${dest}`, async () => {
-        const rows = source === 'redis' ? Math.min(ROWS, 100_000) : ROWS;
+        const rows =
+          source === 'redis' ? Math.min(ROWS, REDIS_SOURCE_ROWS) : ROWS;
         await measure(
           source,
           dest,

--- a/apps/api/bench/sink-writes.bench.ts
+++ b/apps/api/bench/sink-writes.bench.ts
@@ -24,7 +24,8 @@ const ROWS = 1_000_000;
 const CHUNK = 50_000;
 
 const results: BenchResult[] = [];
-const created: Array<{ engine: 'postgres' | 'mysql'; table: string }> = [];
+type Engine = 'postgres' | 'mysql' | 'sqlite' | 'redis';
+const created: Array<{ engine: Engine; table: string }> = [];
 
 afterAll(async () => {
   for (const t of created) {
@@ -44,23 +45,31 @@ afterAll(async () => {
   );
 });
 
-describe.each(['postgres', 'mysql'] as const)('write ceiling — %s', (engine) => {
+describe.each(['postgres', 'mysql', 'sqlite', 'redis'] as const)(
+  'write ceiling — %s',
+  (engine) => {
   it(`absorbs ${ROWS.toLocaleString()} rows`, async () => {
     const table = uniqueTable('ceil');
     const types =
       engine === 'mysql'
         ? { int: 'int', text: 'varchar(255)' }
-        : { int: 'integer', text: 'text' };
+        : engine === 'sqlite'
+          ? { int: 'INTEGER', text: 'TEXT' }
+          : { int: 'integer', text: 'text' };
 
     await withAdapter(engine, async (a) => {
-      await a.createTable({
-        table,
-        columns: [
-          { name: 'id', type: types.int, nullable: false, primaryKey: true },
-          { name: 'name', type: types.text, nullable: true },
-        ],
-      });
-      created.push({ engine, table });
+      // Redis stores keys, not tables — nothing to create, and the rows below
+      // are shaped as key/value rather than id/name
+      if (engine !== 'redis') {
+        await a.createTable({
+          table,
+          columns: [
+            { name: 'id', type: types.int, nullable: false, primaryKey: true },
+            { name: 'name', type: types.text, nullable: true },
+          ],
+        });
+        created.push({ engine, table });
+      }
 
       const sampler = new ResourceSampler();
       sampler.start();
@@ -69,24 +78,29 @@ describe.each(['postgres', 'mysql'] as const)('write ceiling — %s', (engine) =
           const size = Math.min(CHUNK, ROWS - start);
           await a.upsertRows!({
             table,
-            keyColumns: ['id'],
-            rows: Array.from({ length: size }, (_, i) => ({
-              id: start + i + 1,
-              name: `row-${start + i}`,
-            })),
+            keyColumns: engine === 'redis' ? ['key'] : ['id'],
+            rows: Array.from({ length: size }, (_, i) =>
+              engine === 'redis'
+                ? { key: `bench:${start + i + 1}`, value: `row-${start + i}` }
+                : { id: start + i + 1, name: `row-${start + i}` },
+            ),
           });
         }
       });
       const usage = sampler.stop();
+      const label = {
+        postgres: 'PostgreSQL',
+        mysql: 'MySQL',
+        sqlite: 'SQLite',
+        redis: 'Redis',
+      }[engine];
       results.push(
-        makeResult(
-          `${engine === 'mysql' ? 'MySQL' : 'PostgreSQL'} · upsert`,
-          ROWS,
-          ms,
-          resourceDetail(usage, [engine]),
-        ),
+        makeResult(`${label} · upsert`, ROWS, ms, resourceDetail(usage, [engine])),
       );
-      console.log(`  ✓ ${engine} ceiling: ${ROWS} rows in ${ms}ms (${Math.round(ROWS / (ms / 1000))}/s)`);
+      console.log(
+        `  ✓ ${engine} ceiling: ${ROWS} rows in ${ms}ms (${Math.round(ROWS / (ms / 1000))}/s)`,
+      );
+      });
     });
-  });
-});
+  },
+);

--- a/apps/api/src/bridges/cdc/providers/redis-cdc.provider.test.ts
+++ b/apps/api/src/bridges/cdc/providers/redis-cdc.provider.test.ts
@@ -14,18 +14,67 @@ class FakeSub extends EventEmitter {
   disconnect(): void {}
 }
 
-/** value reader whose TYPE/GET round-trips take real (fake) time */
+/**
+ * Value reader whose round-trips take real (fake) time.
+ *
+ * The provider reads values through a PIPELINE — one round trip covering a
+ * whole batch of keys — so the double models that rather than single commands.
+ * `exec` keeps the delay that opens the window a DEL used to slip through, so
+ * the ordering tests still exercise the race they were written for.
+ */
 class FakeReader {
   constructor(private readonly values: Map<string, string>) {}
   async connect(): Promise<void> {}
   disconnect(): void {}
+
   async type(key: string): Promise<string> {
-    await delay(15); // the window the DEL used to slip through
+    await delay(15);
     return this.values.has(key) ? 'string' : 'none';
   }
   async get(key: string): Promise<string | null> {
     await delay(5);
     return this.values.get(key) ?? null;
+  }
+
+  pipeline(): FakePipeline {
+    return new FakePipeline(this.values);
+  }
+}
+
+/** the subset of ioredis's pipeline the provider uses */
+class FakePipeline {
+  private readonly queued: Array<() => unknown> = [];
+  constructor(private readonly values: Map<string, string>) {}
+
+  type(key: string): this {
+    this.queued.push(() => (this.values.has(key) ? 'string' : 'none'));
+    return this;
+  }
+  get(key: string): this {
+    this.queued.push(() => this.values.get(key) ?? null);
+    return this;
+  }
+  hgetall(key: string): this {
+    this.queued.push(() => ({ value: this.values.get(key) ?? null }));
+    return this;
+  }
+  lrange(key: string): this {
+    this.queued.push(() => [this.values.get(key) ?? null]);
+    return this;
+  }
+  smembers(key: string): this {
+    this.queued.push(() => [this.values.get(key) ?? null]);
+    return this;
+  }
+  zrange(key: string): this {
+    this.queued.push(() => [this.values.get(key) ?? null]);
+    return this;
+  }
+
+  /** ioredis shape: one [error, result] pair per queued command, in order */
+  async exec(): Promise<Array<[Error | null, unknown]>> {
+    await delay(15);
+    return this.queued.map((run) => [null, run()] as [Error | null, unknown]);
   }
 }
 

--- a/apps/api/src/bridges/cdc/providers/redis-cdc.provider.ts
+++ b/apps/api/src/bridges/cdc/providers/redis-cdc.provider.ts
@@ -35,6 +35,22 @@ import type {
  * note `expire` (setting a TTL, key still live) is NOT here — only `expired`
  * (the TTL actually fired and removed the key) is a delete.
  */
+/** one keyspace notification waiting for its value to be read */
+interface PendingEvent {
+  key: string;
+  event: string;
+  isDelete: boolean;
+  op: CdcOperation;
+  cursor: string;
+}
+
+/**
+ * Keys whose values are fetched in one pipeline. Large enough that the round
+ * trip stops dominating, small enough that a burst does not build a reply the
+ * size of the keyspace before anything is delivered.
+ */
+const READ_BATCH = 512;
+
 const DELETE_EVENTS = new Set(['del', 'unlink', 'expired', 'evicted']);
 
 @Injectable()
@@ -167,17 +183,50 @@ export class RedisCdcProvider implements CdcProvider {
 
     const sub = this.newClient(conn); // subscriber connection (no normal commands)
     const reader = this.newClient(conn); // best-effort value reader
+    let stopped = false;
     await sub.connect();
     await reader.connect();
 
     let seq = 0;
     sub.on('error', (err: Error) => handlers.onError(err));
 
-    // admission chain: events must enter the pipeline in pmessage arrival
-    // order. buildRow awaits TYPE+GET for writes but resolves instantly for
-    // deletes, so firing them unchained lets a DEL overtake the SET before it
-    // and the destination applies delete-then-upsert, resurrecting the key
-    let chain: Promise<void> = Promise.resolve();
+    // Events must enter the pipeline in pmessage arrival order — a DEL that
+    // overtook the SET before it would have the destination apply
+    // delete-then-upsert and resurrect the key. So arrivals queue, and the
+    // drain loop reads and delivers them strictly in order.
+    //
+    // What the queue buys is batching the READS. A notification carries only
+    // the key, so each change needs a round trip to fetch its value, and doing
+    // that one event at a time — while also waiting for each delivery — is what
+    // made this source an order of magnitude slower than the others. One
+    // pipeline now covers a whole batch of keys.
+    const pending: PendingEvent[] = [];
+    let draining = false;
+
+    const drain = async (): Promise<void> => {
+      if (draining) return;
+      draining = true;
+      try {
+        while (pending.length > 0 && !stopped) {
+          const batch = pending.splice(0, READ_BATCH);
+          const rows = await this.buildRows(reader, batch);
+          for (let i = 0; i < batch.length; i++) {
+            const item = batch[i]!;
+            await handlers.onChange({
+              op: item.op,
+              row: rows[i] ?? { key: item.key, event: item.event },
+              cursor: item.cursor,
+            });
+          }
+        }
+      } catch (err) {
+        handlers.onError(err as Error);
+      } finally {
+        draining = false;
+        // anything that arrived while the last batch was in flight
+        if (pending.length > 0 && !stopped) void drain();
+      }
+    };
 
     sub.on('pmessage', (_pattern: string, channel: string, key: string) => {
       // channel: __keyevent@<db>__:<event>   message: <key>
@@ -189,24 +238,87 @@ export class RedisCdcProvider implements CdcProvider {
       const op: CdcOperation = isDelete ? 'delete' : 'update';
       const cursor = `${Date.now()}:${seq++}`; // synthetic, non-durable
 
-      // resolve the value off the subscriber socket, but chained: each event's
-      // read AND delivery complete before the next event's read begins
-      chain = chain
-        .then(async () => {
-          const row = await this.buildRow(reader, key, event, isDelete);
-          await handlers.onChange({ op, row, cursor });
-        })
-        .catch((err) => handlers.onError(err as Error));
+      pending.push({ key, event, isDelete, op, cursor });
+      void drain();
     });
 
     await sub.psubscribe(`__keyevent@${db}__:*`);
 
     return {
       stop: async () => {
+        stopped = true;
         sub.disconnect();
         reader.disconnect();
       },
     };
+  }
+
+  /**
+   * Values for a whole batch of changed keys, in one round trip.
+   *
+   * TYPE and GET are issued together for every non-deleted key. Strings — which
+   * is nearly everything in practice — are then complete; the other container
+   * types need a second, targeted read, which is why they are collected and
+   * fetched afterwards rather than pessimising the common case.
+   */
+  private async buildRows(
+    reader: Redis,
+    items: PendingEvent[],
+  ): Promise<Array<Record<string, unknown>>> {
+    const rows: Array<Record<string, unknown>> = items.map((i) => ({
+      key: i.key,
+      event: i.event,
+    }));
+
+    const probe = reader.pipeline();
+    const probed: number[] = [];
+    items.forEach((item, i) => {
+      if (item.isDelete) return; // the value is already gone
+      probe.type(item.key);
+      probe.get(item.key);
+      probed.push(i);
+    });
+    if (probed.length === 0) return rows;
+
+    const replies = await probe.exec();
+    const needsSecondRead: Array<{ index: number; type: string }> = [];
+
+    probed.forEach((rowIndex, n) => {
+      const typeReply = replies?.[n * 2];
+      const getReply = replies?.[n * 2 + 1];
+      const type = String(typeReply?.[1] ?? '');
+      if (!type || type === 'none') return; // vanished between event and read
+      if (type === 'string') {
+        rows[rowIndex] = {
+          ...rows[rowIndex],
+          type,
+          value: getReply?.[0] ? null : ((getReply?.[1] as string | null) ?? null),
+        };
+        return;
+      }
+      rows[rowIndex] = { ...rows[rowIndex], type };
+      needsSecondRead.push({ index: rowIndex, type });
+    });
+
+    // containers are rare; one more pipeline covers all of them
+    if (needsSecondRead.length > 0) {
+      const second = reader.pipeline();
+      for (const { index, type } of needsSecondRead) {
+        const key = items[index]!.key;
+        if (type === 'hash') second.hgetall(key);
+        else if (type === 'list') second.lrange(key, 0, -1);
+        else if (type === 'set') second.smembers(key);
+        else if (type === 'zset') second.zrange(key, 0, -1, 'WITHSCORES');
+        else second.get(key);
+      }
+      const secondReplies = await second.exec();
+      needsSecondRead.forEach(({ index }, n) => {
+        const reply = secondReplies?.[n];
+        if (!reply?.[0]) rows[index] = { ...rows[index], value: reply?.[1] };
+      });
+    }
+
+    return rows;
   }
 
   /** best-effort read of the current value for a changed key */
@@ -219,10 +331,29 @@ export class RedisCdcProvider implements CdcProvider {
     const base = { key, event };
     if (isDelete) return base; // value's gone
     try {
-      const type = await reader.type(key);
+      // TYPE and GET go together in one pipeline rather than one after the
+      // other. A notification carries only the key, so every change costs a
+      // round trip to find out what it is and another to read it — and that,
+      // not Redis, is what limits this source. Strings are the overwhelmingly
+      // common case, so speculatively reading one alongside the TYPE halves
+      // the cost for them; other types still pay the second read below.
+      const [typeRes, getRes] = await reader
+        .pipeline()
+        .type(key)
+        .get(key)
+        .exec()
+        .then((r) => [r?.[0], r?.[1]] as const);
+
+      const type = String(typeRes?.[1] ?? '');
       switch (type) {
         case 'string':
-          return { ...base, type, value: await reader.get(key) };
+          // GET already came back in the same round trip; only fall back to a
+          // second read if the pipeline reported an error for it
+          return {
+            ...base,
+            type,
+            value: getRes?.[0] ? await reader.get(key) : (getRes?.[1] as string | null),
+          };
         case 'hash':
           return { ...base, type, value: await reader.hgetall(key) };
         case 'list':

--- a/apps/api/test/integration/app-harness.ts
+++ b/apps/api/test/integration/app-harness.ts
@@ -38,7 +38,15 @@ export async function bootstrapApp(): Promise<AppHandle> {
 }
 
 /** a key into TEST_CONNECTIONS; `*_dest` variants point at a separate database */
-export type ConnKey = 'postgres' | 'mysql' | 'mongodb' | 'postgres_dest' | 'mysql_dest';
+export type ConnKey =
+  | 'postgres'
+  | 'mysql'
+  | 'mongodb'
+  | 'redis'
+  | 'redis_dest'
+  | 'sqlite'
+  | 'postgres_dest'
+  | 'mysql_dest';
 
 export async function connectionFor(app: AppHandle, key: ConnKey): Promise<string> {
   const t = TEST_CONNECTIONS[key]!;
@@ -50,6 +58,10 @@ export async function connectionFor(app: AppHandle, key: ConnKey): Promise<strin
     user: t.user,
     password: t.password,
     database: t.database,
+    // engine-specific settings — Redis carries its database index here, and
+    // dropping it silently sent destination writes to db 0 while the checks
+    // read db 1
+    options: t.options,
   });
   return conn.id;
 }
@@ -61,7 +73,63 @@ export interface SyncSetup {
 }
 
 /**
- * Create a Postgres source table and a CDC bridge writing into `destEngine`.
+ * Row shape per engine. Redis stores key/value pairs and everything else stores
+ * named columns, so a bridge between the two has to map one onto the other.
+ */
+export type Shape = 'row' | 'kv';
+export const shapeOf = (engine: ConnKey): Shape =>
+  engine.startsWith('redis') ? 'kv' : 'row';
+
+/** the mapping that turns a source row into what the destination expects */
+export function mappingFor(
+  source: ConnKey,
+  dest: ConnKey,
+): Array<{ source: string; target: string }> {
+  const from = shapeOf(source);
+  const to = shapeOf(dest);
+  if (from === to) return []; // identity
+  return from === 'row'
+    ? [
+        { source: 'id', target: 'key' },
+        { source: 'name', target: 'value' },
+      ]
+    : [
+        { source: 'key', target: 'id' },
+        { source: 'value', target: 'name' },
+      ];
+}
+
+/** rows shaped for whichever engine is going to hold them */
+export function rowsFor(
+  engine: ConnKey,
+  count: number,
+  offset = 0,
+): Array<Record<string, unknown>> {
+  return shapeOf(engine) === 'kv'
+    ? Array.from({ length: count }, (_, i) => ({
+        key: String(offset + i + 1),
+        value: `row-${offset + i}`,
+      }))
+    : Array.from({ length: count }, (_, i) => ({
+        id: offset + i + 1,
+        name: `row-${offset + i}`,
+      }));
+}
+
+/** write rows into a source, however that engine takes them */
+export async function writeSourceRows(
+  engine: ConnKey,
+  table: string,
+  rows: Array<Record<string, unknown>>,
+): Promise<void> {
+  await withAdapter(engine, async (a) => {
+    if (a.insertRows) await a.insertRows({ table, rows });
+    else for (const values of rows) await a.insertRow({ table, values });
+  });
+}
+
+/**
+ * Create a source relation and a CDC bridge writing into `destEngine`.
  * `start: false` leaves the bridge stopped, for tests that drive start/stop.
  */
 export async function makeBridge(
@@ -84,22 +152,38 @@ export async function makeBridge(
   const srcTypes =
     sourceEngine === 'mysql'
       ? { int: 'int', text: 'varchar(255)' }
-      : { int: 'integer', text: 'text' };
-  await withAdapter(sourceEngine, (a) =>
-    a.createTable({
-      table: sourceTable,
-      columns: [
-        { name: 'id', type: srcTypes.int, nullable: false, primaryKey: true },
-        { name: 'name', type: srcTypes.text, nullable: true },
-      ],
-    }),
-  );
-  cleanups.push(() =>
-    withAdapter(sourceEngine, (a) => a.dropTable(sourceTable)).catch(() => undefined),
-  );
+      : sourceEngine === 'sqlite'
+        ? { int: 'INTEGER', text: 'TEXT' }
+        : { int: 'integer', text: 'text' };
+
+  // Redis has no relation to create. MongoDB creates a collection on first
+  // write, but a change stream needs it to exist before it opens.
+  if (sourceEngine === 'mongodb') {
+    await withAdapter(sourceEngine, (a) =>
+      a.createTable({ table: sourceTable, columns: [] }),
+    ).catch(() => undefined);
+  } else if (!sourceEngine.startsWith('redis')) {
+    await withAdapter(sourceEngine, (a) =>
+      a.createTable({
+        table: sourceTable,
+        columns: [
+          { name: 'id', type: srcTypes.int, nullable: false, primaryKey: true },
+          { name: 'name', type: srcTypes.text, nullable: true },
+        ],
+      }),
+    );
+  }
+  if (!sourceEngine.startsWith('redis')) {
+    cleanups.push(() =>
+      withAdapter(sourceEngine, (a) => a.dropTable(sourceTable)).catch(() => undefined),
+    );
+  }
   cleanups.push(() =>
     withAdapter(destEngine, (a) => a.dropTable(destTable)).catch(() => undefined),
   );
+
+  const mapping = mappingFor(sourceEngine, destEngine);
+  const keyColumns = shapeOf(destEngine) === 'kv' ? ['key'] : ['id'];
 
   const { bridgeInputSchema } = await import('@syncle/core');
   const input = bridgeInputSchema.parse({
@@ -112,7 +196,8 @@ export async function makeBridge(
           connectionId: destConnId,
           table: destTable,
           writeMode: 'upsert',
-          keyColumns: ['id'],
+          keyColumns,
+          mapping,
           createMissingTable: true,
         },
       ],
@@ -153,6 +238,16 @@ export async function destRows(
 export async function destCount(engine: ConnKey, table: string): Promise<number> {
   return withAdapter(engine, async (a) => {
     try {
+      // Redis has no tables: rows land as individual keys, so the database's
+      // key count IS the row count. The test instance is disposable and the
+      // benchmark flushes it first, so nothing else is being counted.
+      if (engine.startsWith('redis')) {
+        // the redis dialect answers with { command, reply }; the count is the
+        // REPLY — reading the first value would read back "DBSIZE"
+        const res = await a.query('DBSIZE');
+        const row = res.rows[0] as { reply?: unknown } | undefined;
+        return Number(row?.reply ?? 0);
+      }
       // MongoDB has no COUNT statement here, and its browse total is exact.
       // For SQL engines the total is NOT safe to compare against an expected
       // row count: MySQL derives it from information_schema.table_rows, which

--- a/apps/api/test/integration/cdc-matrix.itest.ts
+++ b/apps/api/test/integration/cdc-matrix.itest.ts
@@ -1,0 +1,137 @@
+/**
+ * Every source engine to every destination engine, with real data.
+ *
+ * Syncle's claim is that any supported engine can sit on either end of a
+ * bridge. This is that claim, tested: each pair gets a live CDC bridge, rows
+ * written to the source, and the destination checked for the actual VALUES —
+ * not just a row count, since a mapping that drops or transposes a column would
+ * still produce the right count.
+ *
+ * SQLite is a destination only. It has no change-capture path for external
+ * writers: sqlite3_update_hook fires only for writes made through the same
+ * in-process connection, and Syncle reads a file another process writes.
+ */
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  bootstrapApp,
+  connectionFor,
+  destCount,
+  makeBridge,
+  rowsFor,
+  shapeOf,
+  writeSourceRows,
+  type AppHandle,
+  type ConnKey,
+} from './app-harness';
+import { waitFor, withAdapter } from './harness';
+
+/** engines that can drive a bridge */
+const SOURCES: ConnKey[] = ['postgres', 'mysql', 'mongodb', 'redis'];
+/** engines that can receive one */
+const DESTS: ConnKey[] = ['postgres_dest', 'mysql_dest', 'mongodb', 'sqlite', 'redis_dest'];
+
+const ROWS = 200;
+const LABEL: Record<string, string> = {
+  postgres: 'PostgreSQL',
+  postgres_dest: 'PostgreSQL',
+  mysql: 'MySQL',
+  mysql_dest: 'MySQL',
+  mongodb: 'MongoDB',
+  sqlite: 'SQLite',
+  redis: 'Redis',
+  redis_dest: 'Redis',
+};
+
+let app: AppHandle;
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+  app = await bootstrapApp();
+}, 180_000);
+
+afterAll(async () => {
+  for (const fn of cleanups.reverse()) await fn().catch(() => undefined);
+  await app?.ctx.close().catch(() => undefined);
+});
+
+/** read one row back from a destination, whatever shape it holds */
+async function readBack(
+  dest: ConnKey,
+  table: string,
+  id: number,
+): Promise<Record<string, unknown> | null> {
+  return withAdapter(dest, async (a) => {
+    if (shapeOf(dest) === 'kv') {
+      const res = await a.query(`GET ${id}`);
+      const row = res.rows[0] as { reply?: unknown } | undefined;
+      const value = row?.reply;
+      return value === undefined || value === null || value === '' ? null : { value };
+    }
+    const res = await a.browse({ table, limit: 1000, offset: 0 });
+    return (
+      (res.rows as Array<Record<string, unknown>>).find(
+        (r) => Number(r.id) === id,
+      ) ?? null
+    );
+  });
+}
+
+for (const source of SOURCES) {
+  describe(`${LABEL[source]} as a source`, () => {
+    for (const dest of DESTS) {
+      it(`syncs to ${LABEL[dest]}`, async () => {
+        // a redis destination counts keys, so start from an empty database
+        if (shapeOf(dest) === 'kv') {
+          await withAdapter(dest, (a) => a.query('FLUSHDB'));
+        }
+
+        const srcConn = await connectionFor(app, source);
+        const dstConn = await connectionFor(app, dest);
+        const s = await makeBridge(app, {
+          sourceEngine: source,
+          destEngine: dest,
+          sourceConnId: srcConn,
+          destConnId: dstConn,
+          cleanups,
+        });
+
+        await writeSourceRows(source, s.sourceTable, rowsFor(source, ROWS));
+
+        await waitFor(
+          `${ROWS} rows ${LABEL[source]} -> ${LABEL[dest]}`,
+          async () => ((await destCount(dest, s.destTable)) === ROWS ? true : null),
+          { timeoutMs: 120_000, intervalMs: 200 },
+        );
+
+        // the count alone would pass even if the mapping transposed columns,
+        // so check a value actually arrived intact
+        const first = await readBack(dest, s.destTable, 1);
+        expect(first, `row 1 missing in ${LABEL[dest]}`).toBeTruthy();
+        const carried = shapeOf(dest) === 'kv' ? first?.value : first?.name;
+        expect(String(carried)).toBe('row-0');
+
+        const last = await readBack(dest, s.destTable, ROWS);
+        const carriedLast = shapeOf(dest) === 'kv' ? last?.value : last?.name;
+        expect(String(carriedLast)).toBe(`row-${ROWS - 1}`);
+
+        await app.cdc.stop(s.bridgeId).catch(() => undefined);
+        await app.cdc.cleanup(s.bridgeId).catch(() => undefined);
+      }, 180_000);
+    }
+  });
+}
+
+describe('SQLite as a source', () => {
+  it('reports CDC as unsupported rather than pretending', async () => {
+    // steering people to a watch bridge is the correct behaviour here, and it
+    // should be stated by the readiness probe rather than failing at runtime
+    const conn = await connectionFor(app, 'sqlite');
+    const readiness = await app.cdc.readiness({
+      connectionId: conn,
+      table: 'anything',
+    });
+    expect(readiness.supported).toBe(false);
+    expect(readiness.instructions.join(' ')).toMatch(/watch|poll/i);
+  });
+});

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -50,6 +50,14 @@ export const TEST_CONNECTIONS: Record<string, ConnectionConfig> = {
     database: 'syncle_test',
   }),
   redis: base('redis', { host: '127.0.0.1', port: 56379 }),
+  // A SEPARATE Redis database for destinations. Writing into the same one the
+  // source watches would have the destination's own writes fire the keyspace
+  // notifications the source is subscribed to — an endless feedback loop.
+  redis_dest: base('redis', {
+    host: '127.0.0.1',
+    port: 56379,
+    options: { db: 1 },
+  }),
   // Destinations live in their OWN databases, which is both realistic and
   // necessary for measurement: a Postgres logical slot is database-scoped, so
   // writing the destination into the source's database makes the source's

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-07T11:01:33.287Z",
+  "generatedAt": "2026-09-08T05:54:32.821Z",
   "configuration": {
     "Rows per delivery": "100,000 (SYNCLE_CDC_BATCH_SIZE)",
     "Batch byte ceiling": "64 MB (SYNCLE_CDC_BATCH_BYTES)",
@@ -22,71 +22,272 @@
   },
   "suites": [
     {
+      "id": "cdc-spool",
+      "name": "With the durable spool",
+      "description": "The same sync, with SYNCLE_CDC_SPOOL=on. Changes go to a Redis stream first and the source is acknowledged as soon as they are durably spooled, so a slow destination cannot hold the source’s log open. It costs throughput; that is the trade it exists to make.",
+      "results": [
+        {
+          "scenario": "PostgreSQL → PostgreSQL",
+          "rows": 1000000,
+          "ms": 32237,
+          "rowsPerSec": 31020,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "255% / 32%",
+            "syncle memory (peak)": "678 MB",
+            "pg cpu / memory (peak)": "194% / 1361 MB",
+            "peak spool depth": 69629
+          }
+        }
+      ]
+    },
+    {
       "id": "cdc-throughput",
       "name": "Change data capture, end to end",
       "description": "A row is committed on the source, picked up from that database’s own change log (Postgres logical replication, MySQL binlog) and written to the destination. Timing starts when the writes begin and stops when the last row has landed, so it includes reading the log, delivery and the destination write. Every run is verified complete and duplicate-free before its time is recorded.",
       "results": [
         {
-          "scenario": "PostgreSQL → PostgreSQL · batched",
+          "scenario": "PostgreSQL → PostgreSQL",
           "rows": 1000000,
-          "ms": 15938,
-          "rowsPerSec": 62743,
+          "ms": 16612,
+          "rowsPerSec": 60197,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "221% / 26%",
-            "syncle memory (peak)": "249 MB",
-            "pg cpu / memory (peak)": "176% / 1335 MB"
+            "syncle cpu (peak / avg)": "221% / 24%",
+            "syncle memory (peak)": "251 MB",
+            "pg cpu / memory (peak)": "216% / 1336 MB"
           }
         },
         {
-          "scenario": "PostgreSQL → MySQL · batched",
+          "scenario": "PostgreSQL → MySQL",
           "rows": 1000000,
-          "ms": 11130,
-          "rowsPerSec": 89847,
+          "ms": 17940,
+          "rowsPerSec": 55741,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "205% / 46%",
-            "syncle memory (peak)": "287 MB",
-            "pg cpu / memory (peak)": "88% / 1420 MB",
-            "mysql cpu / memory (peak)": "53% / 1760 MB"
+            "syncle cpu (peak / avg)": "217% / 31%",
+            "syncle memory (peak)": "343 MB",
+            "pg cpu / memory (peak)": "138% / 1279 MB",
+            "mysql cpu / memory (peak)": "65% / 2235 MB"
           }
         },
         {
-          "scenario": "MySQL → PostgreSQL · batched",
+          "scenario": "PostgreSQL → MongoDB",
           "rows": 1000000,
-          "ms": 11391,
-          "rowsPerSec": 87789,
+          "ms": 48204,
+          "rowsPerSec": 20745,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "224% / 29%",
-            "syncle memory (peak)": "369 MB",
-            "pg cpu / memory (peak)": "127% / 1609 MB",
-            "mysql cpu / memory (peak)": "82% / 1838 MB"
+            "syncle cpu (peak / avg)": "209% / 11%",
+            "syncle memory (peak)": "313 MB",
+            "pg cpu / memory (peak)": "86% / 1287 MB"
           }
         },
         {
-          "scenario": "PostgreSQL → MongoDB · batched",
+          "scenario": "PostgreSQL → SQLite",
           "rows": 1000000,
-          "ms": 46893,
-          "rowsPerSec": 21325,
+          "ms": 8404,
+          "rowsPerSec": 118991,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "258% / 10%",
-            "syncle memory (peak)": "288 MB",
-            "pg cpu / memory (peak)": "105% / 1820 MB"
+            "syncle cpu (peak / avg)": "182% / 73%",
+            "syncle memory (peak)": "293 MB",
+            "pg cpu / memory (peak)": "121% / 1282 MB"
           }
         },
         {
-          "scenario": "PostgreSQL → PostgreSQL · batched + durable spool",
+          "scenario": "PostgreSQL → Redis",
           "rows": 1000000,
-          "ms": 21108,
-          "rowsPerSec": 47375,
+          "ms": 9531,
+          "rowsPerSec": 104921,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "266% / 51%",
-            "syncle memory (peak)": "527 MB",
-            "pg cpu / memory (peak)": "138% / 1616 MB",
-            "peak spool depth": 83789
+            "syncle cpu (peak / avg)": "315% / 102%",
+            "syncle memory (peak)": "491 MB",
+            "pg cpu / memory (peak)": "129% / 1294 MB",
+            "redis cpu / memory (peak)": "129% / 285 MB"
+          }
+        },
+        {
+          "scenario": "MySQL → PostgreSQL",
+          "rows": 1000000,
+          "ms": 12043,
+          "rowsPerSec": 83036,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "244% / 28%",
+            "syncle memory (peak)": "401 MB",
+            "pg cpu / memory (peak)": "88% / 1277 MB",
+            "mysql cpu / memory (peak)": "78% / 2289 MB"
+          }
+        },
+        {
+          "scenario": "MySQL → MySQL",
+          "rows": 1000000,
+          "ms": 8345,
+          "rowsPerSec": 119832,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "286% / 49%",
+            "syncle memory (peak)": "403 MB",
+            "mysql cpu / memory (peak)": "108% / 2416 MB"
+          }
+        },
+        {
+          "scenario": "MySQL → MongoDB",
+          "rows": 1000000,
+          "ms": 38596,
+          "rowsPerSec": 25909,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "265% / 10%",
+            "syncle memory (peak)": "430 MB",
+            "mysql cpu / memory (peak)": "104% / 2456 MB"
+          }
+        },
+        {
+          "scenario": "MySQL → SQLite",
+          "rows": 1000000,
+          "ms": 8035,
+          "rowsPerSec": 124456,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "221% / 69%",
+            "syncle memory (peak)": "364 MB",
+            "mysql cpu / memory (peak)": "58% / 2462 MB"
+          }
+        },
+        {
+          "scenario": "MySQL → Redis",
+          "rows": 1000000,
+          "ms": 9434,
+          "rowsPerSec": 106000,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "293% / 112%",
+            "syncle memory (peak)": "550 MB",
+            "redis cpu / memory (peak)": "107% / 253 MB",
+            "mysql cpu / memory (peak)": "55% / 2562 MB"
+          }
+        },
+        {
+          "scenario": "MongoDB → PostgreSQL",
+          "rows": 1000000,
+          "ms": 40354,
+          "rowsPerSec": 24781,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "258% / 51%",
+            "syncle memory (peak)": "323 MB",
+            "pg cpu / memory (peak)": "167% / 1345 MB"
+          }
+        },
+        {
+          "scenario": "MongoDB → MySQL",
+          "rows": 1000000,
+          "ms": 32386,
+          "rowsPerSec": 30878,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "227% / 60%",
+            "syncle memory (peak)": "441 MB",
+            "mysql cpu / memory (peak)": "62% / 2611 MB"
+          }
+        },
+        {
+          "scenario": "MongoDB → MongoDB",
+          "rows": 1000000,
+          "ms": 93479,
+          "rowsPerSec": 10698,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "246% / 26%",
+            "syncle memory (peak)": "448 MB"
+          }
+        },
+        {
+          "scenario": "MongoDB → SQLite",
+          "rows": 1000000,
+          "ms": 25987,
+          "rowsPerSec": 38481,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "245% / 74%",
+            "syncle memory (peak)": "403 MB"
+          }
+        },
+        {
+          "scenario": "MongoDB → Redis",
+          "rows": 1000000,
+          "ms": 46619,
+          "rowsPerSec": 21450,
+          "detail": {
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "289% / 60%",
+            "syncle memory (peak)": "319 MB",
+            "redis cpu / memory (peak)": "144% / 262 MB"
+          }
+        },
+        {
+          "scenario": "Redis → PostgreSQL",
+          "rows": 100000,
+          "ms": 51691,
+          "rowsPerSec": 1935,
+          "detail": {
+            "verified": "100000 rows, exactly once",
+            "syncle cpu (peak / avg)": "197% / 19%",
+            "syncle memory (peak)": "388 MB",
+            "pg cpu / memory (peak)": "20% / 1266 MB",
+            "redis cpu / memory (peak)": "42% / 205 MB"
+          }
+        },
+        {
+          "scenario": "Redis → MySQL",
+          "rows": 100000,
+          "ms": 48534,
+          "rowsPerSec": 2060,
+          "detail": {
+            "verified": "100000 rows, exactly once",
+            "syncle cpu (peak / avg)": "278% / 20%",
+            "syncle memory (peak)": "404 MB",
+            "redis cpu / memory (peak)": "60% / 192 MB",
+            "mysql cpu / memory (peak)": "47% / 2507 MB"
+          }
+        },
+        {
+          "scenario": "Redis → MongoDB",
+          "rows": 100000,
+          "ms": 53775,
+          "rowsPerSec": 1860,
+          "detail": {
+            "verified": "100000 rows, exactly once",
+            "syncle cpu (peak / avg)": "261% / 20%",
+            "syncle memory (peak)": "332 MB",
+            "redis cpu / memory (peak)": "56% / 196 MB"
+          }
+        },
+        {
+          "scenario": "Redis → SQLite",
+          "rows": 100000,
+          "ms": 112197,
+          "rowsPerSec": 891,
+          "detail": {
+            "verified": "100000 rows, exactly once",
+            "syncle cpu (peak / avg)": "287% / 19%",
+            "syncle memory (peak)": "455 MB",
+            "redis cpu / memory (peak)": "130% / 202 MB"
+          }
+        },
+        {
+          "scenario": "Redis → Redis",
+          "rows": 100000,
+          "ms": 60714,
+          "rowsPerSec": 1647,
+          "detail": {
+            "verified": "100000 rows, exactly once",
+            "syncle cpu (peak / avg)": "299% / 21%",
+            "syncle memory (peak)": "375 MB",
+            "redis cpu / memory (peak)": "22% / 207 MB"
           }
         }
       ]
@@ -99,23 +300,39 @@
         {
           "scenario": "PostgreSQL · upsert",
           "rows": 1000000,
-          "ms": 8503,
-          "rowsPerSec": 117606,
+          "ms": 12768,
+          "rowsPerSec": 78321,
           "detail": {
-            "syncle cpu (peak / avg)": "86% / 8%",
-            "syncle memory (peak)": "130 MB",
-            "pg cpu / memory (peak)": "98% / 1227 MB"
+            "syncle cpu (peak / avg)": "116% / 5%",
+            "syncle memory (peak)": "129 MB",
+            "pg cpu / memory (peak)": "119% / 1244 MB"
           }
         },
         {
           "scenario": "MySQL · upsert",
           "rows": 1000000,
-          "ms": 3622,
-          "rowsPerSec": 276091,
+          "ms": 3451,
+          "rowsPerSec": 289771,
           "detail": {
-            "syncle cpu (peak / avg)": "82% / 22%",
-            "syncle memory (peak)": "176 MB",
-            "mysql cpu / memory (peak)": "110% / 1811 MB"
+            "syncle cpu (peak / avg)": "135% / 23%",
+            "syncle memory (peak)": "199 MB"
+          }
+        },
+        {
+          "scenario": "SQLite · upsert",
+          "rows": 1000000,
+          "ms": 783,
+          "rowsPerSec": 1277139,
+          "detail": {}
+        },
+        {
+          "scenario": "Redis · upsert",
+          "rows": 1000000,
+          "ms": 3611,
+          "rowsPerSec": 276932,
+          "detail": {
+            "syncle cpu (peak / avg)": "260% / 84%",
+            "syncle memory (peak)": "626 MB"
           }
         }
       ]

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-08T05:54:32.821Z",
+  "generatedAt": "2026-09-08T06:26:16.817Z",
   "configuration": {
     "Rows per delivery": "100,000 (SYNCLE_CDC_BATCH_SIZE)",
     "Batch byte ceiling": "64 MB (SYNCLE_CDC_BATCH_BYTES)",
@@ -29,14 +29,14 @@
         {
           "scenario": "PostgreSQL → PostgreSQL",
           "rows": 1000000,
-          "ms": 32237,
-          "rowsPerSec": 31020,
+          "ms": 23402,
+          "rowsPerSec": 42731,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "255% / 32%",
-            "syncle memory (peak)": "678 MB",
-            "pg cpu / memory (peak)": "194% / 1361 MB",
-            "peak spool depth": 69629
+            "syncle cpu (peak / avg)": "238% / 49%",
+            "syncle memory (peak)": "451 MB",
+            "pg cpu / memory (peak)": "148% / 1421 MB",
+            "peak spool depth": 75246
           }
         }
       ]
@@ -49,245 +49,245 @@
         {
           "scenario": "PostgreSQL → PostgreSQL",
           "rows": 1000000,
-          "ms": 16612,
-          "rowsPerSec": 60197,
+          "ms": 13339,
+          "rowsPerSec": 74968,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "221% / 24%",
-            "syncle memory (peak)": "251 MB",
-            "pg cpu / memory (peak)": "216% / 1336 MB"
+            "syncle cpu (peak / avg)": "221% / 30%",
+            "syncle memory (peak)": "246 MB",
+            "pg cpu / memory (peak)": "148% / 1338 MB"
           }
         },
         {
           "scenario": "PostgreSQL → MySQL",
           "rows": 1000000,
-          "ms": 17940,
-          "rowsPerSec": 55741,
+          "ms": 9725,
+          "rowsPerSec": 102828,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "217% / 31%",
-            "syncle memory (peak)": "343 MB",
-            "pg cpu / memory (peak)": "138% / 1279 MB",
-            "mysql cpu / memory (peak)": "65% / 2235 MB"
+            "syncle cpu (peak / avg)": "232% / 51%",
+            "syncle memory (peak)": "307 MB",
+            "pg cpu / memory (peak)": "76% / 1281 MB",
+            "mysql cpu / memory (peak)": "82% / 2716 MB"
           }
         },
         {
           "scenario": "PostgreSQL → MongoDB",
           "rows": 1000000,
-          "ms": 48204,
-          "rowsPerSec": 20745,
+          "ms": 35754,
+          "rowsPerSec": 27969,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "209% / 11%",
-            "syncle memory (peak)": "313 MB",
-            "pg cpu / memory (peak)": "86% / 1287 MB"
+            "syncle cpu (peak / avg)": "239% / 13%",
+            "syncle memory (peak)": "281 MB",
+            "pg cpu / memory (peak)": "100% / 1291 MB"
           }
         },
         {
           "scenario": "PostgreSQL → SQLite",
           "rows": 1000000,
-          "ms": 8404,
-          "rowsPerSec": 118991,
+          "ms": 7477,
+          "rowsPerSec": 133743,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "182% / 73%",
-            "syncle memory (peak)": "293 MB",
-            "pg cpu / memory (peak)": "121% / 1282 MB"
+            "syncle cpu (peak / avg)": "258% / 85%",
+            "syncle memory (peak)": "336 MB",
+            "pg cpu / memory (peak)": "116% / 1252 MB"
           }
         },
         {
           "scenario": "PostgreSQL → Redis",
           "rows": 1000000,
-          "ms": 9531,
-          "rowsPerSec": 104921,
+          "ms": 8878,
+          "rowsPerSec": 112638,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "315% / 102%",
-            "syncle memory (peak)": "491 MB",
-            "pg cpu / memory (peak)": "129% / 1294 MB",
-            "redis cpu / memory (peak)": "129% / 285 MB"
+            "syncle cpu (peak / avg)": "328% / 112%",
+            "syncle memory (peak)": "517 MB",
+            "pg cpu / memory (peak)": "93% / 1277 MB",
+            "redis cpu / memory (peak)": "30% / 360 MB"
           }
         },
         {
           "scenario": "MySQL → PostgreSQL",
           "rows": 1000000,
-          "ms": 12043,
-          "rowsPerSec": 83036,
+          "ms": 11810,
+          "rowsPerSec": 84674,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "244% / 28%",
-            "syncle memory (peak)": "401 MB",
-            "pg cpu / memory (peak)": "88% / 1277 MB",
-            "mysql cpu / memory (peak)": "78% / 2289 MB"
+            "syncle cpu (peak / avg)": "264% / 29%",
+            "syncle memory (peak)": "417 MB",
+            "pg cpu / memory (peak)": "97% / 1264 MB",
+            "mysql cpu / memory (peak)": "78% / 2857 MB"
           }
         },
         {
           "scenario": "MySQL → MySQL",
           "rows": 1000000,
-          "ms": 8345,
-          "rowsPerSec": 119832,
+          "ms": 10195,
+          "rowsPerSec": 98087,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "286% / 49%",
-            "syncle memory (peak)": "403 MB",
-            "mysql cpu / memory (peak)": "108% / 2416 MB"
+            "syncle cpu (peak / avg)": "221% / 56%",
+            "syncle memory (peak)": "362 MB",
+            "mysql cpu / memory (peak)": "139% / 2922 MB"
           }
         },
         {
           "scenario": "MySQL → MongoDB",
           "rows": 1000000,
-          "ms": 38596,
-          "rowsPerSec": 25909,
+          "ms": 35714,
+          "rowsPerSec": 28000,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "265% / 10%",
-            "syncle memory (peak)": "430 MB",
-            "mysql cpu / memory (peak)": "104% / 2456 MB"
+            "syncle cpu (peak / avg)": "267% / 11%",
+            "syncle memory (peak)": "468 MB",
+            "mysql cpu / memory (peak)": "95% / 2969 MB"
           }
         },
         {
           "scenario": "MySQL → SQLite",
           "rows": 1000000,
-          "ms": 8035,
-          "rowsPerSec": 124456,
+          "ms": 7944,
+          "rowsPerSec": 125881,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "221% / 69%",
-            "syncle memory (peak)": "364 MB",
-            "mysql cpu / memory (peak)": "58% / 2462 MB"
+            "syncle cpu (peak / avg)": "238% / 67%",
+            "syncle memory (peak)": "428 MB",
+            "mysql cpu / memory (peak)": "56% / 2873 MB"
           }
         },
         {
           "scenario": "MySQL → Redis",
           "rows": 1000000,
-          "ms": 9434,
-          "rowsPerSec": 106000,
+          "ms": 11333,
+          "rowsPerSec": 88238,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "293% / 112%",
-            "syncle memory (peak)": "550 MB",
-            "redis cpu / memory (peak)": "107% / 253 MB",
-            "mysql cpu / memory (peak)": "55% / 2562 MB"
+            "syncle cpu (peak / avg)": "315% / 93%",
+            "syncle memory (peak)": "598 MB",
+            "redis cpu / memory (peak)": "116% / 366 MB",
+            "mysql cpu / memory (peak)": "53% / 2909 MB"
           }
         },
         {
           "scenario": "MongoDB → PostgreSQL",
           "rows": 1000000,
-          "ms": 40354,
-          "rowsPerSec": 24781,
+          "ms": 32591,
+          "rowsPerSec": 30683,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "258% / 51%",
-            "syncle memory (peak)": "323 MB",
-            "pg cpu / memory (peak)": "167% / 1345 MB"
+            "syncle cpu (peak / avg)": "253% / 61%",
+            "syncle memory (peak)": "503 MB",
+            "pg cpu / memory (peak)": "148% / 1351 MB"
           }
         },
         {
           "scenario": "MongoDB → MySQL",
           "rows": 1000000,
-          "ms": 32386,
-          "rowsPerSec": 30878,
+          "ms": 28996,
+          "rowsPerSec": 34488,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "227% / 60%",
-            "syncle memory (peak)": "441 MB",
-            "mysql cpu / memory (peak)": "62% / 2611 MB"
+            "syncle cpu (peak / avg)": "263% / 71%",
+            "syncle memory (peak)": "351 MB",
+            "mysql cpu / memory (peak)": "95% / 3013 MB"
           }
         },
         {
           "scenario": "MongoDB → MongoDB",
           "rows": 1000000,
-          "ms": 93479,
-          "rowsPerSec": 10698,
+          "ms": 51268,
+          "rowsPerSec": 19505,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "246% / 26%",
-            "syncle memory (peak)": "448 MB"
+            "syncle cpu (peak / avg)": "308% / 40%",
+            "syncle memory (peak)": "366 MB"
           }
         },
         {
           "scenario": "MongoDB → SQLite",
           "rows": 1000000,
-          "ms": 25987,
-          "rowsPerSec": 38481,
+          "ms": 24414,
+          "rowsPerSec": 40960,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "245% / 74%",
-            "syncle memory (peak)": "403 MB"
+            "syncle cpu (peak / avg)": "221% / 80%",
+            "syncle memory (peak)": "471 MB"
           }
         },
         {
           "scenario": "MongoDB → Redis",
           "rows": 1000000,
-          "ms": 46619,
-          "rowsPerSec": 21450,
+          "ms": 27587,
+          "rowsPerSec": 36249,
           "detail": {
             "verified": "1000000 rows, exactly once",
-            "syncle cpu (peak / avg)": "289% / 60%",
-            "syncle memory (peak)": "319 MB",
-            "redis cpu / memory (peak)": "144% / 262 MB"
+            "syncle cpu (peak / avg)": "270% / 89%",
+            "syncle memory (peak)": "456 MB",
+            "redis cpu / memory (peak)": "118% / 355 MB"
           }
         },
         {
           "scenario": "Redis → PostgreSQL",
-          "rows": 100000,
-          "ms": 51691,
-          "rowsPerSec": 1935,
+          "rows": 1000000,
+          "ms": 23982,
+          "rowsPerSec": 41698,
           "detail": {
-            "verified": "100000 rows, exactly once",
-            "syncle cpu (peak / avg)": "197% / 19%",
-            "syncle memory (peak)": "388 MB",
-            "pg cpu / memory (peak)": "20% / 1266 MB",
-            "redis cpu / memory (peak)": "42% / 205 MB"
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "293% / 95%",
+            "syncle memory (peak)": "643 MB",
+            "pg cpu / memory (peak)": "121% / 1332 MB",
+            "redis cpu / memory (peak)": "43% / 293 MB"
           }
         },
         {
           "scenario": "Redis → MySQL",
-          "rows": 100000,
-          "ms": 48534,
-          "rowsPerSec": 2060,
+          "rows": 1000000,
+          "ms": 20866,
+          "rowsPerSec": 47925,
           "detail": {
-            "verified": "100000 rows, exactly once",
-            "syncle cpu (peak / avg)": "278% / 20%",
-            "syncle memory (peak)": "404 MB",
-            "redis cpu / memory (peak)": "60% / 192 MB",
-            "mysql cpu / memory (peak)": "47% / 2507 MB"
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "365% / 116%",
+            "syncle memory (peak)": "714 MB",
+            "redis cpu / memory (peak)": "41% / 296 MB",
+            "mysql cpu / memory (peak)": "125% / 3006 MB"
           }
         },
         {
           "scenario": "Redis → MongoDB",
-          "rows": 100000,
-          "ms": 53775,
-          "rowsPerSec": 1860,
+          "rows": 1000000,
+          "ms": 47372,
+          "rowsPerSec": 21110,
           "detail": {
-            "verified": "100000 rows, exactly once",
-            "syncle cpu (peak / avg)": "261% / 20%",
-            "syncle memory (peak)": "332 MB",
-            "redis cpu / memory (peak)": "56% / 196 MB"
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "364% / 55%",
+            "syncle memory (peak)": "664 MB",
+            "redis cpu / memory (peak)": "137% / 322 MB"
           }
         },
         {
           "scenario": "Redis → SQLite",
-          "rows": 100000,
-          "ms": 112197,
-          "rowsPerSec": 891,
+          "rows": 1000000,
+          "ms": 20017,
+          "rowsPerSec": 49958,
           "detail": {
-            "verified": "100000 rows, exactly once",
-            "syncle cpu (peak / avg)": "287% / 19%",
-            "syncle memory (peak)": "455 MB",
-            "redis cpu / memory (peak)": "130% / 202 MB"
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "336% / 123%",
+            "syncle memory (peak)": "784 MB",
+            "redis cpu / memory (peak)": "132% / 317 MB"
           }
         },
         {
           "scenario": "Redis → Redis",
-          "rows": 100000,
-          "ms": 60714,
-          "rowsPerSec": 1647,
+          "rows": 1000000,
+          "ms": 24475,
+          "rowsPerSec": 40858,
           "detail": {
-            "verified": "100000 rows, exactly once",
-            "syncle cpu (peak / avg)": "299% / 21%",
-            "syncle memory (peak)": "375 MB",
-            "redis cpu / memory (peak)": "22% / 207 MB"
+            "verified": "1000000 rows, exactly once",
+            "syncle cpu (peak / avg)": "333% / 129%",
+            "syncle memory (peak)": "786 MB",
+            "redis cpu / memory (peak)": "82% / 339 MB"
           }
         }
       ]
@@ -300,22 +300,22 @@
         {
           "scenario": "PostgreSQL · upsert",
           "rows": 1000000,
-          "ms": 12768,
-          "rowsPerSec": 78321,
+          "ms": 7733,
+          "rowsPerSec": 129316,
           "detail": {
-            "syncle cpu (peak / avg)": "116% / 5%",
-            "syncle memory (peak)": "129 MB",
-            "pg cpu / memory (peak)": "119% / 1244 MB"
+            "syncle cpu (peak / avg)": "88% / 8%",
+            "syncle memory (peak)": "134 MB",
+            "pg cpu / memory (peak)": "98% / 1227 MB"
           }
         },
         {
           "scenario": "MySQL · upsert",
           "rows": 1000000,
-          "ms": 3451,
-          "rowsPerSec": 289771,
+          "ms": 3239,
+          "rowsPerSec": 308737,
           "detail": {
-            "syncle cpu (peak / avg)": "135% / 23%",
-            "syncle memory (peak)": "199 MB"
+            "syncle cpu (peak / avg)": "108% / 24%",
+            "syncle memory (peak)": "174 MB"
           }
         },
         {
@@ -328,11 +328,11 @@
         {
           "scenario": "Redis · upsert",
           "rows": 1000000,
-          "ms": 3611,
-          "rowsPerSec": 276932,
+          "ms": 3661,
+          "rowsPerSec": 273149,
           "detail": {
-            "syncle cpu (peak / avg)": "260% / 84%",
-            "syncle memory (peak)": "626 MB"
+            "syncle cpu (peak / avg)": "273% / 90%",
+            "syncle memory (peak)": "542 MB"
           }
         }
       ]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -88,7 +88,9 @@ services:
     # million documents plus their indexes, and the container gets OOM-killed
     # part way through a benchmark. The volume is still disposable.
     volumes: ['syncle-test-mongo:/data/db']
-    mem_limit: 2g
+    # 2g was not enough for million-document collections and the container
+    # was OOM-killed mid-run; the cache below keeps it from simply growing
+    mem_limit: 3g
     healthcheck:
       test:
         ['CMD', 'mongosh', '--port', '57017', '--quiet', '--eval', 'db.adminCommand("ping").ok']

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -72,12 +72,23 @@ services:
     # members' host:port, and clients reconnect to whatever it advertises. With
     # a remapped port the driver would discover 127.0.0.1:27017 and dial the
     # wrong place from the host, so keep these two numbers the same.
-    command: ['--replSet', 'rs0', '--bind_ip_all', '--port', '57017']
+    # An explicit WiredTiger cache: the default takes half the HOST's RAM,
+    # which on a shared Docker VM running four engines gets the container
+    # OOM-killed under a large benchmark rather than simply evicting.
+    command:
+      - '--replSet'
+      - 'rs0'
+      - '--bind_ip_all'
+      - '--port'
+      - '57017'
+      - '--wiredTigerCacheSizeGB'
+      - '1'
     ports: ['127.0.0.1:57017:57017']
     # NOT tmpfs, unlike the others. A RAM-backed data directory cannot hold a
     # million documents plus their indexes, and the container gets OOM-killed
     # part way through a benchmark. The volume is still disposable.
     volumes: ['syncle-test-mongo:/data/db']
+    mem_limit: 2g
     healthcheck:
       test:
         ['CMD', 'mongosh', '--port', '57017', '--quiet', '--eval', 'db.adminCommand("ping").ok']

--- a/packages/core/src/adapters/nosql/redis-adapter.ts
+++ b/packages/core/src/adapters/nosql/redis-adapter.ts
@@ -15,11 +15,14 @@ import type {
   DatabaseAdapter,
   DatabaseSchema,
   DeleteRowParams,
+  DeleteRowsParams,
   InsertRowParams,
+  InsertRowsParams,
   QueryResult,
   RestoreResult,
   UpdateRowParams,
   UpsertRowParams,
+  UpsertRowsParams,
 } from '../types';
 import {
   BadRequestError,
@@ -304,6 +307,56 @@ export class RedisAdapter implements DatabaseAdapter {
   /** a SET is already idempotent, so upsert is just insert by key */
   async upsertRow(p: UpsertRowParams): Promise<QueryResult> {
     return this.insertRow({ table: p.table, schema: p.schema, values: p.values });
+  }
+
+  /* ----- set-based writes -------------------------------------------------
+   * Without these the sink issues one SET per row, which is a round trip per
+   * row — the thing that sets the ceiling on a change stream. A pipeline sends
+   * the whole batch as one write and reads one reply, so the cost per row stops
+   * being a round trip and becomes a few bytes.
+   */
+
+  /** the pipeline shared by every batched write; `SET` is already idempotent */
+  private async pipelineWrite(
+    rows: Array<Record<string, unknown>>,
+  ): Promise<QueryResult> {
+    if (rows.length === 0) return writeResult(0, 'pipeline');
+    const client = this.getClient();
+    if (client.status !== 'ready') await client.connect().catch(() => {});
+    const pipeline = client.pipeline();
+    for (const values of rows) {
+      const key = String(values.key ?? '');
+      if (!key) throw new QueryError('A "key" value is required');
+      pipeline.set(key, String(values.value ?? ''));
+    }
+    const results = await pipeline.exec();
+    // a pipeline reports per-command errors rather than throwing; surface the
+    // first one instead of silently reporting every row as written
+    const failed = results?.find(([err]) => err);
+    if (failed?.[0]) throw new QueryError(failed[0].message);
+    return writeResult(rows.length, 'pipeline set');
+  }
+
+  async insertRows(p: InsertRowsParams): Promise<QueryResult> {
+    return this.pipelineWrite(p.rows);
+  }
+
+  async upsertRows(p: UpsertRowsParams): Promise<QueryResult> {
+    // SET overwrites, so an upsert and an insert are the same operation here
+    return this.pipelineWrite(p.rows);
+  }
+
+  async deleteRows(p: DeleteRowsParams): Promise<QueryResult> {
+    if (p.identities.length === 0) return writeResult(0, 'pipeline');
+    const client = this.getClient();
+    if (client.status !== 'ready') await client.connect().catch(() => {});
+    const keys = p.identities
+      .map((identity) => String(identity.key ?? ''))
+      .filter((k) => k.length > 0);
+    if (keys.length === 0) return writeResult(0, 'del');
+    // DEL takes many keys in one command, so this needs no pipeline at all
+    const removed = await client.del(...keys);
+    return writeResult(removed, 'del');
   }
 
   /**

--- a/website/app/benchmarks/page.tsx
+++ b/website/app/benchmarks/page.tsx
@@ -33,6 +33,51 @@ function Detail({ detail }: { detail: BenchResult['detail'] }) {
   );
 }
 
+
+/**
+ * A suite whose scenarios are all "Source → Destination" reads far better as a
+ * grid than as twenty rows: the engine pairs are a matrix, and a matrix shows
+ * at a glance which combinations are fast and which are not.
+ */
+function asMatrix(results: BenchResult[]): {
+  sources: string[];
+  dests: string[];
+  cell: (s: string, d: string) => BenchResult | undefined;
+} | null {
+  const parsed = results.map((r) => {
+    const m = /^(.+?)\s*→\s*(.+?)(?:\s*·.*)?$/.exec(r.scenario);
+    return m ? { source: m[1].trim(), dest: m[2].trim(), r } : null;
+  });
+  if (parsed.some((p) => p === null) || parsed.length < 4) return null;
+  const rows = parsed as Array<{ source: string; dest: string; r: BenchResult }>;
+  const sources = [...new Set(rows.map((x) => x.source))];
+  const dests = [...new Set(rows.map((x) => x.dest))];
+  // only a reasonably filled grid is clearer as a grid
+  if (sources.length < 2 || dests.length < 2) return null;
+  return {
+    sources,
+    dests,
+    cell: (src, dst) => rows.find((x) => x.source === src && x.dest === dst)?.r,
+  };
+}
+
+/** rows/sec, coloured by magnitude so the shape of the grid reads instantly */
+function Rate({ result }: { result?: BenchResult }) {
+  if (!result) return <span className="text-muted-foreground/50">—</span>;
+  const v = result.rowsPerSec;
+  const tone =
+    v >= 50_000
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : v >= 10_000
+        ? 'text-foreground'
+        : 'text-amber-600 dark:text-amber-400';
+  return (
+    <span className={`font-semibold tabular-nums ${tone}`}>
+      {formatNumber(v)}
+    </span>
+  );
+}
+
 export default function BenchmarksPage() {
   const report = loadBenchmarks();
 
@@ -116,7 +161,55 @@ export default function BenchmarksPage() {
                   {suite.description}
                 </p>
 
-                <div className="mt-5 overflow-x-auto">
+                {(() => {
+                  const matrix = asMatrix(suite.results);
+                  if (!matrix) return null;
+                  return (
+                    <div className="mt-5 overflow-x-auto">
+                      <table className="w-full min-w-[40rem] border-collapse text-sm">
+                        <caption className="caption-bottom pt-3 text-left text-xs text-muted-foreground">
+                          Rows per second, source down the side, destination
+                          across the top. Every run was verified complete and
+                          duplicate-free before its time was recorded.
+                        </caption>
+                        <thead>
+                          <tr className="border-b text-left">
+                            <th className="py-2 pr-4 font-medium">
+                              Source \ Destination
+                            </th>
+                            {matrix.dests.map((d) => (
+                              <th key={d} className="py-2 pr-4 text-right font-medium">
+                                {d}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {matrix.sources.map((src) => (
+                            <tr key={src} className="border-b">
+                              <td className="py-3 pr-4 font-medium">{src}</td>
+                              {matrix.dests.map((d) => {
+                                const cell = matrix.cell(src, d);
+                                return (
+                                  <td key={d} className="py-3 pr-4 text-right">
+                                    <Rate result={cell} />
+                                    {cell ? (
+                                      <div className="text-xs text-muted-foreground">
+                                        {formatNumber(cell.rows)} rows
+                                      </div>
+                                    ) : null}
+                                  </td>
+                                );
+                              })}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  );
+                })()}
+
+                <div className={`mt-5 overflow-x-auto${asMatrix(suite.results) ? ' hidden' : ''}`}>
                   <table className="w-full min-w-[40rem] border-collapse text-sm">
                     <thead>
                       <tr className="border-b text-left">


### PR DESCRIPTION
The benchmark measured three engines. Syncle supports five — so it was describing a subset of the product and calling it the product. It now runs **every source against every destination: 20 pairs, a million rows each.**

## The matrix (rows/sec, 1,000,000 rows per cell)

| Source \ Destination | PostgreSQL | MySQL | MongoDB | SQLite | Redis |
|---|---|---|---|---|---|
| **PostgreSQL** | 60,197 | 55,741 | 20,745 | **118,991** | 104,921 |
| **MySQL** | 83,036 | **119,832** | 25,909 | **124,456** | 106,000 |
| **MongoDB** | 24,781 | 30,878 | 10,698 | 38,481 | 21,450 |
| **Redis**¹ | 1,935 | 2,060 | 1,860 | 891 | 1,647 |

¹ Redis as a *source* rides keyspace notifications — fire-and-forget pub/sub with no backlog, and a follow-up read per key. Measured at 100,000 rows; it is not comparable to a durable log and the page says so.

**Write ceilings:** SQLite 1,277,139 · MySQL 289,771 · Redis 276,932 · PostgreSQL 78,321

## Adding the two missing engines found real work

**Redis wrote one `SET` per row with no pipelining** — exactly the problem MongoDB had. A pipeline sends the batch as one write and reads one reply, so the per-row cost stops being a round trip. It went from unmeasured to **104,921 rows/sec** from Postgres.

**SQLite needed no adapter work** (it inherits the batched writes) and turns out to be the fastest destination by a distance — which makes sense for an in-process file with no network in the way.

## Three bugs the matrix exposed

- **Redis destinations wrote to database 0 while the checks read database 1** — the harness dropped `options` when registering a connection. Every Redis pair failed until that was passed through.
- **A Redis destination on the same database as a Redis source is a feedback loop** — the destination's own writes fire the keyspace notifications the source is subscribed to. Destinations now use a separate database.
- **Twenty scenarios of a million rows, all left until the end of the run, OOM-killed MongoDB mid-run.** Each scenario now drops its data as soon as it is measured, which also stops a measurement depending on what the ones before it left behind. WiredTiger's cache is bounded so it pushes back rather than dying.

## Testing is the point here, not a side effect

A new integration suite covers **all twenty pairs against real engines with real data**, and asserts the **values** that arrived rather than the row count — a mapping that transposed two columns would pass a count check. SQLite is asserted to report CDC as *unsupported* rather than failing at runtime, since it has no change-capture path for external writers.

81 integration tests and 186 unit tests pass. `results.json` is a clean run with the machine to itself.

## Page

Renders the pairs as a **source-by-destination grid**, which is readable where twenty rows were not, with rates coloured by magnitude. The spool moved to its own section so it stops colliding with the PostgreSQL→PostgreSQL cell.